### PR TITLE
[codex] AI workspace benchmark and grounded browser evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist-release/
 .DS_Store
 private/
 docs/improvement-plan.md
+.tmp-benchmark/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.0.19 - 2026-04-06
+## v1.0.23 - 2026-04-06
 
 ### Added
 - Added a repeatable AI workspace benchmark harness and QA/release docs so benchmark prompts can be exercised against grounded seeded evidence before shipping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.0.24 - 2026-04-07
+
+### Added
+- Entity identity routing: "who is ASYV?", "what do I do for Acme Corp?", "tell me about X" now return a grounded answer inferred from window titles, categories, and time patterns — no AI provider required
+- Client listing routing: "list all my clients today", "who are my clients?", "how much time per client?", "export clientele list" now extract named entities from session titles and rank by tracked time
+- Comparison routing: "ASYV vs Acme Corp today" and "compare X versus Y" return a side-by-side time breakdown from local evidence
+- Day summary routing: "summarize my day", "how was my day?", "give me a summary", "recap my day", "what happened today?" now return a full narrative — top apps, named entities, focus %, last active thread
+- "App breakdown today" and related phrases now correctly route to the app breakdown answer
+
+### Fixed
+- Work-thread answers ("what was I working on today?") no longer falsely trigger "light evidence" on normal mixed days — the lowCoverage threshold was firing when no single category dominated even with hours of data
+- Signal double-counting eliminated: buildWorkThreadAnswer, buildDistractionAnswer, buildFocusScoreAnswer, buildTimeAllocationAnswer, and buildTimelineSummary no longer pass both app summaries and individual sessions to the evidence engine, which was doubling every app's second count and corrupting confidence scores
+- Distraction answers no longer repeat the primary source in the "other signals" list
+- Focus score routing runs before entity extraction so "what is my focus score?" is not misidentified as an entity identity question
+- App breakdown now matches "break down my apps today" and similar phrasings
+
 ## v1.0.23 - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.0.19 - 2026-04-06
+
+### Added
+- Added a repeatable AI workspace benchmark harness and QA/release docs so benchmark prompts can be exercised against grounded seeded evidence before shipping
+- Added live Safari active-tab capture on macOS so current browser title and URL can be written into `website_visits` even when Safari history is unavailable to the app
+
+### Changed
+- AI Workspace now stays available for exact local evidence questions even when no provider is configured, and can answer routed questions directly from local tracking
+- Insights routing now handles app-breakdown and title-enumeration follow-ups more naturally, and low-evidence answers stay explicit instead of overstating what Daylens knows
+
+### Fixed
+- Tracking now backfills Safari window titles from the active tab when `active-window` cannot provide them directly
+- Browser evidence is flushed into the local database as real `active_tab` visits so client attribution has a path to browser titles/URLs instead of empty browser sessions
+
 ## v1.0.18 - 2026-04-02
 
 ### Fixed

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -2,6 +2,8 @@
 
 Read this before touching anything. This is the most important document in the codebase.
 
+Also read [docs/BENCHMARK.md](/Users/tonny/Dev-Personal/daylens-windows/docs/BENCHMARK.md) before building. That file defines the product benchmark every implementation must be judged against.
+
 ---
 
 ## What every other tool gets wrong

--- a/README.md
+++ b/README.md
@@ -43,4 +43,6 @@ claude mcp add daylens -- npx -y daylens-mcp
 - `npm start` runs the Electron app in development mode.
 - `npm run typecheck` checks TypeScript without emitting build output.
 - `npm run build:all` builds the main, preload, and renderer bundles.
+- `npm run benchmark:ai-workspace` runs the release benchmark for grounded client-time and follow-up answers.
+- `npm run benchmark:ai-workspace:extended` runs the broader routed-question regression suite for summaries, distractions, identity, client listing, comparisons, and focus questions.
 - `npm run dist:win` builds the NSIS installer and update metadata into `dist-release/`.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ claude mcp add daylens -- npx -y daylens-mcp
 
 ## Development
 
+- Read [docs/BENCHMARK.md](docs/BENCHMARK.md) before changing the insights, AI workspace, tracking, or export pipeline. It defines the product benchmark the system is expected to meet.
 - `npm start` runs the Electron app in development mode.
 - `npm run typecheck` checks TypeScript without emitting build output.
 - `npm run build:all` builds the main, preload, and renderer bundles.

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -1,0 +1,77 @@
+# Daylens Benchmark
+
+Read this before building or changing anything in the insights, AI workspace, tracking, export, or timeline pipeline.
+
+This document defines the benchmark the product is actually judged against.
+
+## The Only Benchmark That Matters
+
+Daylens succeeds only if a user can ask a real work question at any point from the Insights page or the AI Workspace page, and the system can answer it accurately from recorded evidence.
+
+Example:
+
+`How many hours have I spent on ASYV?`
+
+To answer that correctly, Daylens must be able to:
+
+1. Resolve `ASYV` as a real work entity, such as a client.
+2. Find all activity that may relate to that client across the timeline.
+3. Include native app work, not just website summaries.
+4. Attribute Outlook time only when the actual email, thread, title, or message context shows it was about ASYV.
+5. Attribute Excel time only when the workbook, title, or surrounding evidence shows it was about ASYV.
+6. Attribute browser time only when the page title, URL, or context shows it was about ASYV.
+7. Combine those sources into one cumulative, defensible answer.
+8. Explain that answer from evidence, not from vague summarization.
+
+## What Does Not Count
+
+Daylens does not pass the benchmark if it only gives generic summaries like:
+
+- "You spent five minutes on YouTube."
+- "You were mostly browsing."
+- "Here is what you did today."
+
+That may be mildly useful, but it is not the product goal.
+
+## The Product Goal
+
+The real target is that a user can ask complex business questions like:
+
+`Analyze the last 30 days and export the clientele list and how much time I spent on each one.`
+
+A correct system should be able to:
+
+- identify clients and work entities across apps, files, emails, websites, page titles, and window titles
+- calculate time per client accurately enough to trust
+- support useful follow-up questions that stay grounded in evidence
+- export the result into something usable like Udo timesheets
+- do this reliably enough that the end user believes the answer
+
+## What Every Agent Must Check Before Building
+
+Before implementing anything in this area, check whether the change moves the product closer to or farther from this benchmark.
+
+Ask:
+
+1. Does this help Daylens answer client-level questions from evidence?
+2. Does this preserve or improve attribution across Outlook, Excel, browser tabs, and native window titles?
+3. Does this improve export-grade time accounting?
+4. Does this create concrete, useful follow-up questions, or just generic prompts?
+5. Does this help the user get a trustworthy answer, or does it only make the UI look smarter?
+
+If the change improves presentation but does not improve answer correctness, attribution, exportability, or evidence quality, it is not solving the core problem.
+
+## Standard For Success
+
+The only real standard is:
+
+`Does it work?`
+
+Not:
+
+- how advanced the stack is
+- how clever the prompt is
+- how polished the UI is
+- how much effort went into the implementation
+
+If Daylens cannot accurately answer client-level time questions and produce useful exportable outputs, it has not met the benchmark.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -33,6 +33,15 @@ dist/
 
 `electron-builder` then packages `dist/**` + `package.json` into `dist-release/`.
 
+Before treating a build as release-ready, also run:
+
+```bash
+npm run typecheck
+npm run benchmark:ai-workspace
+```
+
+See [QA.md](./QA.md) for the benchmark harness details.
+
 ## Why `STANDALONE_BUILD=1`?
 
 The Vite configs are shared between electron-forge (dev) and electron-builder (prod). The flag switches:
@@ -72,6 +81,8 @@ Steps:
 7. `softprops/action-gh-release@v2` finalises the tagged GitHub release page with install/update notes and release highlights
 
 Workflow file: `.github/workflows/release-windows.yml`
+
+Release-page details and tagging guidance live in [RELEASE_RUNBOOK.md](./RELEASE_RUNBOOK.md).
 
 ## Tagging convention
 

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -8,6 +8,7 @@ Use this before shipping changes to the Insights page, AI Workspace, tracking, t
 npm run typecheck
 npm run build:all
 npm run benchmark:ai-workspace
+npm run benchmark:ai-workspace:extended
 ```
 
 ## What `benchmark:ai-workspace` validates
@@ -29,6 +30,19 @@ Then it verifies that the local AI Workspace router can answer benchmark-shaped 
 - by-app follow-up: `Break ASYV down by app today.`
 - scoped native-app attribution: `How much ASYV time was in Outlook today?`
 - exact-time lookup: `What was I doing today at 10:58 am?`
+
+## What `benchmark:ai-workspace:extended` adds
+
+The extended runner uses the same standalone Electron harness, but exercises broader product-shaped prompts instead of only the core benchmark.
+
+It verifies that the local router can now handle:
+
+- open-ended work-thread prompts like `What was I working on today?` and `What should I resume?`
+- distraction questions without duplicate signals
+- client and project identity questions like `Who is ASYV?` and `What do I do for ASYV?`
+- client listing and comparison prompts like `List all my clients today.` and `ASYV versus Acme Corp`
+- day-summary prompts like `Summarize my day.` and `How was my day?`
+- generic routed questions like focus score, time allocation, top app, and app breakdown
 
 ## What this does not prove
 

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -1,0 +1,40 @@
+# QA Runbook
+
+Use this before shipping changes to the Insights page, AI Workspace, tracking, timeline attribution, or release pipeline.
+
+## Required local checks
+
+```bash
+npm run typecheck
+npm run build:all
+npm run benchmark:ai-workspace
+```
+
+## What `benchmark:ai-workspace` validates
+
+The benchmark runner compiles a small standalone harness and executes it under Electron's Node runtime so native modules match the app runtime.
+
+It seeds an in-memory SQLite database with evidence across:
+
+- VS Code
+- Outlook
+- Excel
+- Windows Terminal
+- Chrome plus browser-history page titles
+
+Then it verifies that the local AI Workspace router can answer benchmark-shaped questions such as:
+
+- cumulative client time: `How many hours have I spent on ASYV today?`
+- title evidence: `Which ASYV titles matched today?`
+- by-app follow-up: `Break ASYV down by app today.`
+- scoped native-app attribution: `How much ASYV time was in Outlook today?`
+- exact-time lookup: `What was I doing today at 10:58 am?`
+
+## What this does not prove
+
+- live provider-backed chat quality from Anthropic, OpenAI, Google, Claude CLI, or Codex CLI
+- export UI behavior
+- production GitHub release publishing
+- real-world attribution quality on a user's existing local database
+
+The harness is a regression guard for the evidence router behind AI Workspace chat, not a full end-to-end product certification.

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -12,6 +12,7 @@ Before tagging:
 npm run typecheck
 npm run build:all
 npm run benchmark:ai-workspace
+npm run benchmark:ai-workspace:extended
 ```
 
 Also confirm:

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -1,0 +1,56 @@
+# Release Runbook
+
+This project publishes Windows releases through GitHub Actions and a GitHub release page.
+
+## Preconditions
+
+Only cut a release from a clean, intentional release commit.
+
+Before tagging:
+
+```bash
+npm run typecheck
+npm run build:all
+npm run benchmark:ai-workspace
+```
+
+Also confirm:
+
+- `CHANGELOG.md` contains a section for the version you are releasing
+- the release tag will follow the Windows convention: `vX.Y.Z-win`
+- any installer-signing secrets required by `.github/workflows/release-windows.yml` are present in GitHub
+
+## How the release page is created
+
+The GitHub Actions workflow `.github/workflows/release-windows.yml` does the release-page work automatically:
+
+1. derives the Windows semver from the pushed tag or manual dispatch inputs
+2. stamps that version into `package.json` during the workflow build
+3. rebuilds native modules, typechecks, and builds the app
+4. publishes the installer, `latest.yml`, and blockmap metadata
+5. extracts the matching `CHANGELOG.md` section
+6. creates the GitHub release page body with highlights, install steps, update notes, and a commit summary
+
+## Triggering CI / release
+
+Preferred path:
+
+```bash
+git tag v1.0.19-win
+git push origin v1.0.19-win
+```
+
+Manual dispatch is also supported by the workflow for cases where you need to rerun packaging against an existing ref.
+
+## Release outputs
+
+Successful release runs publish:
+
+- `Daylens-{version}-Setup.exe`
+- `Daylens-{version}-Setup.exe.blockmap`
+- `latest.yml`
+- a GitHub release page populated from `CHANGELOG.md`
+
+## Safety note
+
+Do not tag from a workstation that still has unrelated uncommitted product changes. The release page and artifacts should always correspond to a reviewable Git commit.

--- a/docs/windows/AI_PROMPT_CONTRACT.md
+++ b/docs/windows/AI_PROMPT_CONTRACT.md
@@ -16,7 +16,7 @@ Current Swift client behavior in `AIService.swift`:
 ```json
 {
   "model": "claude-sonnet-4-6",
-  "max_tokens": 1024,
+  "max_tokens": 4096,
   "system": "<system prompt>",
   "messages": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daylens-windows",
   "productName": "DaylensWindows",
-  "version": "1.0.17",
+  "version": "1.0.19",
   "description": "Activity tracker and AI insights — Windows",
   "main": ".vite/build/main.js",
   "scripts": {
@@ -9,6 +9,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "typecheck": "tsc --noEmit",
+    "benchmark:ai-workspace": "tsc -p tsconfig.benchmark.json && cross-env ELECTRON_RUN_AS_NODE=1 electron scripts/run-benchmark-ai-workspace.mjs",
     "build:main": "cross-env STANDALONE_BUILD=1 vite build --config vite.main.config.ts",
     "build:preload": "cross-env STANDALONE_BUILD=1 vite build --config vite.preload.config.ts",
     "build:renderer": "cross-env STANDALONE_BUILD=1 vite build --config vite.renderer.config.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daylens-windows",
   "productName": "DaylensWindows",
-  "version": "1.0.19",
+  "version": "1.0.23",
   "description": "Activity tracker and AI insights — Windows",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "make": "electron-forge make",
     "typecheck": "tsc --noEmit",
     "benchmark:ai-workspace": "tsc -p tsconfig.benchmark.json && cross-env ELECTRON_RUN_AS_NODE=1 electron scripts/run-benchmark-ai-workspace.mjs",
-    "benchmark:ai-workspace:extended": "tsc -p tsconfig.benchmark.json && cross-env ELECTRON_RUN_AS_NODE=1 electron scripts/run-extended-test.mjs",
+    "benchmark:ai-workspace:extended": "tsc -p tsconfig.benchmark.json && cross-env ELECTRON_RUN_AS_NODE=1 electron scripts/run-benchmark-ai-workspace-extended.mjs",
     "build:main": "cross-env STANDALONE_BUILD=1 vite build --config vite.main.config.ts",
     "build:preload": "cross-env STANDALONE_BUILD=1 vite build --config vite.preload.config.ts",
     "build:renderer": "cross-env STANDALONE_BUILD=1 vite build --config vite.renderer.config.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daylens-windows",
   "productName": "DaylensWindows",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Activity tracker and AI insights — Windows",
   "main": ".vite/build/main.js",
   "scripts": {
@@ -10,6 +10,7 @@
     "make": "electron-forge make",
     "typecheck": "tsc --noEmit",
     "benchmark:ai-workspace": "tsc -p tsconfig.benchmark.json && cross-env ELECTRON_RUN_AS_NODE=1 electron scripts/run-benchmark-ai-workspace.mjs",
+    "benchmark:ai-workspace:extended": "tsc -p tsconfig.benchmark.json && cross-env ELECTRON_RUN_AS_NODE=1 electron scripts/run-extended-test.mjs",
     "build:main": "cross-env STANDALONE_BUILD=1 vite build --config vite.main.config.ts",
     "build:preload": "cross-env STANDALONE_BUILD=1 vite build --config vite.preload.config.ts",
     "build:renderer": "cross-env STANDALONE_BUILD=1 vite build --config vite.renderer.config.ts",

--- a/scripts/benchmark-ai-workspace-extended.ts
+++ b/scripts/benchmark-ai-workspace-extended.ts
@@ -1,0 +1,201 @@
+/**
+ * Extended AI Workspace router regression suite.
+ *
+ * Exercises 32 question categories beyond the core benchmark:
+ * open-ended work threads, distraction detection, entity identity,
+ * client listing, comparison, day summary, focus, and time allocation.
+ *
+ * Run via: npm run benchmark:ai-workspace:extended
+ */
+import assert from 'node:assert/strict'
+import Database from 'better-sqlite3'
+import { insertAppSession, insertWebsiteVisit } from '../src/main/db/queries'
+import { SCHEMA_SQL } from '../src/main/db/schema'
+import { routeInsightsQuestion, type TemporalContext } from '../src/main/lib/insightsQueryRouter'
+import type { AppCategory, AppSession } from '../src/shared/types'
+
+const ANCHOR = new Date('2026-04-06T15:30:00')
+
+function ts(time: string): number {
+  return new Date(`2026-04-06T${time}:00`).getTime()
+}
+
+function addSession(
+  db: Database.Database,
+  p: { bundleId: string; app: string; title: string; cat: AppCategory; start: string; end: string },
+): void {
+  const startTime = ts(p.start)
+  const endTime = ts(p.end)
+  const s: Omit<AppSession, 'id'> = {
+    bundleId: p.bundleId, appName: p.app, windowTitle: p.title,
+    startTime, endTime,
+    durationSeconds: Math.round((endTime - startTime) / 1000),
+    category: p.cat,
+    isFocused: ['development', 'research', 'writing'].includes(p.cat),
+  }
+  insertAppSession(db, s)
+}
+
+function seedData(db: Database.Database): void {
+  db.exec(SCHEMA_SQL)
+  // ASYV client
+  addSession(db, { bundleId: 'Code.exe',            app: 'Visual Studio Code', title: 'ASYV onboarding export - Visual Studio Code', cat: 'development',  start: '09:00', end: '09:50' })
+  addSession(db, { bundleId: 'OUTLOOK.EXE',         app: 'Microsoft Outlook',  title: 'ASYV kickoff notes - Outlook',                 cat: 'email',        start: '09:50', end: '10:05' })
+  addSession(db, { bundleId: 'EXCEL.EXE',           app: 'Microsoft Excel',    title: 'ASYV budget model.xlsx - Excel',               cat: 'productivity', start: '10:05', end: '10:35' })
+  addSession(db, { bundleId: 'WindowsTerminal.exe', app: 'Windows Terminal',   title: 'pnpm test --filter asyv-export',               cat: 'development',  start: '10:35', end: '10:50' })
+  addSession(db, { bundleId: 'chrome.exe',          app: 'Google Chrome',      title: 'ASYV dashboard localhost - Google Chrome',     cat: 'browsing',     start: '10:50', end: '11:10' })
+  // Acme Corp client
+  addSession(db, { bundleId: 'WORD.EXE',    app: 'Microsoft Word',   title: 'Acme Corp proposal draft.docx - Word',    cat: 'writing', start: '11:30', end: '12:00' })
+  addSession(db, { bundleId: 'OUTLOOK.EXE', app: 'Microsoft Outlook',title: 'RE: Acme Corp contract review - Outlook', cat: 'email',   start: '12:00', end: '12:20' })
+  // Distraction
+  addSession(db, { bundleId: 'chrome.exe', app: 'Google Chrome',      title: 'Reddit - Google Chrome', cat: 'entertainment', start: '13:00', end: '13:30' })
+  // Internal
+  addSession(db, { bundleId: 'Code.exe', app: 'Visual Studio Code', title: 'Internal tooling cleanup - Visual Studio Code', cat: 'development', start: '14:00', end: '14:40' })
+  // Website visits
+  insertWebsiteVisit(db, { domain: 'asyv.example.com', pageTitle: 'ASYV dashboard',      url: 'https://asyv.example.com/dashboard', visitTime: ts('10:52'), visitTimeUs: BigInt(ts('10:52')) * 1000n, durationSec: 8 * 60,  browserBundleId: 'chrome.exe', source: 'history' })
+  insertWebsiteVisit(db, { domain: 'localhost:3000',   pageTitle: 'ASYV export preview', url: 'http://localhost:3000/asyv-export',   visitTime: ts('11:00'), visitTimeUs: BigInt(ts('11:00')) * 1000n, durationSec: 10 * 60, browserBundleId: 'chrome.exe', source: 'history' })
+  insertWebsiteVisit(db, { domain: 'reddit.com',       pageTitle: 'r/programming',       url: 'https://reddit.com/r/programming',    visitTime: ts('13:05'), visitTimeUs: BigInt(ts('13:05')) * 1000n, durationSec: 15 * 60, browserBundleId: 'chrome.exe', source: 'history' })
+}
+
+interface Case {
+  name: string
+  question: string
+  expectRouted: boolean
+  check?: (answer: string) => void
+}
+
+const cases: Case[] = [
+  // ── Core benchmark ──────────────────────────────────────────────────────────
+  { name: 'ASYV cumulative time', question: 'How many hours have I spent on ASYV today?', expectRouted: true,
+    check: (a) => { assert.match(a, /2h 10m/i); assert.match(a, /outlook|excel|localhost|terminal|vs code/i) } },
+  { name: 'ASYV title enumeration', question: 'Which ASYV titles matched today?', expectRouted: true,
+    check: (a) => { assert.match(a, /ASYV kickoff notes/i); assert.match(a, /ASYV budget model/i) } },
+  { name: 'ASYV app breakdown', question: 'Break ASYV down by app today.', expectRouted: true,
+    check: (a) => { assert.match(a, /Visual Studio Code|VS Code/i); assert.match(a, /Outlook/i); assert.match(a, /Excel/i) } },
+  { name: 'ASYV Outlook attribution', question: 'How much ASYV time was in Outlook today?', expectRouted: true,
+    check: (a) => assert.match(a, /15m/i) },
+  { name: 'Exact time at 10:58 am', question: 'What was I doing today at 10:58 am?', expectRouted: true,
+    check: (a) => assert.match(a, /10:58|asyv|localhost/i) },
+
+  // ── Work thread ─────────────────────────────────────────────────────────────
+  { name: 'What was I working on today', question: 'What was I working on today?', expectRouted: true,
+    check: (a) => {
+      assert.ok(!a.includes('I only have light evidence'), 'Should NOT say light evidence on a full day')
+      assert.match(a, /Visual Studio Code|VS Code/i)
+    } },
+  { name: 'What should I resume', question: 'What should I resume?', expectRouted: true,
+    check: (a) => assert.match(a, /Visual Studio Code|VS Code|Internal tooling/i) },
+
+  // ── Distraction ─────────────────────────────────────────────────────────────
+  { name: 'Biggest distraction — no duplicates', question: 'What distracted me today?', expectRouted: true,
+    check: (a) => {
+      assert.match(a, /reddit|chrome|r\/programming|entertainment/i)
+      const label = a.match(/^(.+?) was/)?.[1] ?? ''
+      if (label) assert.ok(a.indexOf(label, a.indexOf(label) + label.length) === -1, `"${label}" duplicated: ${a}`)
+    } },
+
+  // ── Entity identity ─────────────────────────────────────────────────────────
+  { name: 'Who is ASYV', question: 'Who is ASYV?', expectRouted: true,
+    check: (a) => { assert.match(a, /ASYV/i); assert.match(a, /client|project|develop/i) } },
+  { name: 'What do I do for ASYV', question: 'What do I do for ASYV?', expectRouted: true,
+    check: (a) => { assert.match(a, /ASYV/i); assert.match(a, /develop|coding|client/i) } },
+  { name: 'What is ASYV', question: 'What is ASYV?', expectRouted: true,
+    check: (a) => assert.match(a, /ASYV/i) },
+  { name: 'Tell me about ASYV', question: 'Tell me about ASYV.', expectRouted: true,
+    check: (a) => assert.match(a, /ASYV/i) },
+  { name: 'What project am I building for ASYV', question: 'What project am I building for ASYV?', expectRouted: true,
+    check: (a) => assert.match(a, /ASYV/i) },
+  { name: 'Who is Acme Corp', question: 'Who is Acme Corp?', expectRouted: true,
+    check: (a) => { assert.match(a, /Acme Corp/i); assert.match(a, /client|proposal|email|doc/i) } },
+
+  // ── Client listing ──────────────────────────────────────────────────────────
+  { name: 'List all my clients today', question: 'List all my clients today.', expectRouted: true,
+    check: (a) => { assert.match(a, /ASYV/i); assert.match(a, /Acme/i) } },
+  { name: 'Who are my clients today', question: 'Who are my clients today?', expectRouted: true,
+    check: (a) => assert.match(a, /ASYV|Acme/i) },
+  { name: 'How much time per client today', question: 'How much time per client today?', expectRouted: true,
+    check: (a) => assert.match(a, /ASYV|Acme/i) },
+  { name: 'Export clientele list', question: 'Analyze today and export the clientele list.', expectRouted: true,
+    check: (a) => assert.match(a, /ASYV|Acme/i) },
+  { name: 'Clientele time breakdown', question: 'Give me a clientele time breakdown for today.', expectRouted: true,
+    check: (a) => assert.match(a, /ASYV|Acme/i) },
+
+  // ── Comparison ──────────────────────────────────────────────────────────────
+  { name: 'Compare ASYV vs Acme Corp', question: 'Compare ASYV vs Acme Corp today.', expectRouted: true,
+    check: (a) => { assert.match(a, /ASYV/i); assert.match(a, /Acme Corp/i); assert.match(a, /\d+h|\d+m/) } },
+  { name: 'ASYV versus Acme', question: 'ASYV versus Acme Corp — which took more time today?', expectRouted: true,
+    check: (a) => assert.match(a, /ASYV.*Acme|Acme.*ASYV/i) },
+
+  // ── Day summary ─────────────────────────────────────────────────────────────
+  { name: 'Summarize my day', question: 'Summarize my day.', expectRouted: true,
+    check: (a) => { assert.ok(a.length > 100); assert.match(a, /tracked|focused|apps/i) } },
+  { name: 'How was my day', question: 'How was my day?', expectRouted: true,
+    check: (a) => assert.ok(a.length > 80) },
+  { name: 'Give me a summary of today', question: 'Give me a summary of today.', expectRouted: true,
+    check: (a) => assert.match(a, /tracked|VS Code|apps/i) },
+  { name: 'What happened today', question: 'What happened today?', expectRouted: true,
+    check: (a) => assert.ok(a.length > 80) },
+  { name: 'Recap my day', question: 'Recap my day.', expectRouted: true,
+    check: (a) => assert.ok(a.length > 80) },
+
+  // ── Other client time ───────────────────────────────────────────────────────
+  { name: 'Time on Acme Corp', question: 'How much time did I spend on Acme Corp today?', expectRouted: true,
+    check: (a) => assert.match(a, /50m|Acme/i) },
+
+  // ── App / site / focus ──────────────────────────────────────────────────────
+  { name: 'Top app today', question: 'What was my most used app today?', expectRouted: true,
+    check: (a) => assert.match(a, /Visual Studio Code|VS Code/i) },
+  { name: 'App breakdown today', question: 'Break down my apps today.', expectRouted: true,
+    check: (a) => assert.match(a, /Visual Studio Code|VS Code/i) },
+  { name: 'Focus score', question: 'What is my focus score today?', expectRouted: true,
+    check: (a) => { assert.match(a, /focus score/i); assert.ok(!a.includes('client or project'), 'Must not misroute to entity identity') } },
+  { name: 'Where did my time go', question: 'Where did my time go today?', expectRouted: true,
+    check: (a) => assert.match(a, /coding|development|writing|email|browsing/i) },
+
+  // ── Correct fall-throughs ───────────────────────────────────────────────────
+  { name: 'Follow-up without context', question: 'What were you doing at that time?', expectRouted: false },
+]
+
+async function main(): Promise<void> {
+  const db = new Database(':memory:')
+  seedData(db)
+
+  let passed = 0
+  let failed = 0
+  let context: TemporalContext | null = null
+
+  for (const tc of cases) {
+    const routed = await routeInsightsQuestion(tc.question, ANCHOR, context, db)
+    if (routed) context = routed.resolvedContext
+    const wasRouted = routed !== null
+    const routingOk = wasRouted === tc.expectRouted
+
+    let checkOk = true
+    let checkError = ''
+    if (tc.check && routed) {
+      try { tc.check(routed.answer) } catch (err) {
+        checkOk = false
+        checkError = err instanceof Error ? err.message : String(err)
+      }
+    }
+
+    const ok = routingOk && checkOk
+    if (ok) {
+      passed++
+      console.log(`PASS ${tc.name}`)
+    } else {
+      failed++
+      console.log(`FAIL ${tc.name}`)
+      if (!routingOk) console.log(`     routing: expected ${tc.expectRouted ? 'ROUTED' : 'FALLTHROUGH'}, got ${wasRouted ? 'ROUTED' : 'FALLTHROUGH'}`)
+      if (!checkOk) console.log(`     assertion: ${checkError}`)
+    }
+    if (routed) console.log(`     ${routed.answer.replace(/\n/g, ' ').slice(0, 120)}`)
+    else console.log(`     <falls through to AI provider>`)
+  }
+
+  console.log('')
+  console.log(`PASS ${passed} / ${passed + failed} extended benchmark checks`)
+  if (failed > 0) process.exitCode = 1
+}
+
+void main().catch((err) => { console.error(err); process.exitCode = 1 })

--- a/scripts/benchmark-ai-workspace.ts
+++ b/scripts/benchmark-ai-workspace.ts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict'
+import Database from 'better-sqlite3'
+import { insertAppSession, insertWebsiteVisit } from '../src/main/db/queries'
+import { SCHEMA_SQL } from '../src/main/db/schema'
+import { routeInsightsQuestion, type TemporalContext } from '../src/main/lib/insightsQueryRouter'
+import type { AppCategory, AppSession } from '../src/shared/types'
+
+interface BenchmarkCase {
+  name: string
+  question: string
+  assertResult: (answer: string) => void
+}
+
+const ANCHOR_DATE = new Date('2026-04-06T15:30:00')
+
+function timestamp(time: string): number {
+  return new Date(`2026-04-06T${time}:00`).getTime()
+}
+
+function insertSession(
+  db: Database.Database,
+  params: {
+    bundleId: string
+    appName: string
+    title: string
+    category: AppCategory
+    start: string
+    end: string
+  },
+): void {
+  const startTime = timestamp(params.start)
+  const endTime = timestamp(params.end)
+  const session: Omit<AppSession, 'id'> = {
+    bundleId: params.bundleId,
+    appName: params.appName,
+    windowTitle: params.title,
+    startTime,
+    endTime,
+    durationSeconds: Math.round((endTime - startTime) / 1000),
+    category: params.category,
+    isFocused: params.category === 'development' || params.category === 'research' || params.category === 'writing',
+  }
+  insertAppSession(db, session)
+}
+
+function seedBenchmarkData(db: Database.Database): void {
+  db.exec(SCHEMA_SQL)
+
+  insertSession(db, {
+    bundleId: 'Code.exe',
+    appName: 'Visual Studio Code',
+    title: 'ASYV onboarding export - Visual Studio Code',
+    category: 'development',
+    start: '09:00',
+    end: '09:50',
+  })
+  insertSession(db, {
+    bundleId: 'OUTLOOK.EXE',
+    appName: 'Microsoft Outlook',
+    title: 'ASYV kickoff notes - Outlook',
+    category: 'email',
+    start: '09:50',
+    end: '10:05',
+  })
+  insertSession(db, {
+    bundleId: 'EXCEL.EXE',
+    appName: 'Microsoft Excel',
+    title: 'ASYV budget model.xlsx - Excel',
+    category: 'productivity',
+    start: '10:05',
+    end: '10:35',
+  })
+  insertSession(db, {
+    bundleId: 'WindowsTerminal.exe',
+    appName: 'Windows Terminal',
+    title: 'pnpm test --filter asyv-export',
+    category: 'development',
+    start: '10:35',
+    end: '10:50',
+  })
+  insertSession(db, {
+    bundleId: 'chrome.exe',
+    appName: 'Google Chrome',
+    title: 'ASYV dashboard localhost - Google Chrome',
+    category: 'browsing',
+    start: '10:50',
+    end: '11:10',
+  })
+  insertSession(db, {
+    bundleId: 'chrome.exe',
+    appName: 'Google Chrome',
+    title: 'Reddit - Google Chrome',
+    category: 'entertainment',
+    start: '13:00',
+    end: '13:30',
+  })
+  insertSession(db, {
+    bundleId: 'Code.exe',
+    appName: 'Visual Studio Code',
+    title: 'Internal tooling cleanup - Visual Studio Code',
+    category: 'development',
+    start: '14:00',
+    end: '14:40',
+  })
+
+  insertWebsiteVisit(db, {
+    domain: 'asyv.example.com',
+    pageTitle: 'ASYV dashboard',
+    url: 'https://asyv.example.com/dashboard',
+    visitTime: timestamp('10:52'),
+    visitTimeUs: BigInt(timestamp('10:52')) * 1000n,
+    durationSec: 8 * 60,
+    browserBundleId: 'chrome.exe',
+    source: 'history',
+  })
+  insertWebsiteVisit(db, {
+    domain: 'localhost:3000',
+    pageTitle: 'ASYV export preview',
+    url: 'http://localhost:3000/asyv-export',
+    visitTime: timestamp('11:00'),
+    visitTimeUs: BigInt(timestamp('11:00')) * 1000n,
+    durationSec: 10 * 60,
+    browserBundleId: 'chrome.exe',
+    source: 'history',
+  })
+  insertWebsiteVisit(db, {
+    domain: 'reddit.com',
+    pageTitle: 'r/programming',
+    url: 'https://reddit.com/r/programming',
+    visitTime: timestamp('13:05'),
+    visitTimeUs: BigInt(timestamp('13:05')) * 1000n,
+    durationSec: 15 * 60,
+    browserBundleId: 'chrome.exe',
+    source: 'history',
+  })
+}
+
+async function ask(
+  db: Database.Database,
+  question: string,
+  previousContext: TemporalContext | null,
+): Promise<{ answer: string; resolvedContext: TemporalContext }> {
+  const result = await routeInsightsQuestion(question, ANCHOR_DATE, previousContext, db)
+  assert.ok(result, `Expected a routed answer for: ${question}`)
+  return { answer: result!.answer, resolvedContext: result!.resolvedContext }
+}
+
+async function main(): Promise<void> {
+  const db = new Database(':memory:')
+  seedBenchmarkData(db)
+
+  const checks: BenchmarkCase[] = [
+    {
+      name: 'Client-level cumulative attribution',
+      question: 'How many hours have I spent on ASYV today?',
+      assertResult: (answer) => {
+        assert.match(answer, /2h 10m/i)
+        assert.match(answer, /outlook|excel|localhost|terminal|vs code/i)
+      },
+    },
+    {
+      name: 'Title evidence enumeration',
+      question: 'Which ASYV titles matched today?',
+      assertResult: (answer) => {
+        assert.match(answer, /ASYV kickoff notes/i)
+        assert.match(answer, /ASYV budget model\.xlsx/i)
+        assert.match(answer, /ASYV dashboard/i)
+      },
+    },
+    {
+      name: 'App breakdown follow-up',
+      question: 'Break ASYV down by app today.',
+      assertResult: (answer) => {
+        assert.match(answer, /ASYV by app/i)
+        assert.match(answer, /Visual Studio Code|VS Code/i)
+        assert.match(answer, /Outlook/i)
+        assert.match(answer, /Excel/i)
+        assert.match(answer, /Chrome/i)
+      },
+    },
+    {
+      name: 'Scoped native-app attribution',
+      question: 'How much ASYV time was in Outlook today?',
+      assertResult: (answer) => {
+        assert.match(answer, /15m/i)
+        assert.match(answer, /ASYV/i)
+      },
+    },
+    {
+      name: 'Exact time lookup for workspace chat follow-up',
+      question: 'What was I doing today at 10:58 am?',
+      assertResult: (answer) => {
+        assert.match(answer, /10:58/i)
+        assert.match(answer, /asyv\.example\.com|localhost:3000|google chrome/i)
+      },
+    },
+  ]
+
+  let previousContext: TemporalContext | null = null
+  for (const check of checks) {
+    const { answer, resolvedContext } = await ask(db, check.question, previousContext)
+    check.assertResult(answer)
+    previousContext = resolvedContext
+    console.log(`PASS ${check.name}`)
+    console.log(answer)
+    console.log('')
+  }
+
+  console.log(`PASS ${checks.length} AI workspace benchmark checks`)
+}
+
+void main().catch((error) => {
+  console.error('FAIL benchmark run')
+  console.error(error instanceof Error ? error.stack : error)
+  process.exitCode = 1
+})

--- a/scripts/run-benchmark-ai-workspace-extended.mjs
+++ b/scripts/run-benchmark-ai-workspace-extended.mjs
@@ -1,0 +1,14 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const tmpDir = path.join(rootDir, '.tmp-benchmark')
+const sharedTypesSource = path.join(tmpDir, 'src', 'shared', 'types.js')
+const sharedTypesTargetDir = path.join(tmpDir, 'node_modules', '@shared')
+const sharedTypesTarget = path.join(sharedTypesTargetDir, 'types.js')
+const entry = path.join(tmpDir, 'scripts', 'benchmark-ai-workspace-extended.js')
+
+await fs.mkdir(sharedTypesTargetDir, { recursive: true })
+await fs.copyFile(sharedTypesSource, sharedTypesTarget)
+await import(pathToFileURL(entry).href)

--- a/scripts/run-benchmark-ai-workspace.mjs
+++ b/scripts/run-benchmark-ai-workspace.mjs
@@ -1,0 +1,14 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..')
+const tmpDir = path.join(rootDir, '.tmp-benchmark')
+const sharedTypesSource = path.join(tmpDir, 'src', 'shared', 'types.js')
+const sharedTypesTargetDir = path.join(tmpDir, 'node_modules', '@shared')
+const sharedTypesTarget = path.join(sharedTypesTargetDir, 'types.js')
+const benchmarkEntry = path.join(tmpDir, 'scripts', 'benchmark-ai-workspace.js')
+
+await fs.mkdir(sharedTypesTargetDir, { recursive: true })
+await fs.copyFile(sharedTypesSource, sharedTypesTarget)
+await import(pathToFileURL(benchmarkEntry).href)

--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -227,6 +227,16 @@ const migrations: Migration[] = [
       `)
     },
   },
+  {
+    version: 9,
+    description: 'Add window titles to app sessions for document-level attribution',
+    up: () => {
+      const db = getDb()
+      if (!hasColumn('app_sessions', 'window_title')) {
+        db.exec(`ALTER TABLE app_sessions ADD COLUMN window_title TEXT`)
+      }
+    },
+  },
 ]
 
 export function runMigrations(): void {

--- a/src/main/db/queries.ts
+++ b/src/main/db/queries.ts
@@ -61,6 +61,15 @@ const UX_NOISE_SUBSTRINGS = [
 const MIN_DISPLAY_SEC = 15
 const SAME_APP_MERGE_GAP_MS = 15_000
 
+export interface WebsiteVisit {
+  domain: string
+  pageTitle: string | null
+  url: string | null
+  visitTime: number
+  durationSeconds: number
+  browserBundleId: string | null
+}
+
 function isUxNoise(appName: string): boolean {
   const lower = appName.toLowerCase()
   return UX_NOISE_SUBSTRINGS.some((s) => lower.includes(s))
@@ -70,6 +79,7 @@ interface AppSessionRow {
   id: number
   bundle_id: string
   app_name: string
+  window_title: string | null
   start_time: number
   end_time: number | null
   duration_sec: number
@@ -83,6 +93,10 @@ function sessionEndTime(row: Pick<AppSessionRow, 'start_time' | 'end_time' | 'du
 
 function appSessionEndTime(session: Pick<AppSession, 'startTime' | 'endTime' | 'durationSeconds'>): number {
   return session.endTime ?? (session.startTime + session.durationSeconds * 1_000)
+}
+
+function normalizedWindowTitle(title?: string | null): string {
+  return (title ?? '').replace(/\s+/g, ' ').trim()
 }
 
 function clipRowToRange(
@@ -100,6 +114,7 @@ function clipRowToRange(
     id: row.id,
     bundleId: row.bundle_id,
     appName: resolvedName ?? row.app_name,
+    windowTitle: row.window_title,
     startTime: clippedStart,
     endTime: clippedEnd,
     durationSeconds: Math.max(1, Math.round((clippedEnd - clippedStart) / 1_000)),
@@ -118,7 +133,11 @@ function mergeSessions(sessions: AppSession[]): AppSession[] {
     const last = merged[merged.length - 1]
     const gap = curr.startTime - appSessionEndTime(last)
 
-    if (curr.bundleId === last.bundleId && gap <= SAME_APP_MERGE_GAP_MS) {
+    if (
+      curr.bundleId === last.bundleId
+      && normalizedWindowTitle(curr.windowTitle) === normalizedWindowTitle(last.windowTitle)
+      && gap <= SAME_APP_MERGE_GAP_MS
+    ) {
       const newEnd = Math.max(appSessionEndTime(last), appSessionEndTime(curr))
       last.endTime = newEnd
       last.durationSeconds = Math.max(1, Math.round((newEnd - last.startTime) / 1000))
@@ -206,11 +225,12 @@ export function insertAppSession(
   session: Omit<AppSession, 'id'>,
 ): number {
   const stmt = db.prepare(`
-    INSERT OR IGNORE INTO app_sessions (bundle_id, app_name, start_time, end_time, duration_sec, category, is_focused)
-    VALUES (@bundleId, @appName, @startTime, @endTime, @durationSeconds, @category, @isFocused)
+    INSERT OR IGNORE INTO app_sessions (bundle_id, app_name, window_title, start_time, end_time, duration_sec, category, is_focused)
+    VALUES (@bundleId, @appName, @windowTitle, @startTime, @endTime, @durationSeconds, @category, @isFocused)
   `)
   const result = stmt.run({
     ...session,
+    windowTitle: session.windowTitle ?? null,
     isFocused: session.isFocused ? 1 : 0,
   })
   return result.lastInsertRowid as number
@@ -840,6 +860,37 @@ export function getWebsiteSummariesForRange(
     visitCount:      r.visit_count,
     topTitle:        r.top_title,
     browserBundleId: r.browser_id,
+  }))
+}
+
+export function getWebsiteVisitsForRange(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+): WebsiteVisit[] {
+  const rows = db
+    .prepare<[number, number]>(`
+      SELECT domain, page_title, url, visit_time, duration_sec, browser_bundle_id
+      FROM website_visits
+      WHERE visit_time >= ? AND visit_time < ?
+      ORDER BY visit_time ASC
+    `)
+    .all(fromMs, toMs) as {
+      domain: string
+      page_title: string | null
+      url: string | null
+      visit_time: number
+      duration_sec: number
+      browser_bundle_id: string | null
+    }[]
+
+  return rows.map((row) => ({
+    domain: row.domain,
+    pageTitle: row.page_title,
+    url: row.url,
+    visitTime: row.visit_time,
+    durationSeconds: row.duration_sec,
+    browserBundleId: row.browser_bundle_id,
   }))
 }
 

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS app_sessions (
   id              INTEGER PRIMARY KEY AUTOINCREMENT,
   bundle_id       TEXT    NOT NULL,
   app_name        TEXT    NOT NULL,
+  window_title    TEXT,
   start_time      INTEGER NOT NULL,
   end_time        INTEGER,
   duration_sec    INTEGER NOT NULL DEFAULT 0,

--- a/src/main/ipc/ai.handlers.ts
+++ b/src/main/ipc/ai.handlers.ts
@@ -8,10 +8,10 @@ import {
   suggestAppCategory,
   testCLITool,
 } from '../services/ai'
-import { IPC, type WorkContextBlock } from '@shared/types'
+import { IPC, type AIReplyPayload, type WorkContextBlock } from '@shared/types'
 
 export function registerAIHandlers(): void {
-  ipcMain.handle(IPC.AI.SEND_MESSAGE, async (_e, message: string) => {
+  ipcMain.handle(IPC.AI.SEND_MESSAGE, async (_e, message: string): Promise<AIReplyPayload> => {
     return sendMessage(message)
   })
 

--- a/src/main/ipc/db.handlers.ts
+++ b/src/main/ipc/db.handlers.ts
@@ -176,6 +176,7 @@ function mergeLiveSessionForDate(sessions: AppSession[], dateStr: string): AppSe
       id: -1,
       bundleId: live.bundleId,
       appName: live.appName,
+      windowTitle: live.windowTitle ?? null,
       startTime: live.startTime,
       endTime,
       durationSeconds: Math.max(1, Math.round((endTime - live.startTime) / 1000)),

--- a/src/main/lib/insightsQueryRouter.ts
+++ b/src/main/lib/insightsQueryRouter.ts
@@ -719,6 +719,11 @@ function extractEntity(question: string): string | null {
     /\b(?:hours\s+(?:on|for|with|in)\s+)(.+)$/i,
     /\b(?:related to|about)\s+(.+)$/i,
     /\b(?:break\s+down)\s+(.+?)(?:\s+(?:this week|that week|last week|past week|today|yesterday|last \d+ days?|past \d+ days?))*\s*\??$/i,
+    // Identity patterns — "who is X", "what is X", "tell me about X", "what do I do for X"
+    /\b(?:who|what)\s+is\s+(.+?)(?:\s+(?:today|this week|yesterday))?\s*\??$/i,
+    /\b(?:tell\s+me\s+about|describe)\s+(.+?)(?:\s+(?:today|this week|yesterday))?\s*\??$/i,
+    /\b(?:what\s+do\s+i\s+(?:do|work)\s+(?:for|on))\s+(.+?)(?:\s+(?:today|this week|yesterday))?\s*\??$/i,
+    /\b(?:what\s+project\s+(?:am\s+i\s+building|do\s+i\s+have)\s+(?:for|on))\s+(.+?)(?:\s+(?:today|this week|yesterday))?\s*\??$/i,
   ]
 
   for (const pattern of patterns) {
@@ -1060,8 +1065,10 @@ function isTitleMatchQuestion(normalized: string): boolean {
 
 function isAppBreakdownQuestion(normalized: string): boolean {
   return normalized.includes('by app')
-    || /\bbreak\b.*\bdown\b.*\bapp\b/.test(normalized)
-    || /\bapp\b.*\bbreak\b.*\bdown\b/.test(normalized)
+    || /\bbreak\b.*\bdown\b.*\bapps?\b/.test(normalized)
+    || /\bapps?\b.*\bbreak\b.*\bdown\b/.test(normalized)
+    || /\bapp\s+breakdown\b/.test(normalized)
+    || /\bbreakdown\b.*\bapp\b/.test(normalized)
 }
 
 function buildEntityAppBreakdown(
@@ -1299,46 +1306,82 @@ function buildWorkThreadAnswer(
 ): string | null {
   if (apps.length === 0 && sites.length === 0 && sessions.length === 0) return null
 
-  const evidence = buildEvidence(apps, sites, sessions)
-  const fallbackLatest = sortedSessions(sessions).at(-1) ?? null
-  const latest = (resolvedPrefix === 'Resume'
+  const meaningfulSessions = sessions.filter(isMeaningfulSession)
+  const totalSeconds = apps.reduce((sum, app) => sum + app.totalSeconds, 0)
+  if (totalSeconds === 0 && meaningfulSessions.length === 0) return null
+
+  // Use apps only for evidence — sessions are already aggregated into apps, passing both doubles counts
+  const evidence = buildEvidence(apps, sites, [])
+
+  const latestActive = (resolvedPrefix === 'Resume'
     ? latestFocusedSession(sessions) ?? latestMeaningfulSession(sessions)
     : latestMeaningfulSession(sessions))
-    ?? fallbackLatest
-  const signals = formatSignalList(evidence.signals, 3)
-  const focusMinutes = Math.round(evidence.focusedSeconds / 60)
-  const taskLabel = evidence.task.label.toLowerCase()
-  const latestTitledSession = [...sortedSessions(sessions)]
-    .reverse()
-    .find((session) => session.windowTitle?.trim())
-  const latestTitle = latestTitledSession?.windowTitle?.trim()
-  const titledSessionCount = sessions.filter((session) => session.windowTitle?.trim()).length
-  const lowCoverage = evidence.totalSeconds < 5 * 60
-    || evidence.task.category === 'browsing'
-    || evidence.task.confidence < 0.45
-    || titledSessionCount <= 1
+    ?? sortedSessions(sessions).at(-1) ?? null
 
-  if (!latest) {
-    return `${resolvedPrefix} ${taskLabel}. The clearest signals were ${signals}.`
+  // Build per-app title map from individual sessions (not summaries — sessions carry window titles)
+  const appTitleMap = new Map<string, string[]>()
+  for (const session of [...sortedSessions(meaningfulSessions)].reverse()) {
+    const title = session.windowTitle?.trim()
+    if (!title) continue
+    const cleaned = stripKnownAppSuffixes(title)
+    if (!cleaned || cleaned.length < 3) continue
+    const existing = appTitleMap.get(session.bundleId) ?? []
+    if (!existing.includes(cleaned) && existing.length < 2) existing.push(cleaned)
+    appTitleMap.set(session.bundleId, existing)
   }
 
-  const end = formatTime(sessionEnd(latest))
-  const start = formatTime(latest.startTime)
-  const sessionLabel = latest.appName
-  const focusText = focusMinutes > 0 ? `, with about ${formatDuration(evidence.focusedSeconds)} in focused apps` : ''
+  // Meaningful apps with at least 1 minute
+  const visibleApps = apps.filter((app) => app.totalSeconds >= 60).slice(0, 5)
 
-  if (lowCoverage) {
-    const concreteLead = latestTitle
-      ? `The clearest concrete signal is ${latestTitledSession!.appName} on "${stripKnownAppSuffixes(latestTitle)}" around ${formatTime(latestTitledSession!.startTime)}.`
-      : `The clearest concrete signal is ${sessionLabel} from ${start} to ${end}.`
+  const appLines = visibleApps.map((app) => {
+    const titles = appTitleMap.get(app.bundleId) ?? []
+    const titleSuffix = titles.length > 0 ? ` — ${humanQuotedList(titles, 2)}` : ''
+    return `${app.appName} (${formatDuration(app.totalSeconds)})${titleSuffix}`
+  })
+
+  const latestLine = latestActive
+    ? (() => {
+        const t = latestActive.windowTitle?.trim()
+        const tDisplay = t ? ` on "${stripKnownAppSuffixes(t)}"` : ''
+        return `Last active: ${latestActive.appName}${tDisplay} at ${formatTime(latestActive.startTime)}.`
+      })()
+    : null
+
+  if (resolvedPrefix === 'Resume' && latestActive) {
+    const t = latestActive.windowTitle?.trim()
+    const tDisplay = t ? ` — "${stripKnownAppSuffixes(t)}"` : ''
+    const otherLines = appLines.filter((_, i) => visibleApps[i]?.bundleId !== latestActive.bundleId).slice(0, 3)
     return [
-      'I only have light evidence for that period so far, so I would not over-interpret it.',
-      concreteLead,
-      `Beyond that, the strongest signals are ${signals}.`,
-    ].join(' ')
+      `Resume with ${latestActive.appName}${tDisplay} (left off at ${formatTime(latestActive.startTime)}).`,
+      otherLines.length > 0 ? `Before that: ${otherLines.join(', ')}.` : null,
+    ].filter(Boolean).join(' ')
   }
 
-  return `${resolvedPrefix} ${taskLabel}. The latest meaningful thread was ${sessionLabel} from ${start} to ${end}${focusText}. Strongest signals: ${signals}.`
+  // Only use "light evidence" when genuinely insufficient — not just because the day is mixed
+  const titledSessionCount = sessions.filter((session) => session.windowTitle?.trim()).length
+  const genuinelyThinData = totalSeconds < 5 * 60 || (titledSessionCount === 0 && visibleApps.length <= 1)
+
+  if (genuinelyThinData) {
+    const latestTitled = [...sortedSessions(sessions)].reverse().find((s) => s.windowTitle?.trim())
+    const latestTitle = latestTitled?.windowTitle?.trim()
+    const concreteLead = latestTitle
+      ? `The clearest signal is ${latestTitled!.appName} on "${stripKnownAppSuffixes(latestTitle)}" around ${formatTime(latestTitled!.startTime)}.`
+      : latestActive ? `The clearest signal is ${latestActive.appName} from ${formatTime(latestActive.startTime)}.` : null
+    return [
+      'I only have light evidence for that period so far.',
+      concreteLead,
+      evidence.signals.length > 0 ? `Strongest signals: ${formatSignalList(evidence.signals, 3)}.` : null,
+    ].filter(Boolean).join(' ')
+  }
+
+  const taskLabel = evidence.task.label
+  const totalLine = `${taskLabel} (${formatDuration(totalSeconds)} tracked).`
+
+  return [
+    totalLine,
+    appLines.length > 0 ? appLines.join(', ') + '.' : null,
+    latestLine,
+  ].filter(Boolean).join(' ')
 }
 
 function buildGeneralAppBreakdown(
@@ -1403,10 +1446,10 @@ function buildGeneralTitleAnswer(
   return `The clearest titles ${windowReferenceLabel(rangeLabel)} were ${humanQuotedList(titles, 6)}.`
 }
 
-function buildTimeAllocationAnswer(apps: AppUsageSummary[], sites: WebsiteSummary[], sessions: AppSession[]): string | null {
+function buildTimeAllocationAnswer(apps: AppUsageSummary[], sites: WebsiteSummary[]): string | null {
   if (apps.length === 0 && sites.length === 0) return null
 
-  const evidence = buildEvidence(apps, sites, sessions)
+  const evidence = buildEvidence(apps, sites, [])
   const strongestFocus = evidence.signals.filter((signal) => FOCUSED_CATEGORIES.includes(signal.category)).slice(0, 3)
   const strongestNonFocus = evidence.signals.filter(isNonFocusSignal).slice(0, 3)
   const focusSeconds = evidence.focusedSeconds
@@ -1423,10 +1466,11 @@ function buildTimeAllocationAnswer(apps: AppUsageSummary[], sites: WebsiteSummar
   return parts.join(' ')
 }
 
-function buildDistractionAnswer(apps: AppUsageSummary[], sites: WebsiteSummary[], sessions: AppSession[]): string | null {
+function buildDistractionAnswer(apps: AppUsageSummary[], sites: WebsiteSummary[]): string | null {
   if (apps.length === 0 && sites.length === 0) return null
 
-  const evidence = buildEvidence(apps, sites, sessions)
+  // Use apps only to avoid double-counting sessions that are already aggregated in apps
+  const evidence = buildEvidence(apps, sites, [])
   const distractingSignals = evidence.signals.filter(isDistractingSignal)
   const nonFocusSignals = evidence.signals.filter(isNonFocusSignal)
   const topSignals = distractingSignals.length > 0 ? distractingSignals : nonFocusSignals
@@ -1436,13 +1480,28 @@ function buildDistractionAnswer(apps: AppUsageSummary[], sites: WebsiteSummary[]
   }
 
   const label = distractingSignals.length > 0 ? 'the clearest distraction pull' : 'the strongest non-focus pull'
-  return `${topSignals[0].label} was ${label} at ${formatDuration(topSignals[0].seconds)}. Other signals: ${formatSignalList(topSignals, 3)}.`
+  const topSignal = topSignals[0]
+  const leadSite = topSignal.source === 'website'
+    ? sites.find((site) => site.topTitle?.trim() === topSignal.label || site.domain === topSignal.label)
+    : null
+  const leadApp = topSignal.source !== 'website'
+    ? apps.find((app) => app.appName === topSignal.label)
+    : null
+  const leadLabel = leadSite
+    ? `${leadSite.domain}${leadSite.topTitle?.trim() ? ` ("${leadSite.topTitle.trim()}")` : ''}`
+    : leadApp
+      ? leadApp.appName
+      : topSignal.label
+  // Slice off the first signal so "other signals" doesn't repeat the lead
+  const rest = topSignals.slice(1)
+  const otherPart = rest.length > 0 ? ` Other signals: ${formatSignalList(rest, 2)}.` : ''
+  return `${leadLabel} was ${label} at ${formatDuration(topSignal.seconds)}.${otherPart}`
 }
 
 function buildFocusScoreAnswer(apps: AppUsageSummary[], sessions: AppSession[], sites: WebsiteSummary[]): string | null {
   if (apps.length === 0 && sessions.length === 0 && sites.length === 0) return null
 
-  const evidence = buildEvidence(apps, sites, sessions)
+  const evidence = buildEvidence(apps, sites, [])
   const totalSeconds = Math.max(evidence.totalSeconds, apps.reduce((sum, app) => sum + app.totalSeconds, 0))
   const focusSeconds = evidence.focusedSeconds
   const switchesPerHour = totalSeconds > 0 ? Math.max(0, sessions.length - 1) / Math.max(totalSeconds / 3600, 0.25) : 0
@@ -1467,7 +1526,7 @@ function buildFocusScoreAnswer(apps: AppUsageSummary[], sessions: AppSession[], 
 
 function buildTimelineSummary(apps: AppUsageSummary[], sites: WebsiteSummary[], sessions: AppSession[]): string | null {
   if (sessions.length === 0 && apps.length === 0 && sites.length === 0) return null
-  const evidence = buildEvidence(apps, sites, sessions)
+  const evidence = buildEvidence(apps, sites, [])
   const recent = sortedSessions(sessions)
     .slice(-5)
     .map((session) => {
@@ -1727,6 +1786,367 @@ function timeRangeAnswer(window: { start: Date; end: Date }, sessions: AppSessio
   return `Between ${formatTime(window.start.getTime())} and ${formatTime(window.end.getTime())}, the main thread was ${evidence.task.label.toLowerCase()}. Top sessions: ${topSessions.join(', ')}. Strongest signals: ${formatSignalList(evidence.signals, 3)}.`
 }
 
+// ── Entity identity ("who is X", "what do I do for X") ────────────────────────
+
+function isEntityIdentityQuestion(normalized: string): boolean {
+  return /\bwho\s+is\b/.test(normalized)
+    || /\bwhat\s+is\b/.test(normalized)
+    || /\btell\s+me\s+about\b/.test(normalized)
+    || /\bdescribe\b/.test(normalized)
+    || /\bwhat\s+do\s+i\s+(?:do|work)\s+(?:for|on)\b/.test(normalized)
+    || /\bwhat\s+(?:kind\s+of\s+work|work)\s+(?:do\s+i\s+do|am\s+i\s+doing)\s+(?:for|on)\b/.test(normalized)
+    || /\bwhat\s+project\s+(?:am\s+i\s+building|is\s+this|do\s+i\s+have)\b/.test(normalized)
+}
+
+function buildEntityIdentityAnswer(
+  evidence: EntityEvidence,
+  resolvedContext: TemporalContext,
+): RouterResult | null {
+  const directSessions = evidence.directSessions.filter(isMeaningfulSession)
+  const directVisits = evidence.directWebsiteVisits
+
+  if (directSessions.length === 0 && directVisits.length === 0) {
+    return {
+      answer: `I don't have tracked activity for "${evidence.entity}" ${windowReferenceLabel(evidence.range.label)}. If this is a client or project, its name needs to appear in a window title, email subject, workbook name, or browser page title for me to attribute time to it.`,
+      resolvedContext,
+      suggestions: [
+        `How much time did I spend on ${evidence.entity} today?`,
+        'What was I working on today?',
+        'List my clients today.',
+      ],
+    }
+  }
+
+  const devSessions = directSessions.filter(isCodingLikeApp)
+  const terminalSess = directSessions.filter(isTerminalLikeApp)
+  const emailSessions = directSessions.filter((s) => s.category === 'email')
+  const docSessions = directSessions.filter((s) => s.category === 'productivity' || s.category === 'writing')
+  const hasDevWork = devSessions.length > 0 || terminalSess.length > 0
+  const hasClientComms = emailSessions.length > 0
+  const hasDocWork = docSessions.length > 0
+  const hasBrowserWork = directVisits.length > 0
+
+  // Infer entity type from activity mix
+  let entityType: string
+  if (hasDevWork && hasClientComms) {
+    entityType = `a client or project — there's both development work and email communication tied to it`
+  } else if (hasDevWork && hasDocWork) {
+    entityType = `a project — evidence spans coding and document/spreadsheet work`
+  } else if (hasDevWork) {
+    entityType = `a project or codebase you're actively developing`
+  } else if (hasClientComms && hasDocWork) {
+    entityType = `a client — the evidence is email and document work`
+  } else if (hasDocWork) {
+    entityType = `a client or project with document/spreadsheet work`
+  } else if (hasBrowserWork) {
+    entityType = `a project or account you're reviewing in a browser`
+  } else {
+    entityType = `a work entity that shows up in your tracked sessions`
+  }
+
+  const allTitles = dedupeStrings([
+    ...directSessions.map((s) => s.windowTitle?.trim() ?? '').filter(Boolean),
+    ...directVisits.map((v) => v.pageTitle?.trim() ?? '').filter(Boolean),
+  ], 5).map(stripKnownAppSuffixes).filter(Boolean)
+
+  const breakdown: string[] = []
+  if (devSessions.length > 0) {
+    breakdown.push(`${formatDuration(devSessions.reduce((sum, s) => sum + s.durationSeconds, 0))} coding`)
+  }
+  if (terminalSess.length > 0) {
+    breakdown.push(`${formatDuration(terminalSess.reduce((sum, s) => sum + s.durationSeconds, 0))} in terminal`)
+  }
+  if (emailSessions.length > 0) {
+    breakdown.push(`${formatDuration(emailSessions.reduce((sum, s) => sum + s.durationSeconds, 0))} in email`)
+  }
+  if (docSessions.length > 0) {
+    breakdown.push(`${formatDuration(docSessions.reduce((sum, s) => sum + s.durationSeconds, 0))} in docs/spreadsheets`)
+  }
+  if (hasBrowserWork) {
+    const browserSeconds = directVisits.reduce((sum, v) => sum + v.durationSeconds, 0)
+    const domains = dedupeStrings(directVisits.map((v) => v.domain), 2)
+    breakdown.push(`${formatDuration(browserSeconds)} in browser (${humanList(domains, 2)})`)
+  }
+
+  const totalSeconds = directSessions.reduce((sum, s) => sum + s.durationSeconds, 0)
+    + directVisits.reduce((sum, v) => sum + v.durationSeconds, 0)
+
+  const parts: string[] = [
+    `Based on tracked activity, ${evidence.entity} looks like ${entityType}.`,
+  ]
+  if (allTitles.length > 0) {
+    parts.push(`Evidence in titles: ${humanQuotedList(allTitles, 4)}.`)
+  }
+  if (breakdown.length > 0) {
+    parts.push(`Work breakdown: ${humanList(breakdown, 4)}.`)
+  }
+  parts.push(`Total tracked ${windowReferenceLabel(evidence.range.label)}: ${formatDuration(totalSeconds)}.`)
+
+  return {
+    answer: parts.join(' '),
+    resolvedContext,
+    suggestions: [
+      `How many hours have I spent on ${evidence.entity} today?`,
+      `Break ${evidence.entity} down by app today.`,
+      `Which ${evidence.entity} titles matched?`,
+    ],
+  }
+}
+
+// ── Client listing ────────────────────────────────────────────────────────────
+
+const APP_DISPLAY_NOISE = new Set([
+  'Visual Studio Code', 'VS Code', 'Microsoft Outlook', 'Outlook',
+  'Microsoft Excel', 'Excel', 'Google Chrome', 'Chrome', 'Windows Terminal',
+  'Microsoft Word', 'Word', 'Microsoft Edge', 'Edge', 'Firefox', 'Safari',
+  'Microsoft Teams', 'Teams', 'Slack', 'Finder', 'Explorer', 'Settings',
+  'New Tab', 'Start Page', 'Home', 'Inbox', 'Untitled',
+])
+
+const ENTITY_STOP_WORDS = new Set([
+  'VS', 'RE', 'FW', 'FWD', 'HTTP', 'HTTPS', 'URL', 'ID', 'API', 'SQL',
+  'PDF', 'UI', 'UX', 'PR', 'WIP', 'TBD', 'EOD', 'THE', 'AND', 'OR',
+  'FOR', 'NOT', 'BUT', 'NEW', 'OLD', 'ALL', 'ANY', 'MY', 'README',
+])
+
+function extractEntitiesFromActivity(
+  sessions: AppSession[],
+  visits: WebsiteVisit[],
+): Map<string, number> {
+  const entitySeconds = new Map<string, number>()
+
+  function addEntity(entity: string, seconds: number): void {
+    if (ENTITY_STOP_WORDS.has(entity.toUpperCase())) return
+    if (entity.length < 2 || entity.length > 30) return
+    if (APP_DISPLAY_NOISE.has(entity)) return
+    entitySeconds.set(entity, (entitySeconds.get(entity) ?? 0) + seconds)
+  }
+
+  for (const session of sessions) {
+    const title = session.windowTitle ?? ''
+    // All-caps acronyms (ASYV, IBM, KPMG — 2 to 8 chars)
+    for (const match of title.matchAll(/\b([A-Z][A-Z0-9]{1,7})\b/g)) {
+      addEntity(match[1], session.durationSeconds)
+    }
+    // Capitalized multi-word proper nouns (Acme Corp, Project Alpha)
+    for (const match of title.matchAll(/\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\b/g)) {
+      if (!APP_DISPLAY_NOISE.has(match[1])) addEntity(match[1], session.durationSeconds)
+    }
+  }
+
+  for (const visit of visits) {
+    const title = visit.pageTitle ?? ''
+    for (const match of title.matchAll(/\b([A-Z][A-Z0-9]{1,7})\b/g)) {
+      addEntity(match[1], visit.durationSeconds)
+    }
+    for (const match of title.matchAll(/\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\b/g)) {
+      if (!APP_DISPLAY_NOISE.has(match[1])) addEntity(match[1], visit.durationSeconds)
+    }
+  }
+
+  return entitySeconds
+}
+
+function isClientListQuestion(normalized: string): boolean {
+  return /\blist\b.*\b(?:clients?|projects?|accounts?|entities)\b/.test(normalized)
+    || /\bwho\s+are\s+my\s+(?:clients?|projects?)\b/.test(normalized)
+    || /\ball\s+(?:my\s+)?(?:clients?|projects?)\b/.test(normalized)
+    || /\b(?:clients?|projects?)\s+(?:list|today|this\s+week)\b/.test(normalized)
+    || /\bhow\s+much\s+time\s+(?:per|for\s+each)\s+client\b/.test(normalized)
+    || /\btime\s+(?:per|for\s+each)\s+client\b/.test(normalized)
+    || /\b(?:export|analyze)\b.*\bclientele\b/.test(normalized)
+    || /\bclientele\b/.test(normalized)
+    || /\btime\s+(?:per|by)\s+(?:client|project)\b/.test(normalized)
+}
+
+function buildClientListAnswer(
+  rangeLabel: string,
+  sessions: AppSession[],
+  visits: WebsiteVisit[],
+  resolvedContext: TemporalContext,
+): RouterResult | null {
+  const meaningfulSessions = sessions.filter(isMeaningfulSession)
+  const entitySeconds = extractEntitiesFromActivity(meaningfulSessions, visits)
+
+  const ranked = [...entitySeconds.entries()]
+    .filter(([, seconds]) => seconds >= 60)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 10)
+
+  if (ranked.length === 0) {
+    return {
+      answer: `I couldn't identify named clients or projects from titles ${windowReferenceLabel(rangeLabel)}. Attribution requires the client or project name to appear in window titles, email subjects, workbook names, or page titles.`,
+      resolvedContext,
+      suggestions: [
+        'What was I working on today?',
+        'Break my work down by app today.',
+        'What was I doing this week?',
+      ],
+    }
+  }
+
+  const lines = ranked.map(([entity, seconds], index) =>
+    `${index + 1}. ${entity}: ${formatDuration(seconds)}`,
+  )
+
+  const totalTracked = ranked.reduce((sum, [, s]) => sum + s, 0)
+  const footnote = 'Time per entity is inferred from window titles and may overlap when multiple entities appeared in the same session.'
+
+  return {
+    answer: [
+      `Named entities by tracked time ${windowReferenceLabel(rangeLabel)} (${formatDuration(totalTracked)} total):`,
+      ...lines,
+      '',
+      footnote,
+    ].join('\n'),
+    resolvedContext,
+    suggestions: ranked.slice(0, 3).map(([entity]) => `How many hours have I spent on ${entity} today?`),
+  }
+}
+
+// ── Comparison ("ASYV vs Acme Corp today") ────────────────────────────────────
+
+function isComparisonQuestion(normalized: string): boolean {
+  return /\bvs\.?\s|\bversus\b|\bcompare\b|\bcompared\s+to\b/.test(normalized)
+}
+
+function extractTwoEntities(question: string): [string, string] | null {
+  const vsMatch = question.match(
+    /(.+?)\s+(?:vs\.?|versus|compared?\s+to)\s+(.+?)(?:\s+(?:today|yesterday|this week|that week|last week|past week|last \d+ days?))*\s*\??$/i,
+  )
+  if (!vsMatch) return null
+
+  const rawA = vsMatch[1].replace(/^(?:compare\s+|how\s+much\s+time\s+(?:on|for)\s+|time\s+on\s+)/i, '').trim()
+  const rawB = vsMatch[2]
+    .replace(/\s*[—–-]+\s+(?:which|who|what)\b.*$/i, '')  // strip "— which took more time"
+    .replace(/\s*\b(?:which|who)\s+(?:took|had|has|is|was)\b.*$/i, '')
+    .trim()
+
+  const a = cleanedEntityCandidate(rawA)
+  const b = cleanedEntityCandidate(rawB)
+
+  if (!a || !b || meaningfulQueryTokens(a).length === 0 || meaningfulQueryTokens(b).length === 0) return null
+  return [a, b]
+}
+
+function buildComparisonAnswer(
+  entityA: string,
+  entityB: string,
+  range: ResolvedRange,
+  sessions: AppSession[],
+  visits: WebsiteVisit[],
+  resolvedContext: TemporalContext,
+): RouterResult | null {
+  const evidenceA = buildEntityEvidence(entityA, range, '', sessions, visits)
+  const evidenceB = buildEntityEvidence(entityB, range, '', sessions, visits)
+
+  const secondsA = evidenceA.contextualSessions.filter(isMeaningfulSession).reduce((sum, s) => sum + s.durationSeconds, 0)
+    + evidenceA.contextualWebsiteVisits.reduce((sum, v) => sum + v.durationSeconds, 0)
+  const secondsB = evidenceB.contextualSessions.filter(isMeaningfulSession).reduce((sum, s) => sum + s.durationSeconds, 0)
+    + evidenceB.contextualWebsiteVisits.reduce((sum, v) => sum + v.durationSeconds, 0)
+
+  if (secondsA === 0 && secondsB === 0) {
+    return {
+      answer: `I couldn't find tracked evidence for either ${entityA} or ${entityB} ${windowReferenceLabel(range.label)}.`,
+      resolvedContext,
+      suggestions: ['What was I working on today?', 'List my clients today.'],
+    }
+  }
+
+  const lineA = secondsA > 0
+    ? `${entityA}: ${formatDuration(secondsA)}`
+    : `${entityA}: no tracked evidence ${windowReferenceLabel(range.label)}`
+  const lineB = secondsB > 0
+    ? `${entityB}: ${formatDuration(secondsB)}`
+    : `${entityB}: no tracked evidence ${windowReferenceLabel(range.label)}`
+
+  const winner = secondsA > secondsB ? entityA : secondsB > secondsA ? entityB : null
+  const closingLine = winner
+    ? `${winner} had more tracked time ${windowReferenceLabel(range.label)}.`
+    : `Both had the same tracked time ${windowReferenceLabel(range.label)}.`
+
+  return {
+    answer: [
+      `Comparison ${windowReferenceLabel(range.label)}: ${entityA} vs ${entityB}.`,
+      lineA,
+      lineB,
+      '',
+      closingLine,
+    ].join('\n'),
+    resolvedContext,
+    suggestions: [
+      `Break ${entityA} down by app today.`,
+      `Break ${entityB} down by app today.`,
+      'List my clients today.',
+    ],
+  }
+}
+
+// ── Day summary ("summarize my day", "how was my day") ────────────────────────
+
+function isDaySummaryQuestion(normalized: string): boolean {
+  return normalized.includes('summarize my day')
+    || normalized.includes('summarize today')
+    || normalized.includes('daily summary')
+    || normalized.includes('how was my day')
+    || normalized.includes('give me a summary')
+    || normalized.includes('overview of today')
+    || normalized.includes('overview of my day')
+    || normalized.includes('what happened today')
+    || normalized.includes('recap my day')
+    || normalized.includes('day recap')
+    || normalized.includes('summary of today')
+    || normalized.includes('summary of my day')
+    || (normalized.includes('analyze') && (normalized.includes('clientele') || normalized.includes('client')))
+}
+
+function buildDaySummaryAnswer(
+  apps: AppUsageSummary[],
+  sites: WebsiteSummary[],
+  sessions: AppSession[],
+  visits: WebsiteVisit[],
+  rangeLabel: string,
+): string | null {
+  if (apps.length === 0 && sessions.length === 0) return null
+
+  const totalSeconds = apps.reduce((sum, app) => sum + app.totalSeconds, 0)
+  const focusedSeconds = apps.filter((app) => isFocusedCategory(app.category)).reduce((sum, app) => sum + app.totalSeconds, 0)
+  const focusPct = totalSeconds > 0 ? Math.round((focusedSeconds / totalSeconds) * 100) : 0
+
+  // Extract named entities from session/visit titles
+  const entitySeconds = extractEntitiesFromActivity(sessions.filter(isMeaningfulSession), visits)
+  const topEntities = [...entitySeconds.entries()]
+    .filter(([, s]) => s >= 60)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 4)
+
+  const topAppsLine = apps
+    .slice(0, 4)
+    .map((app) => `${app.appName} (${formatDuration(app.totalSeconds)})`)
+    .join(', ')
+
+  const entityLine = topEntities.length > 0
+    ? topEntities.map(([e, s]) => `${e} (${formatDuration(s)})`).join(', ')
+    : null
+
+  const topSite = sites[0]
+  const latestSession = [...sortedSessions(sessions)].at(-1)
+
+  const parts: string[] = [
+    `${windowLeadLabel(rangeLabel).charAt(0).toUpperCase() + windowLeadLabel(rangeLabel).slice(1)}: ${formatDuration(totalSeconds)} tracked, ${focusPct}% in focused apps.`,
+  ]
+
+  if (topAppsLine) parts.push(`Top apps: ${topAppsLine}.`)
+  if (entityLine) parts.push(`Clients/projects in titles: ${entityLine}.`)
+  if (topSite) parts.push(`Most visited site: ${topSite.domain} (${formatDuration(topSite.totalSeconds)}).`)
+  if (latestSession) {
+    const t = latestSession.windowTitle?.trim()
+    parts.push(`Last active: ${latestSession.appName}${t ? ` on "${stripKnownAppSuffixes(t)}"` : ''} at ${formatTime(latestSession.startTime)}.`)
+  }
+
+  return parts.join(' ')
+}
+
 export async function routeInsightsQuestion(
   question: string,
   defaultDate: Date,
@@ -1738,25 +2158,75 @@ export async function routeInsightsQuestion(
 
   const normalized = trimmed.toLowerCase()
   const resolvedContext = resolveTemporalContext(trimmed, defaultDate, previousContext)
+
+  // Resolve the date-scoped range used by most routes
+  const dayRange = resolveQuestionRange(trimmed, resolvedContext.date, !hasTemporalCue(normalized))
+
+  // ── Client list / clientele export ─────────────────────────────────────────
+  if (isClientListQuestion(normalized)) {
+    const sessions = getSessionsForRange(db, dayRange.startMs, dayRange.endMs + 1)
+    const visits = getWebsiteVisitsForRange(db, dayRange.startMs, dayRange.endMs + 1)
+    const result = buildClientListAnswer(dayRange.label, sessions, visits, resolvedContext)
+    if (result) return result
+  }
+
+  // ── Comparison ("ASYV vs Acme") ─────────────────────────────────────────────
+  if (isComparisonQuestion(normalized)) {
+    const entities = extractTwoEntities(trimmed)
+    if (entities) {
+      const [entityA, entityB] = entities
+      const sessions = getSessionsForRange(db, dayRange.startMs, dayRange.endMs + 1)
+      const visits = getWebsiteVisitsForRange(db, dayRange.startMs, dayRange.endMs + 1)
+      const result = buildComparisonAnswer(entityA, entityB, dayRange, sessions, visits, resolvedContext)
+      if (result) return result
+    }
+  }
+
+  // ── Known metric / scoring questions — route before entity extraction hijacks them ─
+  if (normalized.includes('focus score') || /\bwas\s+i\s+focused\b/.test(normalized)) {
+    const [fromMsMetric, toMsMetric] = dayBounds(resolvedContext.date)
+    const appsMetric = getAppSummariesForRange(db, fromMsMetric, toMsMetric)
+    const sessionsMetric = getSessionsForRange(db, fromMsMetric, toMsMetric)
+    const sitesMetric = getWebsiteSummariesForRange(db, fromMsMetric, toMsMetric)
+    const answer = buildFocusScoreAnswer(appsMetric, sessionsMetric, sitesMetric)
+    if (answer) return { answer, resolvedContext }
+  }
+
+  // ── Entity quantity + title questions ("how many hours on X", "break X down") ─
   const entity = extractEntity(trimmed)
   if (isEntityQuestion(normalized, entity)) {
-    const range = resolveQuestionRange(
-      trimmed,
-      resolvedContext.date,
-      !hasTemporalCue(normalized),
-    )
-    const sessions = getSessionsForRange(db, range.startMs, range.endMs + 1)
-    const visits = getWebsiteVisitsForRange(db, range.startMs, range.endMs + 1)
-    const evidence = buildEntityEvidence(entity!, range, trimmed, sessions, visits)
+    const sessions = getSessionsForRange(db, dayRange.startMs, dayRange.endMs + 1)
+    const visits = getWebsiteVisitsForRange(db, dayRange.startMs, dayRange.endMs + 1)
+    const evidence = buildEntityEvidence(entity!, dayRange, trimmed, sessions, visits)
     const result = buildEntityAnswer(evidence, trimmed, sessions, resolvedContext)
     if (result) return result
   }
 
+  // ── Entity identity ("who is X", "what do I do for X") ─────────────────────
+  if (isEntityIdentityQuestion(normalized) && entity) {
+    const sessions = getSessionsForRange(db, dayRange.startMs, dayRange.endMs + 1)
+    const visits = getWebsiteVisitsForRange(db, dayRange.startMs, dayRange.endMs + 1)
+    const evidence = buildEntityEvidence(entity, dayRange, trimmed, sessions, visits)
+    const result = buildEntityIdentityAnswer(evidence, resolvedContext)
+    if (result) return result
+  }
+
+  // ── Weekly questions ────────────────────────────────────────────────────────
   if (isWeeklyQuestion(normalized)) {
     const weeklyRange = resolveWeeklyRange(normalized, resolvedContext.date)
     const apps = getAppSummariesForRange(db, weeklyRange.startMs, weeklyRange.endMs + 1)
     const sites = getWebsiteSummariesForRange(db, weeklyRange.startMs, weeklyRange.endMs + 1)
     const sessions = getSessionsForRange(db, weeklyRange.startMs, weeklyRange.endMs + 1)
+    const visits = getWebsiteVisitsForRange(db, weeklyRange.startMs, weeklyRange.endMs + 1)
+
+    if (isClientListQuestion(normalized)) {
+      const result = buildClientListAnswer(weeklyRange.label, sessions, visits, resolvedContext)
+      if (result) return result
+    }
+    if (isDaySummaryQuestion(normalized) || normalized.includes('summarize this week') || normalized.includes('what happened this week')) {
+      const answer = buildDaySummaryAnswer(apps, sites, sessions, visits, weeklyRange.label)
+      return answer ? { answer, resolvedContext } : null
+    }
     if (isAppBreakdownQuestion(normalized)) {
       const answer = buildGeneralAppBreakdown(weeklyRange.label, apps, sites)
       return answer ? { answer, resolvedContext } : null
@@ -1782,14 +2252,15 @@ export async function routeInsightsQuestion(
       || normalized.includes('what did i work on')
       || normalized.includes('what did i do')
       || normalized.includes('where did my time go')
-      || normalized.includes('what happened this week')
-      || normalized.includes('summarize this week')
     ) {
-      const answer = buildTimelineSummary(apps, sites, sessions) ?? dailyTopCategoryAnswer(apps, sites)
+      const answer = buildWorkThreadAnswer(apps, sites, sessions, 'You were mostly working on')
+        ?? buildTimelineSummary(apps, sites, sessions)
+        ?? dailyTopCategoryAnswer(apps, sites)
       return answer ? { answer, resolvedContext } : null
     }
   }
 
+  // ── Time-window exact lookups ───────────────────────────────────────────────
   if (resolvedContext.timeWindow) {
     const sessions = getSessionsForRange(db, resolvedContext.timeWindow.start.getTime(), resolvedContext.timeWindow.end.getTime())
     const sites = getWebsiteSummariesForRange(db, resolvedContext.timeWindow.start.getTime(), resolvedContext.timeWindow.end.getTime())
@@ -1797,10 +2268,18 @@ export async function routeInsightsQuestion(
     return answer ? { answer, resolvedContext } : null
   }
 
+  // ── Day-scoped routes ───────────────────────────────────────────────────────
   const [fromMs, toMs] = dayBounds(resolvedContext.date)
   const apps = getAppSummariesForRange(db, fromMs, toMs)
   const sites = getWebsiteSummariesForRange(db, fromMs, toMs)
   const sessions = getSessionsForRange(db, fromMs, toMs)
+  const visits = getWebsiteVisitsForRange(db, fromMs, toMs)
+
+  // Day summary / "summarize my day" / "how was my day" / "give me a summary"
+  if (isDaySummaryQuestion(normalized)) {
+    const answer = buildDaySummaryAnswer(apps, sites, sessions, visits, 'today')
+    return answer ? { answer, resolvedContext } : null
+  }
 
   if (isAppBreakdownQuestion(normalized)) {
     const answer = buildGeneralAppBreakdown('today', apps, sites)
@@ -1813,7 +2292,7 @@ export async function routeInsightsQuestion(
   }
 
   if (normalized.includes('what distracted me') || normalized.includes('biggest distraction')) {
-    const answer = buildDistractionAnswer(apps, sites, sessions)
+    const answer = buildDistractionAnswer(apps, sites)
     return answer ? { answer, resolvedContext } : null
   }
 
@@ -1826,6 +2305,11 @@ export async function routeInsightsQuestion(
   ) {
     const prefix = normalized.includes('what should i resume') ? 'Resume' : 'You were mostly working on'
     const answer = buildWorkThreadAnswer(apps, sites, sessions, prefix)
+    return answer ? { answer, resolvedContext } : null
+  }
+
+  if (normalized.includes('where did my time go') || normalized.includes('where did the time go') || normalized.includes('time allocation')) {
+    const answer = buildTimeAllocationAnswer(apps, sites)
     return answer ? { answer, resolvedContext } : null
   }
 
@@ -1858,11 +2342,6 @@ export async function routeInsightsQuestion(
       answer: `${topSite.domain} was your top site at ${formatDuration(topSite.totalSeconds)}.`,
       resolvedContext,
     }
-  }
-
-  if (normalized.includes('where did my time go') || normalized.includes('where did the time go')) {
-    const answer = buildTimeAllocationAnswer(apps, sites, sessions)
-    return answer ? { answer, resolvedContext } : null
   }
 
   if (normalized.includes('how much time') || normalized.includes('how long')) {

--- a/src/main/lib/insightsQueryRouter.ts
+++ b/src/main/lib/insightsQueryRouter.ts
@@ -1,5 +1,11 @@
 import type Database from 'better-sqlite3'
-import { getAppSummariesForRange, getSessionsForRange, getWebsiteSummariesForRange } from '../db/queries'
+import {
+  getAppSummariesForRange,
+  getSessionsForRange,
+  getWebsiteSummariesForRange,
+  getWebsiteVisitsForRange,
+  type WebsiteVisit,
+} from '../db/queries'
 import type { AppCategory, AppSession, AppUsageSummary, WebsiteSummary } from '@shared/types'
 import { FOCUSED_CATEGORIES } from '@shared/types'
 import { computeFocusScore } from '../lib/focusScore'
@@ -13,6 +19,7 @@ export interface TemporalContext {
 export interface RouterResult {
   answer: string
   resolvedContext: TemporalContext
+  suggestions?: string[]
 }
 
 const FOLLOW_UP_PATTERNS = [
@@ -20,6 +27,7 @@ const FOLLOW_UP_PATTERNS = [
   'at that point',
   'then',
   'doing what',
+  'working on what',
   'what exactly',
   'that moment',
 ]
@@ -46,6 +54,67 @@ function formatTime(ms: number): string {
     minute: '2-digit',
     hour12: true,
   })
+}
+
+function normalizedText(value: string | null | undefined): string {
+  return (value ?? '').toLowerCase().replace(/\s+/g, ' ').trim()
+}
+
+function sessionDescriptor(session: AppSession): string {
+  const title = session.windowTitle?.trim()
+  return title ? `${session.appName} (${title})` : session.appName
+}
+
+interface ResolvedRange {
+  startMs: number
+  endMs: number
+  label: string
+}
+
+interface DirectEvidence {
+  startMs: number
+  endMs: number
+  label: string
+}
+
+type ActivityBucket =
+  | 'coding'
+  | 'browserTesting'
+  | 'terminal'
+  | 'aiCollaboration'
+  | 'docs'
+  | 'related'
+
+interface StrongestSession {
+  startMs: number
+  endMs: number
+}
+
+interface ActivityContribution {
+  bucket: ActivityBucket
+  durationSeconds: number
+  appNames: string[]
+  titles: string[]
+  domains: string[]
+  includesLocalhost: boolean
+  activeDays: Date[]
+  strongestSession: StrongestSession | null
+}
+
+interface ExplicitWeekdayReference {
+  weekdayValue: number
+  modifier: string | null
+}
+
+interface EntityEvidence {
+  entity: string
+  directSessions: AppSession[]
+  directWebsiteVisits: WebsiteVisit[]
+  contextualSessions: AppSession[]
+  contextualWebsiteVisits: WebsiteVisit[]
+  directEvidence: DirectEvidence[]
+  appFilter: string | null
+  range: ResolvedRange
 }
 
 function sessionEnd(session: AppSession): number {
@@ -78,6 +147,1104 @@ function formatSignalList(signals: WorkEvidenceSignal[], limit = 3): string {
 
 function sortedSessions(sessions: AppSession[]): AppSession[] {
   return [...sessions].sort((left, right) => left.startTime - right.startTime)
+}
+
+function dedupeStrings(values: string[], limit = values.length): string[] {
+  const unique = values
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .filter((value, index, arr) => arr.indexOf(value) === index)
+  return unique.slice(0, limit)
+}
+
+function endOfDay(date: Date): Date {
+  const result = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  result.setHours(23, 59, 59, 999)
+  return result
+}
+
+function mondayFor(date: Date): Date {
+  const result = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  const day = result.getDay()
+  const delta = day === 0 ? -6 : 1 - day
+  result.setDate(result.getDate() + delta)
+  result.setHours(0, 0, 0, 0)
+  return result
+}
+
+function addDays(date: Date, days: number): Date {
+  const result = new Date(date)
+  result.setDate(result.getDate() + days)
+  return result
+}
+
+function weekRangeContaining(date: Date): ResolvedRange {
+  const start = mondayFor(date)
+  const end = endOfDay(addDays(start, 6))
+  return {
+    startMs: start.getTime(),
+    endMs: end.getTime(),
+    label: 'that week',
+  }
+}
+
+function formatWeekday(date: Date): string {
+  return date.toLocaleDateString('en-US', { weekday: 'long' })
+}
+
+function humanList(values: string[], maxItems = values.length): string {
+  const items = dedupeStrings(values, maxItems)
+  if (items.length === 0) return 'the relevant tools'
+  if (items.length === 1) return items[0]
+  if (items.length === 2) return `${items[0]} and ${items[1]}`
+  return `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`
+}
+
+function humanQuotedList(values: string[], maxItems: number): string {
+  return humanList(values.map((value) => `"${value}"`), maxItems)
+}
+
+function daysList(dates: Date[]): string {
+  return humanList(dates.map(formatWeekday), dates.length)
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/i)
+    .filter(Boolean)
+    .join(' ')
+}
+
+function meaningfulQueryTokens(value: string): string[] {
+  const stopWords = new Set([
+    'a',
+    'an',
+    'and',
+    'for',
+    'from',
+    'have',
+    'hours',
+    'how',
+    'i',
+    'in',
+    'last',
+    'long',
+    'many',
+    'much',
+    'on',
+    'past',
+    'spent',
+    'spend',
+    'spending',
+    'that',
+    'the',
+    'this',
+    'time',
+    'today',
+    'total',
+    'week',
+    'with',
+    'work',
+    'yesterday',
+    'cumulative',
+    'cumulatively',
+    'things',
+    'stuff',
+    'activity',
+  ])
+
+  return normalizeSearchText(value)
+    .split(' ')
+    .filter((token) => token.length >= 2 && !stopWords.has(token))
+}
+
+function isPriorWeekMention(normalized: string): boolean {
+  return normalized.includes('last week') || normalized.includes('past week')
+}
+
+function stripTrailingQueryAddOns(candidate: string): string {
+  let cleaned = candidate.trim()
+  const patterns = [
+    /[.!?]\s+(?:also|and|really|what|break|drill|show|tell|can|could|would)\b.*$/i,
+    /\s+(?:also|and then|then)\s+(?:what|show|break|drill|tell)\b.*$/i,
+    /\s+(?:break it down|drill down|go deeper|tell me more)\b.*$/i,
+    /\s+(?:comprehensively|specifically)\s*$/i,
+    /\s+in total\s*$/i,
+    /\s+related\s+(?:things|work|stuff|activity)\s*$/i,
+  ]
+
+  for (const pattern of patterns) {
+    cleaned = cleaned.replace(pattern, '')
+  }
+
+  return cleaned.trim()
+}
+
+function stripKnownAppSuffixes(rawTitle: string): string {
+  return rawTitle.replace(
+    /\s(?:-|\||—)\s(?:Visual Studio Code|VS Code|Cursor|Windsurf|Visual Studio|Rider|IntelliJ IDEA|PyCharm|WebStorm|Microsoft Outlook|Outlook|Google Chrome|Chrome|Microsoft Edge|Edge|Firefox|Excel|Word|PowerPoint|Windows Terminal|PowerShell|Command Prompt|Teams)$/i,
+    '',
+  )
+}
+
+function looksLikeWorkArtifact(value: string): boolean {
+  return value.includes('/')
+    || value.includes('\\')
+    || /\.[a-z0-9]{1,6}\b/i.test(value)
+}
+
+function windowLeadLabel(label: string): string {
+  if (label === 'today' || label === 'yesterday' || label === 'this week' || label === 'that week' || label === 'last week') {
+    return label
+  }
+  if (label === 'past week') return 'over the past week'
+  if (label.startsWith('the last ')) return `over ${label}`
+  return `on ${label}`
+}
+
+function windowReferenceLabel(label: string): string {
+  if (label === 'past week') return 'over the past week'
+  if (label.startsWith('the last ')) return `over ${label}`
+  if (label === 'today' || label === 'yesterday' || label === 'this week' || label === 'that week' || label === 'last week') {
+    return `for ${label}`
+  }
+  return `on ${label}`
+}
+
+function localhostLabel(domains: string[]): string {
+  const match = domains
+    .map((domain) => domain.match(/localhost(?::\d{2,5})?/i)?.[0] ?? null)
+    .find(Boolean)
+  return match ?? 'localhost'
+}
+
+function strongestSessionObservation(session: StrongestSession | null): string | null {
+  if (!session) return null
+  if (session.endMs - session.startMs < 20 * 60_000) return null
+  return `Heaviest stretch was ${formatWeekday(new Date(session.startMs))} ${formatTime(session.startMs)} to ${formatTime(session.endMs)}.`
+}
+
+function appDisplayNames(names: string[]): string[] {
+  return dedupeStrings(names.map((raw) => {
+    const lower = raw.toLowerCase()
+    if (lower === 'visual studio code') return 'VS Code'
+    if (lower === 'google chrome') return 'Chrome'
+    if (lower === 'microsoft edge') return 'Edge'
+    if (lower === 'windows terminal') return 'Windows Terminal'
+    return raw
+  }))
+}
+
+function terminalDisplayNames(names: string[]): string[] {
+  return dedupeStrings(names.map((raw) => {
+    const lower = raw.toLowerCase()
+    if (lower.includes('windows terminal')) return 'Windows Terminal'
+    if (lower.includes('powershell') || lower === 'pwsh') return 'PowerShell'
+    if (lower.includes('command prompt') || lower === 'cmd') return 'Command Prompt'
+    if (lower.includes('wezterm')) return 'WezTerm'
+    if (lower.includes('git bash')) return 'Git Bash'
+    return raw
+  }))
+}
+
+function isTerminalLikeApp(session: AppSession): boolean {
+  const combined = `${session.appName} ${session.bundleId}`.toLowerCase()
+  return combined.includes('terminal')
+    || combined.includes('powershell')
+    || combined.includes('pwsh')
+    || combined.includes('command prompt')
+    || combined.includes('cmd.exe')
+    || combined.includes('wezterm')
+    || combined.includes('git bash')
+}
+
+function isCodingLikeApp(session: AppSession): boolean {
+  if (session.category === 'development') return true
+  const combined = `${session.appName} ${session.bundleId}`.toLowerCase()
+  return combined.includes('cursor')
+    || combined.includes('visual studio code')
+    || combined.includes('code.exe')
+    || combined.includes('vscode')
+    || combined.includes('visual studio')
+    || combined.includes('devenv')
+    || combined.includes('rider')
+    || combined.includes('intellij')
+    || combined.includes('webstorm')
+    || combined.includes('pycharm')
+    || combined.includes('windsurf')
+}
+
+function isAIApp(session: AppSession): boolean {
+  const combined = `${session.appName} ${session.bundleId}`.toLowerCase()
+  return combined.includes('claude')
+    || combined.includes('chatgpt')
+    || combined.includes('codex')
+    || combined.includes('openai')
+    || combined.includes('anthropic')
+    || combined.includes('perplexity')
+}
+
+function isBrowserLikeSession(session: AppSession): boolean {
+  if (session.category === 'browsing' || session.category === 'research') return true
+  const combined = `${session.appName} ${session.bundleId}`.toLowerCase()
+  return combined.includes('chrome')
+    || combined.includes('edge')
+    || combined.includes('firefox')
+    || combined.includes('browser')
+    || combined.includes('brave')
+    || combined.includes('opera')
+}
+
+function featureContext(titles: string[], target: string): string[] {
+  const targetLower = target.toLowerCase()
+  const targetTokens = new Set(meaningfulQueryTokens(target))
+  const blocked = new Set([
+    'new tab',
+    'home',
+    'untitled',
+    'login',
+    'loading...',
+    'start page',
+    'inbox',
+    'compose',
+    'mail',
+    'google',
+    'localhost',
+  ])
+  const seen = new Set<string>()
+
+  return titles
+    .map((raw) => stripKnownAppSuffixes(raw).trim())
+    .filter((cleaned) => cleaned.length > 3)
+    .filter((cleaned) => {
+      const lower = cleaned.toLowerCase()
+      if (lower === targetLower || blocked.has(lower) || seen.has(lower)) return false
+      const cleanedTokens = new Set(meaningfulQueryTokens(cleaned))
+      const overlapsTarget = [...cleanedTokens].some((token) => targetTokens.has(token))
+      const keep = looksLikeWorkArtifact(cleaned) || overlapsTarget
+      if (keep) seen.add(lower)
+      return keep
+    })
+}
+
+function visitEnd(visit: WebsiteVisit): number {
+  return visit.visitTime + visit.durationSeconds * 1000
+}
+
+function directEvidenceLabel(entity: string, session: AppSession | null, visit: WebsiteVisit | null): string | null {
+  if (session) {
+    const title = session.windowTitle?.trim()
+    if (title && textContainsEntity(title, entity)) return title
+    return session.appName.trim() || null
+  }
+
+  if (!visit) return null
+  const candidates = [visit.pageTitle?.trim(), visit.url?.trim(), visit.domain.trim()]
+  return candidates.find((value) => value && textContainsEntity(value, entity)) ?? candidates.find(Boolean) ?? null
+}
+
+function mergeTimeRanges(
+  ranges: Array<{ startMs: number; endMs: number }>,
+  maxGapMs = 0,
+): Array<{ startMs: number; endMs: number }> {
+  const sorted = [...ranges]
+    .filter((range) => range.endMs > range.startMs)
+    .sort((left, right) => left.startMs - right.startMs)
+
+  const merged: Array<{ startMs: number; endMs: number }> = []
+  for (const range of sorted) {
+    const last = merged.at(-1)
+    if (!last) {
+      merged.push({ ...range })
+      continue
+    }
+    if (range.startMs - last.endMs <= maxGapMs) {
+      last.endMs = Math.max(last.endMs, range.endMs)
+      continue
+    }
+    merged.push({ ...range })
+  }
+
+  return merged
+}
+
+function buildDirectEvidence(entity: string, sessions: AppSession[], visits: WebsiteVisit[]): DirectEvidence[] {
+  const evidence: DirectEvidence[] = []
+
+  for (const session of sessions) {
+    const label = directEvidenceLabel(entity, session, null)
+    if (!label) continue
+    evidence.push({
+      startMs: session.startTime,
+      endMs: sessionEnd(session),
+      label,
+    })
+  }
+
+  for (const visit of visits) {
+    const label = directEvidenceLabel(entity, null, visit)
+    if (!label) continue
+    evidence.push({
+      startMs: visit.visitTime,
+      endMs: visitEnd(visit),
+      label,
+    })
+  }
+
+  return evidence.sort((left, right) => {
+    if (left.startMs === right.startMs) return left.endMs - right.endMs
+    return left.startMs - right.startMs
+  })
+}
+
+function buildContextWindows(evidence: DirectEvidence[], range: ResolvedRange): Array<{ startMs: number; endMs: number }> {
+  const rangeEndExclusive = range.endMs + 1
+  return mergeTimeRanges(
+    evidence.map((item) => ({
+      startMs: Math.max(range.startMs, item.startMs - 5 * 60_000),
+      endMs: Math.min(rangeEndExclusive, item.endMs + 5 * 60_000),
+    })),
+    3 * 60_000,
+  )
+}
+
+function clipSessionToWindows(
+  session: AppSession,
+  windows: Array<{ startMs: number; endMs: number }>,
+): AppSession | null {
+  const overlaps = windows
+    .map((window) => ({
+      startMs: Math.max(session.startTime, window.startMs),
+      endMs: Math.min(sessionEnd(session), window.endMs),
+    }))
+    .filter((window) => window.endMs > window.startMs)
+
+  if (overlaps.length === 0) return null
+
+  const overlapMs = overlaps.reduce((sum, window) => sum + (window.endMs - window.startMs), 0)
+  return {
+    ...session,
+    startTime: overlaps[0].startMs,
+    endTime: overlaps.at(-1)?.endMs ?? overlaps[0].endMs,
+    durationSeconds: Math.max(1, Math.round(overlapMs / 1000)),
+  }
+}
+
+function clipVisitToWindows(
+  visit: WebsiteVisit,
+  windows: Array<{ startMs: number; endMs: number }>,
+): WebsiteVisit | null {
+  const overlaps = windows
+    .map((window) => ({
+      startMs: Math.max(visit.visitTime, window.startMs),
+      endMs: Math.min(visitEnd(visit), window.endMs),
+    }))
+    .filter((window) => window.endMs > window.startMs)
+
+  if (overlaps.length === 0) return null
+
+  const overlapMs = overlaps.reduce((sum, window) => sum + (window.endMs - window.startMs), 0)
+  return {
+    ...visit,
+    visitTime: overlaps[0].startMs,
+    durationSeconds: Math.max(1, Math.round(overlapMs / 1000)),
+  }
+}
+
+function explicitWeekdayReference(normalized: string): ExplicitWeekdayReference | null {
+  const weekdayNames: Array<{ name: string; value: number }> = [
+    { name: 'sunday', value: 0 },
+    { name: 'monday', value: 1 },
+    { name: 'tuesday', value: 2 },
+    { name: 'wednesday', value: 3 },
+    { name: 'thursday', value: 4 },
+    { name: 'friday', value: 5 },
+    { name: 'saturday', value: 6 },
+  ]
+
+  const tokens = normalized.split(/[^a-z0-9]+/i).filter(Boolean)
+  const match = weekdayNames.find((weekday) => tokens.includes(weekday.name))
+  if (!match) return null
+
+  const index = tokens.indexOf(match.name)
+  const modifier = index > 0 ? tokens[index - 1] : null
+  return {
+    weekdayValue: match.value,
+    modifier,
+  }
+}
+
+function resolveExplicitWeekday(normalized: string, referenceDate: Date): Date | null {
+  const weekdayReference = explicitWeekdayReference(normalized)
+  if (!weekdayReference) return null
+
+  const modifier = weekdayReference.modifier
+  const weekOffset = modifier === 'last' ? -1 : modifier === 'next' ? 1 : 0
+  const anchor = addDays(referenceDate, weekOffset * 7)
+  const weekStart = mondayFor(anchor)
+
+  for (let offset = 0; offset < 7; offset++) {
+    const candidate = addDays(weekStart, offset)
+    if (candidate.getDay() === weekdayReference.weekdayValue) {
+      candidate.setHours(0, 0, 0, 0)
+      return candidate
+    }
+  }
+
+  return null
+}
+
+function hasTemporalCue(normalized: string): boolean {
+  return normalized.includes('today')
+    || normalized.includes('yesterday')
+    || normalized.includes('tomorrow')
+    || normalized.includes('this week')
+    || normalized.includes('that week')
+    || normalized.includes('last week')
+    || normalized.includes('past week')
+    || /\b(?:last|past)\s+\d+\s+(?:days?|weeks?)\b/i.test(normalized)
+    || explicitWeekdayReference(normalized) !== null
+    || FOLLOW_UP_PATTERNS.some((pattern) => normalized.includes(pattern))
+}
+
+function resolveQuestionRange(question: string, anchorDate: Date, preferAllTrackedTime = false): ResolvedRange {
+  const normalized = question.toLowerCase()
+  const dayStart = new Date(anchorDate.getFullYear(), anchorDate.getMonth(), anchorDate.getDate())
+  const dayEnd = endOfDay(anchorDate)
+
+  const dayWindowMatch = normalized.match(/\b(?:last|past)\s+(\d+)\s+days?\b/)
+  if (dayWindowMatch) {
+    const days = Math.max(1, Number(dayWindowMatch[1]))
+    const start = new Date(dayStart)
+    start.setDate(start.getDate() - (days - 1))
+    return {
+      startMs: start.getTime(),
+      endMs: dayEnd.getTime(),
+      label: `the last ${days} days`,
+    }
+  }
+
+  const weekWindowMatch = normalized.match(/\b(?:last|past)\s+(\d+)\s+weeks?\b/)
+  if (weekWindowMatch) {
+    const weeks = Math.max(1, Number(weekWindowMatch[1]))
+    const start = new Date(dayStart)
+    start.setDate(start.getDate() - (weeks * 7 - 1))
+    return {
+      startMs: start.getTime(),
+      endMs: dayEnd.getTime(),
+      label: `the last ${weeks} weeks`,
+    }
+  }
+
+  if (isPriorWeekMention(normalized)) {
+    const week = weekRangeContaining(anchorDate)
+    return {
+      ...week,
+      label: normalized.includes('past week') ? 'past week' : 'last week',
+    }
+  }
+
+  if (normalized.includes('this week') || normalized.includes('that week')) {
+    const week = weekRangeContaining(anchorDate)
+    return {
+      ...week,
+      label: normalized.includes('this week') ? 'this week' : 'that week',
+    }
+  }
+
+  if (normalized.includes('yesterday')) {
+    const date = new Date(dayStart)
+    date.setDate(date.getDate() - 1)
+    const [startMs, nextMs] = dayBounds(date)
+    return {
+      startMs,
+      endMs: nextMs - 1,
+      label: 'yesterday',
+    }
+  }
+
+  if (normalized.includes('today')) {
+    const [startMs, nextMs] = dayBounds(anchorDate)
+    return {
+      startMs,
+      endMs: nextMs - 1,
+      label: 'today',
+    }
+  }
+
+  if (preferAllTrackedTime) {
+    return {
+      startMs: 0,
+      endMs: Date.now(),
+      label: 'all tracked time',
+    }
+  }
+
+  const [startMs, nextMs] = dayBounds(anchorDate)
+  return {
+    startMs,
+    endMs: nextMs - 1,
+    label: anchorDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+  }
+}
+
+function cleanEntityCandidate(value: string): string {
+  return value
+    .replace(/^[`"'“”‘’]+|[`"'“”‘’]+$/g, '')
+    .replace(/\b(?:today|yesterday|this week|that week|last week|past week|last \d+ days?|past \d+ days?|last \d+ weeks?|past \d+ weeks?)\b/gi, '')
+    .replace(/\b(?:cumulative|cumulatively|total|altogether)\b/gi, '')
+    .replace(/\b(?:break it down|by app|which titles matched|what matched|in outlook|in excel)\b/gi, '')
+    .replace(/[?.,]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function cleanedEntityCandidate(value: string): string {
+  return stripTrailingQueryAddOns(cleanEntityCandidate(value))
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function extractEntity(question: string): string | null {
+  const quoted = question.match(/["“]([^"”]+)["”]/)
+  if (quoted) {
+    const cleaned = cleanedEntityCandidate(quoted[1])
+    return meaningfulQueryTokens(cleaned).length > 0 ? cleaned : null
+  }
+
+  const patterns = [
+    /\b(?:how\s+(?:many\s+hours|much\s+time|long)(?:\s+did\s+i)?(?:\s+(?:spend|spent|spending))?\s+(?:on|for|with|in)\s+)(.+)$/i,
+    /\b(?:time\s+spent\s+(?:on|for|with|in)\s+)(.+)$/i,
+    /\b(?:hours\s+(?:on|for|with|in)\s+)(.+)$/i,
+    /\b(?:related to|about)\s+(.+)$/i,
+    /\b(?:break\s+down)\s+(.+?)(?:\s+(?:this week|that week|last week|past week|today|yesterday|last \d+ days?|past \d+ days?))*\s*\??$/i,
+  ]
+
+  for (const pattern of patterns) {
+    const match = question.match(pattern)
+    if (!match) continue
+    const cleaned = cleanedEntityCandidate(match[1])
+    if (meaningfulQueryTokens(cleaned).length > 0) return cleaned
+  }
+
+  const acronym = question.match(/\b[A-Z][A-Z0-9&._-]{1,}\b/)
+  return acronym?.[0] ?? null
+}
+
+function isEntityQuestion(normalized: string, entity: string | null): boolean {
+  if (!entity) return false
+  return normalized.includes('how many hours')
+    || normalized.includes('how much time')
+    || (normalized.includes('how much') && normalized.includes(' time'))
+    || normalized.includes('how long')
+    || normalized.includes('break it down')
+    || normalized.includes('by app')
+    || isTitleMatchQuestion(normalized)
+}
+
+function extractAppFilter(question: string): string | null {
+  const normalized = question.toLowerCase()
+  for (const candidate of ['outlook', 'excel', 'word', 'teams', 'chrome', 'edge', 'firefox']) {
+    if (normalized.includes(candidate)) return candidate
+  }
+  return null
+}
+
+function textContainsEntity(text: string | null | undefined, entity: string): boolean {
+  const haystack = normalizedText(text)
+  const needle = normalizedText(entity)
+  if (!haystack || !needle) return false
+  if (haystack.includes(needle)) return true
+
+  const tokens = meaningfulQueryTokens(entity)
+  return tokens.length > 1 && tokens.every((token) => haystack.includes(token))
+}
+
+function matchesAppFilter(session: AppSession, appFilter: string | null): boolean {
+  if (!appFilter) return true
+  const haystack = normalizedText(`${session.appName} ${session.bundleId} ${session.windowTitle ?? ''}`)
+  return haystack.includes(appFilter)
+}
+
+function matchesVisitAppFilter(visit: WebsiteVisit, appFilter: string | null): boolean {
+  if (!appFilter) return true
+  const haystack = normalizedText(`${visit.browserBundleId ?? ''} ${visit.pageTitle ?? ''} ${visit.domain}`)
+  return haystack.includes(appFilter)
+}
+
+function bucketForSession(session: AppSession, visits: WebsiteVisit[]): ActivityBucket {
+  if (isTerminalLikeApp(session)) return 'terminal'
+  if (isBrowserLikeSession(session)) return 'browserTesting'
+  if (isCodingLikeApp(session)) return 'coding'
+  if (session.category === 'aiTools' || isAIApp(session)) return 'aiCollaboration'
+  if (session.category === 'email' || session.category === 'productivity' || session.category === 'writing' || session.category === 'communication') return 'docs'
+  if (visits.some((visit) => normalizedText(`${visit.domain} ${visit.url ?? ''}`).includes('localhost'))) return 'browserTesting'
+  return 'related'
+}
+
+function buildContributions(sessions: AppSession[], websiteVisits: WebsiteVisit[]): ActivityContribution[] {
+  interface ContributionAccumulator {
+    durationSeconds: number
+    appNames: string[]
+    titles: string[]
+    domains: string[]
+    includesLocalhost: boolean
+    activeDaySet: Set<number>
+    strongestSession: StrongestSession | null
+  }
+
+  const grouped = new Map<ActivityBucket, ContributionAccumulator>()
+
+  for (const session of sessions) {
+    const relatedVisits = websiteVisits.filter((visit) => (
+      Math.max(session.startTime, visit.visitTime) < Math.min(sessionEnd(session), visitEnd(visit))
+    ))
+
+    const bucket = bucketForSession(session, relatedVisits)
+    const current = grouped.get(bucket) ?? {
+      durationSeconds: 0,
+      appNames: [],
+      titles: [],
+      domains: [],
+      includesLocalhost: false,
+      activeDaySet: new Set<number>(),
+      strongestSession: null,
+    }
+
+    current.durationSeconds += session.durationSeconds
+    current.activeDaySet.add(new Date(session.startTime).setHours(0, 0, 0, 0))
+    if (!current.strongestSession || session.durationSeconds > ((current.strongestSession.endMs - current.strongestSession.startMs) / 1000)) {
+      current.strongestSession = {
+        startMs: session.startTime,
+        endMs: sessionEnd(session),
+      }
+    }
+
+    if (!current.appNames.includes(session.appName)) current.appNames.push(session.appName)
+    if (session.windowTitle?.trim() && !current.titles.includes(session.windowTitle.trim())) {
+      current.titles.push(session.windowTitle.trim())
+    }
+
+    for (const visit of relatedVisits) {
+      if (!current.domains.includes(visit.domain)) current.domains.push(visit.domain)
+      if (visit.pageTitle?.trim() && !current.titles.includes(visit.pageTitle.trim())) {
+        current.titles.push(visit.pageTitle.trim())
+      }
+      if (normalizedText(`${visit.domain} ${visit.url ?? ''}`).includes('localhost')) {
+        current.includesLocalhost = true
+      }
+    }
+
+    grouped.set(bucket, current)
+  }
+
+  return [...grouped.entries()]
+    .map(([bucket, accumulator]) => ({
+      bucket,
+      durationSeconds: accumulator.durationSeconds,
+      appNames: accumulator.appNames,
+      titles: accumulator.titles,
+      domains: accumulator.domains,
+      includesLocalhost: accumulator.includesLocalhost,
+      activeDays: [...accumulator.activeDaySet].sort((left, right) => left - right).map((value) => new Date(value)),
+      strongestSession: accumulator.strongestSession,
+    }))
+    .sort((left, right) => {
+      if (left.durationSeconds === right.durationSeconds) {
+        return left.bucket.localeCompare(right.bucket)
+      }
+      return right.durationSeconds - left.durationSeconds
+    })
+}
+
+function entityLead(entity: string, range: ResolvedRange, durationSeconds: number): string {
+  return `You put in ${formatDuration(durationSeconds)} on ${entity} ${windowLeadLabel(range.label)}.`
+}
+
+function narrativeBullet(contribution: ActivityContribution, entity: string): string {
+  const duration = formatDuration(contribution.durationSeconds)
+  const apps = humanList(appDisplayNames(contribution.appNames), 2)
+  const days = contribution.activeDays.length > 0 ? daysList(contribution.activeDays) : null
+  const daysPhrase = days ? ` on ${days}` : ''
+  const features = featureContext(contribution.titles, entity)
+  const featurePhrase = features.length > 0 ? humanQuotedList(features, 2) : null
+  const strongestSessionPhrase = strongestSessionObservation(contribution.strongestSession)
+
+  switch (contribution.bucket) {
+    case 'coding': {
+      let line = `${duration} coding in ${apps}${daysPhrase}`
+      if (featurePhrase) {
+        line += `, mainly ${featurePhrase}.`
+      } else {
+        line += ` on ${entity}-related implementation.`
+      }
+      if (strongestSessionPhrase) line += ` ${strongestSessionPhrase}`
+      return line
+    }
+
+    case 'browserTesting': {
+      let line: string
+      if (contribution.includesLocalhost) {
+        line = `${duration} testing on ${localhostLabel(contribution.domains)} in ${apps}${daysPhrase}`
+        if (featurePhrase) {
+          line += `, around ${featurePhrase}.`
+        } else {
+          line += '.'
+        }
+        line += ' The back-and-forth pattern suggests active iteration.'
+      } else {
+        const reviewTargets = contribution.domains.filter((domain) => !domain.toLowerCase().includes('localhost'))
+        line = `${duration} in ${apps}${daysPhrase}`
+        if (reviewTargets.length > 0) {
+          line += ` reviewing ${humanList(reviewTargets, 2)}`
+        } else {
+          line += ' reviewing related pages'
+        }
+        if (featurePhrase) {
+          line += `, especially ${featurePhrase}.`
+        } else {
+          line += '.'
+        }
+      }
+      if (strongestSessionPhrase) line += ` ${strongestSessionPhrase}`
+      return line
+    }
+
+    case 'terminal': {
+      let line = `${duration} in ${humanList(terminalDisplayNames(contribution.appNames), 2)}${daysPhrase}, likely commands, logs, or build steps tied to ${entity}.`
+      if (strongestSessionPhrase) line += ` ${strongestSessionPhrase}`
+      return line
+    }
+
+    case 'aiCollaboration': {
+      let line = `${duration} in ${apps}${daysPhrase}`
+      if (featurePhrase) {
+        line += ` using AI to iterate on ${featurePhrase}.`
+      } else {
+        line += ` using AI to push the ${entity} work forward.`
+      }
+      if (strongestSessionPhrase) line += ` ${strongestSessionPhrase}`
+      return line
+    }
+
+    case 'docs': {
+      const looksLikeCommunication = contribution.appNames.some((appName) => {
+        const lower = appName.toLowerCase()
+        return lower.includes('outlook') || lower.includes('mail') || lower.includes('teams')
+      })
+      let line = `${duration} in ${apps}${daysPhrase}`
+      if (looksLikeCommunication) {
+        if (featurePhrase) {
+          line += `, around ${featurePhrase}. It looks like client comms or updates.`
+        } else {
+          line += `, which looks like client comms or updates for ${entity}.`
+        }
+      } else if (featurePhrase) {
+        line += ` across docs or spreadsheets like ${featurePhrase}.`
+      } else {
+        line += ` across docs, spreadsheets, or notes for ${entity}.`
+      }
+      if (strongestSessionPhrase) line += ` ${strongestSessionPhrase}`
+      return line
+    }
+
+    case 'related':
+    default: {
+      let line = `${duration} in ${apps}${daysPhrase} on adjacent ${entity} work.`
+      if (strongestSessionPhrase) line += ` ${strongestSessionPhrase}`
+      return line
+    }
+  }
+}
+
+function closingObservation(contributions: ActivityContribution[], activeDays: Date[], entity: string): string | null {
+  if (contributions.length === 0) return null
+
+  const hasCoding = contributions.some((contribution) => contribution.bucket === 'coding')
+  const hasTesting = contributions.some((contribution) => contribution.bucket === 'browserTesting' && contribution.includesLocalhost)
+  const hasTerminal = contributions.some((contribution) => contribution.bucket === 'terminal')
+  const hasAI = contributions.some((contribution) => contribution.bucket === 'aiCollaboration')
+  const hasReview = contributions.some((contribution) => contribution.bucket === 'browserTesting' && !contribution.includesLocalhost)
+  const hasDocs = contributions.some((contribution) => contribution.bucket === 'docs')
+
+  if (hasCoding && hasTesting && hasTerminal) {
+    return 'The editor to localhost to terminal loop points to active implementation and verification. Want me to pull out the sessions with the most switching?'
+  }
+  if (hasCoding && hasAI) {
+    return 'The coding and AI mix suggests you were iterating quickly rather than just reviewing. Want me to show which features drove the most back-and-forth?'
+  }
+  if (hasCoding && hasTesting) {
+    return 'The build and test pattern looks like forward progress on a live feature. Want me to zoom into the testing sessions?'
+  }
+  if (hasCoding && hasDocs) {
+    return 'This looks like implementation paired with docs or client comms rather than heads-down coding only. Want me to separate the build work from the coordination?'
+  }
+  if (hasTesting && hasTerminal && !hasCoding) {
+    return 'Mostly testing plus terminal work, which usually means debugging or validation rather than new code. Want me to pinpoint the roughest sessions?'
+  }
+  if (hasReview && !hasCoding && !hasTesting) {
+    return 'This reads more like review, research, or planning than active implementation. Want me to check what was open in those sessions?'
+  }
+  if (activeDays.length >= 3) {
+    return `The work was spread out, with the center of gravity around ${formatWeekday(activeDays[Math.floor(activeDays.length / 2)])}. Want me to zoom into that day specifically?`
+  }
+  return `Want me to drill into the exact files, pages, or sessions behind the ${entity} work?`
+}
+
+function buildEntityEvidence(
+  entity: string,
+  range: ResolvedRange,
+  question: string,
+  sessions: AppSession[],
+  visits: WebsiteVisit[],
+): EntityEvidence {
+  const appFilter = extractAppFilter(question)
+
+  const directSessions = sessions.filter((session) => (
+    matchesAppFilter(session, appFilter)
+    && (
+      textContainsEntity(session.windowTitle, entity)
+      || textContainsEntity(session.appName, entity)
+      || textContainsEntity(session.bundleId, entity)
+    )
+  ))
+
+  const directWebsiteVisits = visits.filter((visit) => (
+    matchesVisitAppFilter(visit, appFilter)
+    && (
+      textContainsEntity(visit.pageTitle, entity)
+      || textContainsEntity(visit.url, entity)
+      || textContainsEntity(visit.domain, entity)
+    )
+  ))
+
+  const directEvidence = buildDirectEvidence(entity, directSessions, directWebsiteVisits)
+  const contextWindows = buildContextWindows(directEvidence, range)
+  const contextualSessions = sessions
+    .filter((session) => matchesAppFilter(session, appFilter))
+    .map((session) => clipSessionToWindows(session, contextWindows))
+    .filter((session): session is AppSession => session !== null)
+  const contextualWebsiteVisits = visits
+    .filter((visit) => matchesVisitAppFilter(visit, appFilter))
+    .map((visit) => clipVisitToWindows(visit, contextWindows))
+    .filter((visit): visit is WebsiteVisit => visit !== null)
+
+  return {
+    entity,
+    directSessions,
+    directWebsiteVisits,
+    contextualSessions,
+    contextualWebsiteVisits,
+    directEvidence,
+    appFilter,
+    range,
+  }
+}
+
+function buildEntitySuggestions(entity: string): string[] {
+  return dedupeStrings([
+    `Break ${entity} down by app`,
+    `Which ${entity} titles matched?`,
+    `How much ${entity} time was in Outlook?`,
+    `How much ${entity} time was in Excel?`,
+  ], 4)
+}
+
+function isTitleMatchQuestion(normalized: string): boolean {
+  return normalized.includes('which titles')
+    || normalized.includes('what matched')
+    || /\bwhich\b.*\btitles?\b.*\bmatched\b/.test(normalized)
+    || /\bwhat\b.*\bmatched\b/.test(normalized)
+}
+
+function isAppBreakdownQuestion(normalized: string): boolean {
+  return normalized.includes('by app')
+    || /\bbreak\b.*\bdown\b.*\bapp\b/.test(normalized)
+    || /\bapp\b.*\bbreak\b.*\bdown\b/.test(normalized)
+}
+
+function buildEntityAppBreakdown(
+  entity: string,
+  range: ResolvedRange,
+  activitySessions: AppSession[],
+  websiteVisits: WebsiteVisit[],
+): string | null {
+  if (activitySessions.length === 0 && websiteVisits.length === 0) return null
+
+  interface AppBreakdown {
+    appName: string
+    bundleId: string | null
+    totalSeconds: number
+    titles: string[]
+    domains: string[]
+  }
+
+  const grouped = new Map<string, AppBreakdown>()
+
+  for (const session of activitySessions) {
+    const key = `${session.bundleId}::${session.appName}`
+    const current = grouped.get(key) ?? {
+      appName: session.appName,
+      bundleId: session.bundleId,
+      totalSeconds: 0,
+      titles: [],
+      domains: [],
+    }
+
+    current.totalSeconds += session.durationSeconds
+    if (session.windowTitle?.trim() && !current.titles.includes(session.windowTitle.trim())) {
+      current.titles.push(session.windowTitle.trim())
+    }
+    grouped.set(key, current)
+  }
+
+  for (const visit of websiteVisits) {
+    const match = [...grouped.values()].find((entry) => entry.bundleId === visit.browserBundleId)
+    if (!match) continue
+    if (!match.domains.includes(visit.domain)) {
+      match.domains.push(visit.domain)
+    }
+    if (visit.pageTitle?.trim() && !match.titles.includes(visit.pageTitle.trim())) {
+      match.titles.push(visit.pageTitle.trim())
+    }
+  }
+
+  const lines = [...grouped.values()]
+    .sort((left, right) => right.totalSeconds - left.totalSeconds)
+    .slice(0, 6)
+    .map((entry, index) => {
+      const evidenceParts: string[] = []
+      const features = featureContext(entry.titles, entity)
+      if (features.length > 0) {
+        evidenceParts.push(humanQuotedList(features, 2))
+      }
+      if (entry.domains.length > 0) {
+        evidenceParts.push(humanList(entry.domains, 2))
+      }
+      return `${index + 1}. ${entry.appName}: ${formatDuration(entry.totalSeconds)}${evidenceParts.length > 0 ? ` — ${evidenceParts.join('; ')}` : ''}`
+    })
+
+  if (lines.length === 0) return null
+
+  return [
+    `${entity} by app ${windowReferenceLabel(range.label)}:`,
+    ...lines,
+  ].join('\n')
+}
+
+function buildEntityAnswer(
+  evidence: EntityEvidence,
+  question: string,
+  sessionsInRange: AppSession[],
+  resolvedContext: TemporalContext,
+): RouterResult | null {
+  const normalized = question.toLowerCase()
+  const activitySessions = evidence.contextualSessions.filter(isMeaningfulSession)
+  const activitySeconds = activitySessions.reduce((sum, session) => sum + session.durationSeconds, 0)
+  const websiteSeconds = evidence.contextualWebsiteVisits.reduce((sum, visit) => sum + visit.durationSeconds, 0)
+  const totalSeconds = activitySeconds > 0 ? activitySeconds : websiteSeconds
+
+  const titleCoverageIsPartial = sessionsInRange.some((session) => (
+    (session.category === 'email' || session.category === 'productivity' || session.category === 'writing')
+    && !session.windowTitle
+  ))
+
+  if (totalSeconds <= 0) {
+    const answer = [
+      `I couldn't find title-level evidence for ${evidence.entity} ${windowReferenceLabel(evidence.range.label)}.`,
+      'Right now I can only attribute client work when the client name appears in a window title, email subject, workbook title, page title, or URL.',
+      titleCoverageIsPartial ? 'Native app attribution is still partial for older sessions that were recorded before window-title capture was added.' : null,
+    ].filter(Boolean).join(' ')
+    return {
+      answer,
+      resolvedContext,
+      suggestions: buildEntitySuggestions(evidence.entity),
+    }
+  }
+
+  if (isTitleMatchQuestion(normalized)) {
+    const examples = dedupeStrings(evidence.directEvidence.map((item) => item.label), 6)
+    const answer = examples.length > 0
+      ? `The strongest ${evidence.entity} matches ${windowReferenceLabel(evidence.range.label)} were ${humanQuotedList(examples, 6)}.`
+      : `I found ${formatDuration(totalSeconds)} linked to ${evidence.entity} ${windowReferenceLabel(evidence.range.label)}, but there weren't enough distinct titles to list cleanly.`
+
+    return {
+      answer,
+      resolvedContext,
+      suggestions: buildEntitySuggestions(evidence.entity),
+    }
+  }
+
+  if (isAppBreakdownQuestion(normalized)) {
+    const answer = buildEntityAppBreakdown(
+      evidence.entity,
+      evidence.range,
+      activitySessions,
+      evidence.contextualWebsiteVisits,
+    )
+    if (answer) {
+      return {
+        answer,
+        resolvedContext,
+        suggestions: buildEntitySuggestions(evidence.entity),
+      }
+    }
+  }
+
+  if (activitySessions.length === 0) {
+    const examples = dedupeStrings(
+      evidence.contextualWebsiteVisits.map((visit) => visit.pageTitle?.trim() || visit.domain),
+      4,
+    )
+    const answer = [
+      `I found about ${formatDuration(websiteSeconds)} of browser evidence linked to ${evidence.entity} ${windowReferenceLabel(evidence.range.label)}.`,
+      examples.length > 0 ? `Strongest page matches were ${humanQuotedList(examples, 4)}.` : null,
+      titleCoverageIsPartial ? 'Native app attribution is still partial for older sessions recorded before title capture was enabled.' : null,
+    ].filter(Boolean).join(' ')
+
+    return {
+      answer,
+      resolvedContext,
+      suggestions: buildEntitySuggestions(evidence.entity),
+    }
+  }
+
+  const contributions = buildContributions(activitySessions, evidence.contextualWebsiteVisits)
+  const activeDays = [...new Set(activitySessions.map((session) => new Date(session.startTime).setHours(0, 0, 0, 0)))]
+    .sort((left, right) => left - right)
+    .map((value) => new Date(value))
+
+  let lead = entityLead(evidence.entity, evidence.range, totalSeconds)
+  if (lead.endsWith('.')) lead = lead.slice(0, -1)
+  if (activeDays.length > 1) {
+    lead += `, spread across ${daysList(activeDays)}.`
+  } else if (activeDays.length === 1) {
+    lead += `, all on ${formatWeekday(activeDays[0])}.`
+  } else {
+    lead += '.'
+  }
+
+  const lines = [lead]
+  for (const [index, contribution] of contributions.slice(0, 4).entries()) {
+    lines.push(`${index + 1}. ${narrativeBullet(contribution, evidence.entity)}`)
+  }
+
+  if (contributions.length === 0 && evidence.directEvidence.length > 0) {
+    lines.push(`The strongest saved signal was "${evidence.directEvidence[0].label}".`)
+  }
+
+  const closing = closingObservation(contributions, activeDays, evidence.entity)
+  if (closing) lines.push(closing)
+  if (titleCoverageIsPartial) {
+    lines.push('Some older native app sessions still lack titles, so this should be treated as directional rather than exhaustive.')
+  }
+
+  return {
+    answer: lines.join('\n'),
+    resolvedContext,
+    suggestions: buildEntitySuggestions(evidence.entity),
+  }
 }
 
 function latestMeaningfulSession(sessions: AppSession[]): AppSession | null {
@@ -133,12 +1300,23 @@ function buildWorkThreadAnswer(
   if (apps.length === 0 && sites.length === 0 && sessions.length === 0) return null
 
   const evidence = buildEvidence(apps, sites, sessions)
-  const latest = resolvedPrefix === 'Resume'
+  const fallbackLatest = sortedSessions(sessions).at(-1) ?? null
+  const latest = (resolvedPrefix === 'Resume'
     ? latestFocusedSession(sessions) ?? latestMeaningfulSession(sessions)
-    : latestMeaningfulSession(sessions)
+    : latestMeaningfulSession(sessions))
+    ?? fallbackLatest
   const signals = formatSignalList(evidence.signals, 3)
   const focusMinutes = Math.round(evidence.focusedSeconds / 60)
   const taskLabel = evidence.task.label.toLowerCase()
+  const latestTitledSession = [...sortedSessions(sessions)]
+    .reverse()
+    .find((session) => session.windowTitle?.trim())
+  const latestTitle = latestTitledSession?.windowTitle?.trim()
+  const titledSessionCount = sessions.filter((session) => session.windowTitle?.trim()).length
+  const lowCoverage = evidence.totalSeconds < 5 * 60
+    || evidence.task.category === 'browsing'
+    || evidence.task.confidence < 0.45
+    || titledSessionCount <= 1
 
   if (!latest) {
     return `${resolvedPrefix} ${taskLabel}. The clearest signals were ${signals}.`
@@ -149,7 +1327,80 @@ function buildWorkThreadAnswer(
   const sessionLabel = latest.appName
   const focusText = focusMinutes > 0 ? `, with about ${formatDuration(evidence.focusedSeconds)} in focused apps` : ''
 
+  if (lowCoverage) {
+    const concreteLead = latestTitle
+      ? `The clearest concrete signal is ${latestTitledSession!.appName} on "${stripKnownAppSuffixes(latestTitle)}" around ${formatTime(latestTitledSession!.startTime)}.`
+      : `The clearest concrete signal is ${sessionLabel} from ${start} to ${end}.`
+    return [
+      'I only have light evidence for that period so far, so I would not over-interpret it.',
+      concreteLead,
+      `Beyond that, the strongest signals are ${signals}.`,
+    ].join(' ')
+  }
+
   return `${resolvedPrefix} ${taskLabel}. The latest meaningful thread was ${sessionLabel} from ${start} to ${end}${focusText}. Strongest signals: ${signals}.`
+}
+
+function buildGeneralAppBreakdown(
+  rangeLabel: string,
+  apps: AppUsageSummary[],
+  sites: WebsiteSummary[],
+): string | null {
+  if (apps.length === 0) return null
+
+  const browserDomains = dedupeStrings(sites.map((site) => site.domain), 3)
+  const browserTitles = dedupeStrings(
+    sites
+      .map((site) => site.topTitle?.trim() ?? '')
+      .filter(Boolean),
+    2,
+  )
+
+  const lines = apps.slice(0, 6).map((app, index) => {
+    const lower = app.appName.toLowerCase()
+    const detailParts: string[] = []
+    const isBrowserApp = lower.includes('safari')
+      || lower.includes('chrome')
+      || lower.includes('edge')
+      || lower.includes('firefox')
+      || lower.includes('arc')
+      || lower.includes('brave')
+
+    if (isBrowserApp && browserTitles.length > 0) {
+      detailParts.push(humanQuotedList(browserTitles, 2))
+    }
+    if (isBrowserApp && browserDomains.length > 0) {
+      detailParts.push(humanList(browserDomains, 2))
+    }
+
+    return `${index + 1}. ${app.appName}: ${formatDuration(app.totalSeconds)}${detailParts.length > 0 ? ` — ${detailParts.join('; ')}` : ''}`
+  })
+
+  return [
+    `By app ${windowReferenceLabel(rangeLabel)}:`,
+    ...lines,
+  ].join('\n')
+}
+
+function buildGeneralTitleAnswer(
+  rangeLabel: string,
+  sessions: AppSession[],
+  sites: WebsiteSummary[],
+): string | null {
+  const titles = dedupeStrings([
+    ...sessions
+      .map((session) => session.windowTitle?.trim() ?? '')
+      .filter(Boolean),
+    ...sites
+      .map((site) => site.topTitle?.trim() ?? '')
+      .filter(Boolean),
+  ], 6)
+
+  if (titles.length === 0) {
+    return `I don't have enough title-level evidence ${windowReferenceLabel(rangeLabel)} yet.`
+  }
+
+  return `The clearest titles ${windowReferenceLabel(rangeLabel)} were ${humanQuotedList(titles, 6)}.`
 }
 
 function buildTimeAllocationAnswer(apps: AppUsageSummary[], sites: WebsiteSummary[], sessions: AppSession[]): string | null {
@@ -236,41 +1487,39 @@ function buildTimelineSummary(apps: AppUsageSummary[], sites: WebsiteSummary[], 
 function resolveTargetDate(question: string, defaultDate: Date, previousContext: TemporalContext | null): Date {
   const normalized = question.toLowerCase()
   const reference = previousContext?.date ?? defaultDate
-  const calendarDate = new Date(reference.getFullYear(), reference.getMonth(), reference.getDate())
+  const explicitWeekday = explicitWeekdayReference(normalized)
+  const explicitWeekdayReferenceDate = isPriorWeekMention(normalized) && explicitWeekday && explicitWeekday.modifier !== 'last' && explicitWeekday.modifier !== 'next'
+    ? addDays(mondayFor(defaultDate), -7)
+    : reference
+
+  const resolvedExplicitWeekday = resolveExplicitWeekday(normalized, explicitWeekdayReferenceDate)
+  if (resolvedExplicitWeekday) {
+    if (!previousContext && !isPriorWeekMention(normalized) && explicitWeekday?.modifier == null) {
+      const todayStart = new Date(defaultDate.getFullYear(), defaultDate.getMonth(), defaultDate.getDate())
+      if (resolvedExplicitWeekday.getTime() > todayStart.getTime()) {
+        return addDays(resolvedExplicitWeekday, -7)
+      }
+    }
+    return resolvedExplicitWeekday
+  }
 
   if (normalized.includes('yesterday')) {
-    calendarDate.setDate(calendarDate.getDate() - 1)
-    return calendarDate
+    return addDays(new Date(defaultDate.getFullYear(), defaultDate.getMonth(), defaultDate.getDate()), -1)
   }
   if (normalized.includes('today')) return new Date(defaultDate.getFullYear(), defaultDate.getMonth(), defaultDate.getDate())
-
-  const weekdayMatch = normalized.match(/\b(last|this)?\s*(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/)
-  if (weekdayMatch) {
-    const weekdayMap: Record<string, number> = {
-      sunday: 0,
-      monday: 1,
-      tuesday: 2,
-      wednesday: 3,
-      thursday: 4,
-      friday: 5,
-      saturday: 6,
-    }
-    const modifier = weekdayMatch[1] ?? 'this'
-    const targetWeekday = weekdayMap[weekdayMatch[2]]
-    const result = new Date(calendarDate)
-    const currentWeekday = result.getDay()
-    let delta = targetWeekday - currentWeekday
-    if (modifier === 'last') {
-      if (delta >= 0) delta -= 7
-    } else if (modifier === 'this' && delta > 0) {
-      delta -= 7
-    }
-    result.setDate(result.getDate() + delta)
-    return result
-  }
+  if (normalized.includes('tomorrow')) return addDays(new Date(defaultDate.getFullYear(), defaultDate.getMonth(), defaultDate.getDate()), 1)
 
   if (FOLLOW_UP_PATTERNS.some((pattern) => normalized.includes(pattern)) && previousContext) {
+    const priorDate = previousContext.timeWindow?.start ?? previousContext.date
+    return new Date(priorDate.getFullYear(), priorDate.getMonth(), priorDate.getDate())
+  }
+
+  if (normalized.includes('that week') && previousContext) {
     return new Date(previousContext.date.getFullYear(), previousContext.date.getMonth(), previousContext.date.getDate())
+  }
+
+  if (isPriorWeekMention(normalized)) {
+    return addDays(mondayFor(defaultDate), -7)
   }
 
   return new Date(defaultDate.getFullYear(), defaultDate.getMonth(), defaultDate.getDate())
@@ -373,7 +1622,18 @@ function resolveTemporalContext(question: string, defaultDate: Date, previousCon
 }
 
 function isWeeklyQuestion(normalized: string): boolean {
-  return normalized.includes('this week') || normalized.includes('last week')
+  return normalized.includes('this week')
+    || normalized.includes('that week')
+    || normalized.includes('last week')
+    || normalized.includes('past week')
+}
+
+function resolveWeeklyRange(normalized: string, resolvedDate: Date): ResolvedRange {
+  const week = weekRangeContaining(resolvedDate)
+  if (normalized.includes('past week')) return { ...week, label: 'past week' }
+  if (normalized.includes('last week')) return { ...week, label: 'last week' }
+  if (normalized.includes('this week')) return { ...week, label: 'this week' }
+  return { ...week, label: 'that week' }
 }
 
 function isFocusedCategory(category: AppCategory): boolean {
@@ -450,7 +1710,7 @@ function exactMomentAnswer(window: { start: Date; end: Date }, sessions: AppSess
   if (isBrowser && topSite) {
     return `At ${formatTime(midpoint.getTime())}, you were on ${topSite.domain}${topSite.topTitle ? ` viewing "${topSite.topTitle}".` : '.'} Strongest signals: ${formatSignalList(evidence.signals, 3)}.`
   }
-  return `At ${formatTime(midpoint.getTime())}, you were in ${topSession.appName}. Strongest signals: ${formatSignalList(evidence.signals, 3)}.`
+  return `At ${formatTime(midpoint.getTime())}, you were in ${sessionDescriptor(topSession)}. Strongest signals: ${formatSignalList(evidence.signals, 3)}.`
 }
 
 function timeRangeAnswer(window: { start: Date; end: Date }, sessions: AppSession[], sites: WebsiteSummary[]): string | null {
@@ -463,7 +1723,7 @@ function timeRangeAnswer(window: { start: Date; end: Date }, sessions: AppSessio
   const topSessions = [...sessions]
     .sort((left, right) => right.durationSeconds - left.durationSeconds)
     .slice(0, 3)
-    .map((session) => `${session.appName} (${formatDuration(session.durationSeconds)})`)
+    .map((session) => `${sessionDescriptor(session)} (${formatDuration(session.durationSeconds)})`)
   return `Between ${formatTime(window.start.getTime())} and ${formatTime(window.end.getTime())}, the main thread was ${evidence.task.label.toLowerCase()}. Top sessions: ${topSessions.join(', ')}. Strongest signals: ${formatSignalList(evidence.signals, 3)}.`
 }
 
@@ -478,29 +1738,49 @@ export async function routeInsightsQuestion(
 
   const normalized = trimmed.toLowerCase()
   const resolvedContext = resolveTemporalContext(trimmed, defaultDate, previousContext)
+  const entity = extractEntity(trimmed)
+  if (isEntityQuestion(normalized, entity)) {
+    const range = resolveQuestionRange(
+      trimmed,
+      resolvedContext.date,
+      !hasTemporalCue(normalized),
+    )
+    const sessions = getSessionsForRange(db, range.startMs, range.endMs + 1)
+    const visits = getWebsiteVisitsForRange(db, range.startMs, range.endMs + 1)
+    const evidence = buildEntityEvidence(entity!, range, trimmed, sessions, visits)
+    const result = buildEntityAnswer(evidence, trimmed, sessions, resolvedContext)
+    if (result) return result
+  }
 
   if (isWeeklyQuestion(normalized)) {
-    const end = new Date(resolvedContext.date)
-    end.setHours(23, 59, 59, 999)
-    const start = new Date(end)
-    start.setDate(end.getDate() - 6)
-    start.setHours(0, 0, 0, 0)
-    const apps = getAppSummariesForRange(db, start.getTime(), end.getTime())
-    const sites = getWebsiteSummariesForRange(db, start.getTime(), end.getTime())
-    const sessions = getSessionsForRange(db, start.getTime(), end.getTime())
+    const weeklyRange = resolveWeeklyRange(normalized, resolvedContext.date)
+    const apps = getAppSummariesForRange(db, weeklyRange.startMs, weeklyRange.endMs + 1)
+    const sites = getWebsiteSummariesForRange(db, weeklyRange.startMs, weeklyRange.endMs + 1)
+    const sessions = getSessionsForRange(db, weeklyRange.startMs, weeklyRange.endMs + 1)
+    if (isAppBreakdownQuestion(normalized)) {
+      const answer = buildGeneralAppBreakdown(weeklyRange.label, apps, sites)
+      return answer ? { answer, resolvedContext } : null
+    }
+    if (isTitleMatchQuestion(normalized)) {
+      const answer = buildGeneralTitleAnswer(weeklyRange.label, sessions, sites)
+      return answer ? { answer, resolvedContext } : null
+    }
     if (normalized.includes('what distracted me') || normalized.includes('biggest distraction')) {
       const topNonFocusApp = apps.find((app) => !isFocusedCategory(app.category))
       const topNonFocusSite = sites[0]
+      const weekLabel = windowLeadLabel(weeklyRange.label)
       const answer = topNonFocusSite && (!topNonFocusApp || topNonFocusSite.totalSeconds > topNonFocusApp.totalSeconds)
-        ? `${topNonFocusSite.domain} was the clearest non-focus pull this week at ${formatDuration(topNonFocusSite.totalSeconds)}.`
+        ? `${topNonFocusSite.domain} was the clearest non-focus pull ${weekLabel} at ${formatDuration(topNonFocusSite.totalSeconds)}.`
         : topNonFocusApp
-          ? `${topNonFocusApp.appName} was the biggest non-focus pull this week at ${formatDuration(topNonFocusApp.totalSeconds)}.`
-          : "I don't see one dominant distraction sink this week."
+          ? `${topNonFocusApp.appName} was the biggest non-focus pull ${weekLabel} at ${formatDuration(topNonFocusApp.totalSeconds)}.`
+          : `I don't see one dominant distraction sink ${weekLabel}.`
       return { answer, resolvedContext }
     }
     if (
       normalized.includes('what was i working on')
+      || normalized.includes('what was i doing')
       || normalized.includes('what did i work on')
+      || normalized.includes('what did i do')
       || normalized.includes('where did my time go')
       || normalized.includes('what happened this week')
       || normalized.includes('summarize this week')
@@ -522,6 +1802,16 @@ export async function routeInsightsQuestion(
   const sites = getWebsiteSummariesForRange(db, fromMs, toMs)
   const sessions = getSessionsForRange(db, fromMs, toMs)
 
+  if (isAppBreakdownQuestion(normalized)) {
+    const answer = buildGeneralAppBreakdown('today', apps, sites)
+    return answer ? { answer, resolvedContext } : null
+  }
+
+  if (isTitleMatchQuestion(normalized)) {
+    const answer = buildGeneralTitleAnswer('today', sessions, sites)
+    return answer ? { answer, resolvedContext } : null
+  }
+
   if (normalized.includes('what distracted me') || normalized.includes('biggest distraction')) {
     const answer = buildDistractionAnswer(apps, sites, sessions)
     return answer ? { answer, resolvedContext } : null
@@ -529,7 +1819,9 @@ export async function routeInsightsQuestion(
 
   if (
     normalized.includes('what was i working on')
+    || normalized.includes('what was i doing')
     || normalized.includes('what did i work on')
+    || normalized.includes('what did i do')
     || normalized.includes('what should i resume')
   ) {
     const prefix = normalized.includes('what should i resume') ? 'Resume' : 'You were mostly working on'

--- a/src/main/services/ai.ts
+++ b/src/main/services/ai.ts
@@ -24,7 +24,13 @@ import { deriveWorkEvidenceSummary } from '../lib/workEvidence'
 import { getDb } from './database'
 import { getApiKey, getSettings, getSettingsAsync } from './settings'
 import { computeEnhancedFocusScore } from '../lib/focusScore'
-import type { AIProviderMode, AppCategorySuggestion, WorkContextBlock, WorkContextInsight } from '@shared/types'
+import type {
+  AIProviderMode,
+  AIReplyPayload,
+  AppCategorySuggestion,
+  WorkContextBlock,
+  WorkContextInsight,
+} from '@shared/types'
 import { fallbackNarrativeForBlock, userVisibleLabelForBlock } from './workBlocks'
 
 const GOOGLE_CLIENT_HEADER = 'daylens-windows/1.0.0'
@@ -55,6 +61,123 @@ class CLIProviderError extends Error {
 
 const CLI_TIMEOUT_MS = 180_000
 const conversationTemporalContext = new Map<number, TemporalContext | null>()
+
+function normalizeSuggestion(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function dedupeSuggestions(values: string[], limit = 4): string[] {
+  const unique = values
+    .map(normalizeSuggestion)
+    .filter(Boolean)
+    .filter((value, index, arr) => arr.indexOf(value) === index)
+  return unique.slice(0, limit)
+}
+
+function parseSuggestionBlock(raw: string): AIReplyPayload {
+  const match = raw.match(/```suggestions\s*([\s\S]*?)```/i)
+  if (!match) {
+    return { content: raw.trim(), suggestions: [] }
+  }
+
+  let suggestions: string[] = []
+  try {
+    const parsed = JSON.parse(match[1].trim()) as unknown
+    if (Array.isArray(parsed)) {
+      suggestions = dedupeSuggestions(
+        parsed.filter((value): value is string => typeof value === 'string'),
+      )
+    }
+  } catch {
+    suggestions = []
+  }
+
+  return {
+    content: raw.replace(match[0], '').trim(),
+    suggestions,
+  }
+}
+
+function fallbackSuggestionsForMessage(userMessage: string): string[] {
+  const normalized = userMessage.toLowerCase()
+
+  const quoted = userMessage.match(/["“]([^"”]+)["”]/)?.[1]
+  const acronym = userMessage.match(/\b[A-Z][A-Z0-9&._-]{1,}\b/)?.[0]
+  const entity = quoted || acronym
+  if (entity && (normalized.includes('how much time') || normalized.includes('how many hours') || normalized.includes('how long'))) {
+    return dedupeSuggestions([
+      `Break ${entity} down by app`,
+      `Which ${entity} titles matched?`,
+      `How much ${entity} time was in Outlook?`,
+    ], 3)
+  }
+
+  if (normalized.includes('what was i doing') || normalized.includes('what happened')) {
+    return dedupeSuggestions([
+      'Where did my time go?',
+      'What was I doing then?',
+      'What distracted me?',
+    ], 3)
+  }
+
+  return dedupeSuggestions([
+    'Where did my time go?',
+    'What distracted me?',
+    'What changed most?',
+  ], 3)
+}
+
+function noProviderReply(userMessage: string): AIReplyPayload {
+  const normalized = userMessage.toLowerCase()
+  const content = normalized.includes('what was i working on')
+    || normalized.includes('where did my time go')
+    || normalized.includes('what was i doing')
+    ? 'I can answer exact evidence-based questions from your local data right now, but deeper analysis still needs an AI provider configured in Settings. Try a narrower question like "What was I working on today?" or connect a provider for richer synthesis.'
+    : 'I can still answer exact evidence-based questions from local tracking, but this question needs an AI provider for a fuller answer. Connect Claude, Codex, OpenAI, Anthropic, or Gemini in Settings, or ask a narrower question tied to recorded activity.'
+
+  return {
+    content,
+    suggestions: dedupeSuggestions(fallbackSuggestionsForMessage(userMessage)),
+  }
+}
+
+async function maybeRewriteRoutedAnswer(
+  userMessage: string,
+  routedAnswer: string,
+  prior: ConversationMessage[],
+  suggestions: string[],
+): Promise<AIReplyPayload | null> {
+  try {
+    const providerConfigs = await resolveProviderConfigs()
+    const preferredConfig = providerConfigs[0]
+    const systemPrompt =
+      'You are Daylens, the assistant inside a local activity-tracking app.\n' +
+      'Rewrite grounded evidence into a user-facing answer that feels like a well-informed teammate, not a raw report.\n' +
+      'Rules:\n' +
+      '- Use only the facts explicitly present in the evidence summary\n' +
+      '- Do not add new claims, clients, durations, apps, or interpretations beyond that evidence\n' +
+      '- If the evidence says coverage is partial or insufficient, keep that limitation explicit\n' +
+      '- Keep the answer concise but natural and helpful\n' +
+      '- Never mention databases, routers, prompt rewriting, or internal implementation\n' +
+      `- If asked about the underlying model, say Daylens is currently using ${providerLabel(preferredConfig.provider)} with model ${preferredConfig.model}\n` +
+      '- End substantive answers with a fenced ```suggestions``` block containing a JSON array of 3 short follow-up questions answerable from recorded activity only'
+
+    const rewritePrompt =
+      `User question:\n${userMessage}\n\n` +
+      `Grounded evidence summary:\n${routedAnswer}\n\n` +
+      'Write the final user-facing answer using only that evidence.'
+
+    const { text } = await sendWithFallback(systemPrompt, prior, rewritePrompt)
+    const parsed = parseSuggestionBlock(text)
+    if (!parsed.content.trim()) return null
+    return {
+      content: parsed.content,
+      suggestions: dedupeSuggestions(parsed.suggestions.length > 0 ? parsed.suggestions : suggestions),
+    }
+  } catch {
+    return null
+  }
+}
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -258,7 +381,7 @@ async function sendWithAnthropic(
   const client = new Anthropic({ apiKey: config.apiKey ?? '' })
   const response = await client.messages.create({
     model: config.model,
-    max_tokens: 1024,
+    max_tokens: 4096,
     system: systemPrompt,
     messages: [
       ...prior.map((message) => ({ role: message.role, content: message.content })),
@@ -286,7 +409,7 @@ async function sendWithOpenAI(
       ...prior,
       { role: 'user', content: userMessage },
     ]),
-    max_output_tokens: 1024,
+    max_output_tokens: 4096,
     store: false,
   })
 
@@ -959,7 +1082,7 @@ export async function generateWorkBlockInsight(block: WorkContextBlock): Promise
   }
 }
 
-export async function sendMessage(userMessage: string): Promise<string> {
+export async function sendMessage(userMessage: string): Promise<AIReplyPayload> {
   const db = getDb()
   const conversationId = getOrCreateConversation(db)
   const previousContext = conversationTemporalContext.get(conversationId) ?? null
@@ -967,9 +1090,21 @@ export async function sendMessage(userMessage: string): Promise<string> {
   const routed = await routeInsightsQuestion(userMessage, new Date(), previousContext, db)
   if (routed) {
     appendConversationMessage(db, conversationId, 'user', userMessage)
-    appendConversationMessage(db, conversationId, 'assistant', routed.answer)
+    const prior = getConversationMessages(db, conversationId).slice(0, -1)
+    const fallbackReply = {
+      content: routed.answer,
+      suggestions: dedupeSuggestions(routed.suggestions ?? fallbackSuggestionsForMessage(userMessage)),
+    }
+    const rewrittenReply = await maybeRewriteRoutedAnswer(
+      userMessage,
+      routed.answer,
+      prior,
+      fallbackReply.suggestions,
+    )
+    const finalReply = rewrittenReply ?? fallbackReply
+    appendConversationMessage(db, conversationId, 'assistant', finalReply.content)
     conversationTemporalContext.set(conversationId, routed.resolvedContext)
-    return routed.answer
+    return finalReply
   }
 
   appendConversationMessage(db, conversationId, 'user', userMessage)
@@ -984,7 +1119,18 @@ export async function sendMessage(userMessage: string): Promise<string> {
   const persona = userName
     ? `You are Daylens, a personal productivity coach helping ${userName} understand their time.`
     : `You are Daylens, a personal productivity coach embedded in a local screen-time tracker.`
-  const providerConfigs = await resolveProviderConfigs()
+  let providerConfigs: ResolvedProviderConfig[]
+  try {
+    providerConfigs = await resolveProviderConfigs()
+  } catch {
+    const fallback = noProviderReply(userMessage)
+    appendConversationMessage(db, conversationId, 'assistant', fallback.content)
+    conversationTemporalContext.set(conversationId, {
+      date: new Date(),
+      timeWindow: null,
+    })
+    return fallback
+  }
   const preferredConfig = providerConfigs[0]
   const systemPrompt =
     persona + ' You have access to tracked local activity data and should answer as a careful analyst, not a hype machine.\n\n' +
@@ -999,20 +1145,27 @@ export async function sendMessage(userMessage: string): Promise<string> {
     '- Treat website timing as approximate browser evidence unless the question is only about websites\n' +
     '- If you include recommendations, clearly label them as suggestions\n' +
     '- Prefer short headings like "Tracked facts" and "Suggestions" when both are present\n' +
-    '- Keep responses concise and grounded\n\n' +
+    '- Match response length to the question. Simple factual questions can be answered in 1-3 sentences. Breakdown, analysis, or drill-down requests deserve full structured answers, without filler and without truncating useful insight\n' +
+    '- End substantive answers with a fenced ```suggestions``` block that contains a JSON array of 3 short follow-up questions\n' +
+    '- Suggestion questions must be answerable from recorded local activity only\n' +
+    '- Keep suggestion questions specific to the latest answer and do not repeat them in the main body\n\n' +
     (dayContext
       ? `Tracked local data context:\n${dayContext}`
       : 'No activity has been recorded yet today. If the user asks about stats, say tracking needs more time to collect evidence.') +
     (specificTimeContext ? `\n\nSpecific historical context:\n${specificTimeContext}` : '')
 
   const { text: assistantText } = await sendWithFallback(systemPrompt, prior, userMessage)
+  const parsed = parseSuggestionBlock(assistantText)
 
-  appendConversationMessage(db, conversationId, 'assistant', assistantText)
+  appendConversationMessage(db, conversationId, 'assistant', parsed.content)
   conversationTemporalContext.set(conversationId, {
     date: new Date(),
     timeWindow: null,
   })
-  return assistantText
+  return {
+    content: parsed.content,
+    suggestions: dedupeSuggestions(parsed.suggestions.length > 0 ? parsed.suggestions : fallbackSuggestionsForMessage(userMessage)),
+  }
 }
 
 export function getAIHistory(): { role: 'user' | 'assistant'; content: string }[] {

--- a/src/main/services/browser.ts
+++ b/src/main/services/browser.ts
@@ -66,6 +66,23 @@ interface ProcessedHistoryRow {
   durationSec: number
 }
 
+export interface LiveBrowserContext {
+  browserBundleId: string
+  url: string
+  pageTitle: string | null
+  capturedAt: number
+  source: 'active_tab'
+}
+
+interface InFlightBrowserVisit {
+  browserBundleId: string
+  domain: string
+  pageTitle: string | null
+  url: string
+  startTime: number
+  lastSeenAt: number
+}
+
 function macBrowsers(): BrowserEntry[] {
   const home = os.homedir()
   return [
@@ -301,6 +318,7 @@ function processFirefoxRows(rows: FirefoxHistoryRow[]): ProcessedHistoryRow[] {
 // ─── State ────────────────────────────────────────────────────────────────────
 
 let pollTimer: ReturnType<typeof setInterval> | null = null
+let liveBrowserVisit: InFlightBrowserVisit | null = null
 
 // Per-browser cursor: Map<bundleId, last processed visit_time_us as bigint>
 const browserCursors = new Map<string, bigint>()
@@ -328,10 +346,72 @@ export function stopBrowserTracking(): void {
     clearInterval(pollTimer)
     pollTimer = null
   }
+  flushLiveBrowserVisit()
 }
 
 export function getBrowserStatus() {
   return { ...browserStatus }
+}
+
+function flushLiveBrowserVisit(overrideEndTime?: number): void {
+  if (!liveBrowserVisit) return
+
+  const endTime = overrideEndTime ?? liveBrowserVisit.lastSeenAt
+  const durationSec = Math.max(1, Math.round((endTime - liveBrowserVisit.startTime) / 1000))
+  if (durationSec >= 5) {
+    try {
+      insertWebsiteVisit(getDb(), {
+        domain: liveBrowserVisit.domain,
+        pageTitle: liveBrowserVisit.pageTitle,
+        url: liveBrowserVisit.url,
+        visitTime: liveBrowserVisit.startTime,
+        visitTimeUs: BigInt(liveBrowserVisit.startTime) * 1000n,
+        durationSec,
+        browserBundleId: liveBrowserVisit.browserBundleId,
+        source: 'active_tab',
+      })
+      browserStatus.visitsToday += 1
+    } catch (err) {
+      console.warn('[browser] failed to write live browser visit:', err)
+    }
+  }
+
+  liveBrowserVisit = null
+}
+
+export function ingestLiveBrowserContext(context: LiveBrowserContext | null): void {
+  if (!context) {
+    flushLiveBrowserVisit()
+    return
+  }
+
+  const domain = extractDomain(context.url)
+  if (!domain) {
+    flushLiveBrowserVisit()
+    return
+  }
+
+  if (
+    liveBrowserVisit
+    && liveBrowserVisit.browserBundleId === context.browserBundleId
+    && liveBrowserVisit.url === context.url
+  ) {
+    liveBrowserVisit.lastSeenAt = context.capturedAt
+    if (!liveBrowserVisit.pageTitle && context.pageTitle) {
+      liveBrowserVisit.pageTitle = context.pageTitle
+    }
+    return
+  }
+
+  flushLiveBrowserVisit(context.capturedAt)
+  liveBrowserVisit = {
+    browserBundleId: context.browserBundleId,
+    domain,
+    pageTitle: context.pageTitle,
+    url: context.url,
+    startTime: context.capturedAt,
+    lastSeenAt: context.capturedAt,
+  }
 }
 
 // ─── Chromium poll ─────────────────────────────────────────────────────────────

--- a/src/main/services/browserActiveTab.ts
+++ b/src/main/services/browserActiveTab.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from 'node:child_process'
+
+export interface ActiveBrowserTabContext {
+  browserBundleId: string
+  url: string
+  pageTitle: string | null
+}
+
+function normalizeLine(value: string | undefined): string {
+  return (value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function isSupportedBrowser(bundleId: string, appName: string): boolean {
+  const combined = `${bundleId} ${appName}`.toLowerCase()
+  return combined.includes('safari')
+}
+
+function safariContext(): ActiveBrowserTabContext | null {
+  const script = [
+    'tell application "Safari"',
+    '  if it is running then',
+    '    try',
+    '      set pageTitle to name of current tab of front window',
+    '      set pageURL to URL of current tab of front window',
+    '      return pageTitle & linefeed & pageURL',
+    '    on error',
+    '      return ""',
+    '    end try',
+    '  end if',
+    'end tell',
+  ]
+
+  try {
+    const output = execFileSync('osascript', script.flatMap((line) => ['-e', line]), {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1_500,
+    }).trim()
+
+    if (!output) return null
+    const [rawTitle, rawUrl] = output.split(/\r?\n/, 2)
+    const url = normalizeLine(rawUrl)
+    if (!/^https?:\/\//i.test(url)) return null
+
+    return {
+      browserBundleId: 'com.apple.Safari',
+      pageTitle: normalizeLine(rawTitle) || null,
+      url,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function getActiveBrowserTabContext(bundleId: string, appName: string): ActiveBrowserTabContext | null {
+  if (process.platform !== 'darwin') return null
+  if (!isSupportedBrowser(bundleId, appName)) return null
+
+  const combined = `${bundleId} ${appName}`.toLowerCase()
+  if (combined.includes('safari')) {
+    return safariContext()
+  }
+
+  return null
+}

--- a/src/main/services/tracking.ts
+++ b/src/main/services/tracking.ts
@@ -5,6 +5,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { insertAppSession } from '../db/queries'
 import { getDb } from './database'
+import { ingestLiveBrowserContext } from './browser'
+import { getActiveBrowserTabContext } from './browserActiveTab'
 import type { AppCategory, LiveSession } from '@shared/types'
 import { isCategoryFocused } from '../lib/focusScore'
 
@@ -25,6 +27,7 @@ interface ActiveWinResult {
 interface InFlightSession {
   bundleId: string
   appName: string
+  windowTitle: string | null
   startTime: number
   category: AppCategory
 }
@@ -154,6 +157,14 @@ function deriveWindowIdentity(win: ActiveWinResult): { bundleId: string; appName
   const appName = win.application || exeName || uwpPackage || 'Unknown app'
   const bundleId = win.path || uwpPackage || appName
   return { bundleId, appName }
+}
+
+function normalizeWindowTitle(title: string | null | undefined): string {
+  return (title ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function shouldSplitOnTitleChange(category: AppCategory): boolean {
+  return category !== 'browsing' && category !== 'system'
 }
 
 // ─── OS noise filter ─────────────────────────────────────────────────────────
@@ -333,8 +344,30 @@ async function poll(): Promise<void> {
     // Skip OS infrastructure processes
     if (isOsNoise(bundleId, appName, win.path)) return
 
-    // App switched → flush the previous session
-    if (currentSession && currentSession.bundleId !== bundleId) {
+    const nextCategory = classifyApp(bundleId, appName)
+    let nextWindowTitle = normalizeWindowTitle(win.title)
+    const activeBrowserTab = getActiveBrowserTabContext(bundleId, appName)
+    if (activeBrowserTab) {
+      if (!nextWindowTitle && activeBrowserTab.pageTitle) {
+        nextWindowTitle = normalizeWindowTitle(activeBrowserTab.pageTitle)
+      }
+      ingestLiveBrowserContext({
+        browserBundleId: activeBrowserTab.browserBundleId,
+        url: activeBrowserTab.url,
+        pageTitle: activeBrowserTab.pageTitle,
+        capturedAt: Date.now(),
+        source: 'active_tab',
+      })
+    } else {
+      ingestLiveBrowserContext(null)
+    }
+    const titleChanged = currentSession
+      && currentSession.bundleId === bundleId
+      && shouldSplitOnTitleChange(nextCategory)
+      && normalizeWindowTitle(currentSession.windowTitle) !== nextWindowTitle
+
+    // App switched or the active document/message changed → flush the previous session
+    if (currentSession && (currentSession.bundleId !== bundleId || titleChanged)) {
       flushCurrent()
     }
 
@@ -343,9 +376,12 @@ async function poll(): Promise<void> {
       currentSession = {
         bundleId,
         appName,
+        windowTitle: nextWindowTitle || null,
         startTime: Date.now(),
-        category:  classifyApp(bundleId, appName),
+        category: nextCategory,
       }
+    } else if (!currentSession.windowTitle && nextWindowTitle) {
+      currentSession.windowTitle = nextWindowTitle
     }
   } catch (err) {
     // active-window can throw on permissions denial (macOS) or unsupported platform
@@ -375,6 +411,7 @@ function flushCurrent(overrideEndTime?: number): void {
       insertAppSession(getDb(), {
         bundleId:        currentSession.bundleId,
         appName:         currentSession.appName,
+        windowTitle:     currentSession.windowTitle,
         startTime:       currentSession.startTime,
         endTime,
         durationSeconds,

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -521,8 +521,13 @@ function buildBlockFromCandidate(
   const switchCount = countAppSwitches(candidate.sessions)
   const websites = getWebsiteSummariesForRange(db, candidate.sessions[0].startTime, candidate.sessions[candidate.sessions.length - 1].endTime ?? (candidate.sessions[candidate.sessions.length - 1].startTime + candidate.sessions[candidate.sessions.length - 1].durationSeconds * 1000)).slice(0, 5)
   const keyPagesByDomain = getTopPagesForDomains(db, candidate.sessions[0].startTime, candidate.sessions[candidate.sessions.length - 1].endTime ?? (candidate.sessions[candidate.sessions.length - 1].startTime + candidate.sessions[candidate.sessions.length - 1].durationSeconds * 1000), websites.map((site) => site.domain), 2)
-  const keyPages = websites.flatMap((site) => keyPagesByDomain[site.domain] ?? [])
-    .map((page) => page.title?.trim())
+  const nativeWindowTitles = candidate.sessions
+    .map((session) => session.windowTitle?.trim())
+    .filter((title): title is string => Boolean(title))
+  const keyPages = [
+    ...nativeWindowTitles,
+    ...websites.flatMap((site) => keyPagesByDomain[site.domain] ?? []).map((page) => page.title?.trim()),
+  ]
     .filter((title): title is string => Boolean(title))
     .filter((title, index, titles) => titles.indexOf(title) === index)
     .slice(0, 4)
@@ -661,6 +666,7 @@ function mergeLiveSession(sessions: AppSession[], liveSession?: LiveSession | nu
       id: -1,
       bundleId: liveSession.bundleId,
       appName: liveSession.appName,
+      windowTitle: liveSession.windowTitle ?? null,
       startTime: liveSession.startTime,
       endTime: liveEnd,
       durationSeconds: Math.max(1, Math.round((liveEnd - liveSession.startTime) / 1000)),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,6 +5,7 @@ import type {
   AppSettings,
   AppCategorySuggestion,
   AIProviderMode,
+  AIReplyPayload,
   BreakRecommendation,
   FocusStartPayload,
   HistoryDayPayload,
@@ -69,7 +70,7 @@ const api = {
       ipcRenderer.invoke(IPC.FOCUS.GET_BREAK_RECOMMENDATION),
   },
   ai: {
-    sendMessage: (message: string) => ipcRenderer.invoke(IPC.AI.SEND_MESSAGE, message),
+    sendMessage: (message: string): Promise<AIReplyPayload> => ipcRenderer.invoke(IPC.AI.SEND_MESSAGE, message),
     getHistory: () => ipcRenderer.invoke(IPC.AI.GET_HISTORY),
     clearHistory: () => ipcRenderer.invoke(IPC.AI.CLEAR_HISTORY),
     detectCliTools: () => ipcRenderer.invoke(IPC.AI.DETECT_CLI_TOOLS),

--- a/src/renderer/views/Insights.tsx
+++ b/src/renderer/views/Insights.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import type { AIProvider, AppSession, AppUsageSummary, AppSettings, FocusSession, WebsiteSummary, WeeklySummary } from '@shared/types'
+import type { AIProvider, AIReplyPayload, AppSession, AppUsageSummary, AppSettings, FocusSession, WebsiteSummary, WeeklySummary } from '@shared/types'
 import {
   buildCategoryTotalsFromSummaries,
   calculateFocusTotals,
@@ -379,6 +379,7 @@ function buildWeeklyTrend(
 export default function Insights() {
   const navigate = useNavigate()
   const [messages, setMessages] = useState<Message[]>([])
+  const [suggestions, setSuggestions] = useState<string[]>([])
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
   const [activeTab, setActiveTab] = useState<'overview' | 'chat'>('overview')
@@ -417,10 +418,14 @@ export default function Insights() {
         setTodaySessions(sessionData as AppSession[])
         setSettings(currentSettings as AppSettings)
         setWeeklySummary((weekly as WeeklySummary | null) ?? null)
+        if ((history as Message[]).length === 0) {
+          setSuggestions([])
+        }
       } catch (err) {
         if (cancelled) return
         setMessages([{ role: 'assistant', content: 'Error loading insights: ' + String(err) }])
         setHasApiKey(false)
+        setSuggestions([])
       }
     }
 
@@ -435,21 +440,24 @@ export default function Insights() {
   useEffect(() => {
     if (activeTab !== 'chat') return
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages, activeTab, loading])
+  }, [messages, suggestions, activeTab, loading])
 
   async function handleSend(text?: string) {
     const message = (text ?? input).trim()
-    if (!message || loading || !hasApiKey) return
+    if (!message || loading) return
     track('insight_generated', { message_length: message.length })
     setInput('')
     setActiveTab('chat')
+    setSuggestions([])
     setMessages((prev) => [...prev, { role: 'user', content: message }])
     setLoading(true)
     try {
-      const reply = (await ipc.ai.sendMessage(message)) as string
-      setMessages((prev) => [...prev, { role: 'assistant', content: reply }])
+      const reply = (await ipc.ai.sendMessage(message)) as AIReplyPayload
+      setMessages((prev) => [...prev, { role: 'assistant', content: reply.content }])
+      setSuggestions(reply.suggestions ?? [])
     } catch (err) {
       setMessages((prev) => [...prev, { role: 'assistant', content: 'Error: ' + String(err) }])
+      setSuggestions([])
     } finally {
       setLoading(false)
     }
@@ -479,8 +487,7 @@ export default function Insights() {
   const todayLabel = today.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
 
   // ── Render ────────────────────────────────────────────────────────────────
-  const isCliProvider = settings.aiProvider === 'claude-cli' || settings.aiProvider === 'codex-cli'
-  const showChatInput = hasApiKey === true || isCliProvider
+  const showChatInput = true
 
   const peakInsight = algorithmicInsights.find((i) => i.key === 'peak-hours')
   const peakHourText = peakInsight ? peakInsight.headline : null
@@ -496,8 +503,6 @@ export default function Insights() {
   const maxSparkVal = Math.max(...weeklyTrend.map((day) => day.focusSeconds), 1)
 
   const focusQuality = focusPct >= 70 ? 'Peak Velocity' : focusPct >= 40 ? 'Building Momentum' : 'Getting Started'
-  const providerMeta = AI_PROVIDER_META[settings.aiProvider]
-
   const firstInsight = algorithmicInsights[0]
   const lastAssistantMessage = [...messages].reverse().find((msg) => msg.role === 'assistant')
 
@@ -894,7 +899,10 @@ export default function Insights() {
               )}
               {messages.length > 0 && (
                 <button
-                  onClick={() => void ipc.ai.clearHistory().then(() => setMessages([]))}
+                  onClick={() => void ipc.ai.clearHistory().then(() => {
+                    setMessages([])
+                    setSuggestions([])
+                  })}
                   style={{
                     fontSize: 11, fontWeight: 700, background: 'none', border: 'none',
                     cursor: 'pointer', color: 'var(--color-text-secondary)',
@@ -909,42 +917,6 @@ export default function Insights() {
               )}
             </div>
 
-            {/* No API key state */}
-            {!showChatInput && (
-              <div style={{
-                display: 'flex', flexDirection: 'column', alignItems: 'center',
-                gap: 14, padding: '40px 0', textAlign: 'center',
-              }}>
-                <div style={{
-                  width: 44, height: 44, borderRadius: 12,
-                  background: 'var(--color-accent-dim)',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  color: 'var(--color-primary)',
-                }}>
-                  <IconSparkle />
-                </div>
-                <div>
-                  <p style={{ fontSize: 15, fontWeight: 600, color: 'var(--color-text-primary)', margin: '0 0 6px' }}>
-                    Ask about your day
-                  </p>
-                  <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', maxWidth: 260, margin: '0 auto' }}>
-                    Add your {providerMeta.label} API key to ask questions about your productivity.
-                  </p>
-                </div>
-                <Link
-                  to="/settings"
-                  style={{
-                    padding: '9px 20px', borderRadius: 8,
-                    background: 'var(--gradient-primary)',
-                    color: 'var(--color-primary-contrast)', fontSize: 13, fontWeight: 700, textDecoration: 'none',
-                  }}
-                >
-                  Add API key →
-                </Link>
-              </div>
-            )}
-
-            {/* Chat with API key or CLI */}
             {showChatInput && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
                 {/* Empty state */}
@@ -1008,40 +980,6 @@ export default function Insights() {
                           borderBottom: i < messages.length - 1 ? '1px solid var(--color-border-ghost)' : 'none',
                         }}>
                           <MarkdownMessage content={msg.content} />
-                          {/* Follow-up chips after last assistant message */}
-                          {i === messages.length - 1 && !loading && (
-                            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 12 }}>
-                              {[
-                                'What changed most?',
-                                'Where did my time go?',
-                                ...(/\b\d{1,2}(:\d{2})?\s*(am|pm)\b|\b(morning|afternoon|evening)\b/i.test(msg.content)
-                                  ? ['What was I doing then?'] : []),
-                              ].map((chip) => (
-                                <button
-                                  key={chip}
-                                  onClick={() => void handleSend(chip)}
-                                  style={{
-                                    padding: '5px 12px', borderRadius: 999, fontSize: 12,
-                                    border: '1px solid var(--color-border-ghost)',
-                                    background: 'transparent',
-                                    color: 'var(--color-text-secondary)',
-                                    cursor: 'pointer', fontFamily: 'inherit',
-                                    transition: 'border-color 120ms, color 120ms',
-                                  }}
-                                  onMouseEnter={(e) => {
-                                    e.currentTarget.style.borderColor = 'var(--color-primary)'
-                                    e.currentTarget.style.color = 'var(--color-primary)'
-                                  }}
-                                  onMouseLeave={(e) => {
-                                    e.currentTarget.style.borderColor = 'var(--color-border-ghost)'
-                                    e.currentTarget.style.color = 'var(--color-text-secondary)'
-                                  }}
-                                >
-                                  {chip}
-                                </button>
-                              ))}
-                            </div>
-                          )}
                         </div>
                       </div>
                     )
@@ -1068,6 +1006,35 @@ export default function Insights() {
                           />
                         ))}
                       </div>
+                    </div>
+                  )}
+
+                  {!loading && suggestions.length > 0 && (
+                    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', paddingTop: 4 }}>
+                      {suggestions.map((chip) => (
+                        <button
+                          key={chip}
+                          onClick={() => void handleSend(chip)}
+                          style={{
+                            padding: '5px 12px', borderRadius: 999, fontSize: 12,
+                            border: '1px solid var(--color-border-ghost)',
+                            background: 'transparent',
+                            color: 'var(--color-text-secondary)',
+                            cursor: 'pointer', fontFamily: 'inherit',
+                            transition: 'border-color 120ms, color 120ms',
+                          }}
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.borderColor = 'var(--color-primary)'
+                            e.currentTarget.style.color = 'var(--color-primary)'
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.borderColor = 'var(--color-border-ghost)'
+                            e.currentTarget.style.color = 'var(--color-text-secondary)'
+                          }}
+                        >
+                          {chip}
+                        </button>
+                      ))}
                     </div>
                   )}
                   <div ref={bottomRef} />
@@ -1133,7 +1100,7 @@ export default function Insights() {
                   ? 'Exact answers use local data. Analysis uses your OpenAI subscription.'
                   : hasApiKey
                     ? `Exact answers use local data. Analysis uses your ${AI_PROVIDER_META[settings.aiProvider as AIProvider].label} key.`
-                    : 'Exact answers use local data. Connect AI in Settings for deeper analysis.'}
+                    : 'Exact answers use local data. Connect AI in Settings for richer analysis and follow-up.'}
             </p>
           </div>
         </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,6 +6,7 @@ export interface AppSession {
   id: number
   bundleId: string          // exe name on Windows, bundle ID on macOS
   appName: string
+  windowTitle?: string | null
   startTime: number         // Unix ms
   endTime: number | null
   durationSeconds: number
@@ -108,6 +109,11 @@ export interface AIMessage {
   timestamp: number
 }
 
+export interface AIReplyPayload {
+  content: string
+  suggestions: string[]
+}
+
 export interface WebsiteSummary {
   domain: string
   totalSeconds: number
@@ -200,6 +206,7 @@ export interface AppSettings {
 export interface LiveSession {
   bundleId: string
   appName: string
+  windowTitle?: string | null
   startTime: number   // Unix ms
   category: AppCategory
 }

--- a/tsconfig.benchmark.json
+++ b/tsconfig.benchmark.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": ".tmp-benchmark",
+    "rootDir": ".",
+    "noEmit": false,
+    "isolatedModules": false,
+    "verbatimModuleSyntax": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": [
+    "scripts/benchmark-ai-workspace.ts",
+    "src/main/db/queries.ts",
+    "src/main/db/schema.ts",
+    "src/main/lib/focusScore.ts",
+    "src/main/lib/insightsQueryRouter.ts",
+    "src/main/lib/localDate.ts",
+    "src/main/lib/workEvidence.ts",
+    "src/shared/types.ts"
+  ]
+}

--- a/tsconfig.benchmark.json
+++ b/tsconfig.benchmark.json
@@ -13,6 +13,7 @@
   },
   "include": [
     "scripts/benchmark-ai-workspace.ts",
+    "scripts/benchmark-ai-workspace-extended.ts",
     "src/main/db/queries.ts",
     "src/main/db/schema.ts",
     "src/main/lib/focusScore.ts",


### PR DESCRIPTION
## What changed
- added an AI workspace benchmark harness plus QA/release docs so benchmark prompts can be run against grounded seeded evidence
- kept AI Workspace usable for exact local evidence questions even without a configured provider
- added live Safari active-tab capture and persistence into `website_visits` so browser title/URL evidence can actually feed attribution
- tightened routed answers so app-breakdown/title follow-ups work and thin-data responses stay explicit instead of bluffing

## Why it changed
The benchmark in `docs/BENCHMARK.md` is whether Daylens can answer client-level questions from recorded evidence. The app was falling short because browser/title evidence was too sparse and the workspace could sound more certain than the data justified.

## Impact
- benchmark prompts are now testable locally
- browser evidence has a real path into the local DB on macOS Safari
- AI workspace responses are more trustworthy under sparse evidence and more useful when no provider is configured

## Validation
- `npm run typecheck`
- `npm run build:all`
- `npm run benchmark:ai-workspace`
- real local DB smoke check for `What was I doing today?`, `Which titles matched today?`, `Break today down by app.`, and `How much time was in Safari today?`
