### PR TITLE
Security: Harden Web Companion workspaceLinker

### DIFF
--- a/src/main/services/workspaceLinker.ts
+++ b/src/main/services/workspaceLinker.ts
@@ -17,6 +17,11 @@ import {
 } from './credentials'
 import { BIP39_ENGLISH } from './bip39wordlist'
 
+// Validate BIP39 wordlist integrity at module load time
+if (BIP39_ENGLISH.length !== 2048) {
+  throw new Error(`BIP39 wordlist corrupted: expected 2048 words, got ${BIP39_ENGLISH.length}`)
+}
+
 // Convex site URL — hardcoded for the Daylens backend.
 // In production, replace with your deployed URL.
 const CONVEX_SITE_URL = 'https://decisive-aardvark-847.convex.site'
@@ -253,7 +258,9 @@ async function callConvex(
 
   if (!res.ok) {
     const text = await res.text().catch(() => '')
-    throw new Error(`Server error (HTTP ${res.status}): ${text}`)
+    // Truncate server response to avoid leaking internal details in error messages
+    const safeText = text.slice(0, 200)
+    throw new Error(`Server error (HTTP ${res.status}): ${safeText}`)
   }
 
   return (await res.json()) as Record<string, unknown>


### PR DESCRIPTION
## Summary

Security hardening for the Windows Web Companion workspace linker.

### Changes
- **BIP39 wordlist validation** — Assert exactly 2048 words at module load. A corrupted or tampered wordlist would silently weaken mnemonic entropy.
- **Error message truncation** — Server error responses truncated to 200 chars before inclusion in thrown errors. Prevents internal server details from leaking into crash reports or user-visible dialogs.

## Test plan
- [ ] App starts without BIP39 assertion error
- [ ] Link creation works end-to-end
- [ ] Server error responses are truncated in logs

@greptileai please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented validation to detect and immediately reject corrupted data during module initialization, ensuring data integrity from startup.
  * Enhanced error handling to truncate server response details in error messages, reducing the risk of sensitive information exposure when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->