### PR TITLE
Harden focus event capture contract

### DIFF
--- a/docs/adr/001-focus-events-contract.md
+++ b/docs/adr/001-focus-events-contract.md
@@ -1,0 +1,5 @@
+# 001 — Treat focus_events as a capture contract
+Date: 2026-05-27
+Status: accepted
+
+`focus_events` is the raw replay log for future session and block projections, so helper output must be validated against a small explicit event contract before persistence instead of accepting arbitrary strings. We will keep the current v1 behavior, including the never-guess rule for browser failures, but make the TypeScript sink reject unknown event types, sources, confidence values, schema versions, and `confidence=unknown` rows that carry URL or page-title content; fresh v27 tables mirror those checks where SQLite can express them. We rejected leaving the contract in comments because projection code would have to rediscover producer semantics, and we rejected a broad repair migration now because existing databases may already have v27; runtime validation gives the contract immediately without weakening raw capture.

--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -1595,17 +1595,40 @@ const migrations: Migration[] = [
           id            INTEGER PRIMARY KEY AUTOINCREMENT,
           ts_ms         INTEGER NOT NULL,
           mono_ns       INTEGER NOT NULL,
-          event_type    TEXT    NOT NULL,
+          event_type    TEXT    NOT NULL CHECK(event_type IN (
+            'app_activated',
+            'app_deactivated',
+            'space_changed',
+            'sleep',
+            'wake',
+            'lock',
+            'unlock',
+            'tab_changed',
+            'tab_sampled'
+          )),
           app_bundle_id TEXT,
           app_name      TEXT,
           pid           INTEGER,
           window_title  TEXT,
           url           TEXT,
           page_title    TEXT,
-          source        TEXT    NOT NULL,
-          confidence    TEXT    NOT NULL,
+          source        TEXT    NOT NULL CHECK(source IN ('nsworkspace_event', 'apple_events_tab')),
+          confidence    TEXT    NOT NULL CHECK(confidence IN ('observed', 'unknown')),
           platform      TEXT    NOT NULL DEFAULT 'darwin',
-          schema_ver    INTEGER NOT NULL DEFAULT 1
+          schema_ver    INTEGER NOT NULL DEFAULT 1 CHECK(schema_ver = 1),
+          CHECK(confidence <> 'unknown' OR (url IS NULL AND page_title IS NULL)),
+          CHECK(source <> 'nsworkspace_event' OR (url IS NULL AND page_title IS NULL)),
+          CHECK(source <> 'apple_events_tab' OR confidence <> 'observed' OR url IS NOT NULL),
+          CHECK(source <> 'apple_events_tab' OR event_type IN ('tab_changed', 'tab_sampled')),
+          CHECK(source <> 'nsworkspace_event' OR event_type IN (
+            'app_activated',
+            'app_deactivated',
+            'space_changed',
+            'sleep',
+            'wake',
+            'lock',
+            'unlock'
+          ))
         );
         CREATE INDEX IF NOT EXISTS idx_focus_events_ts ON focus_events(ts_ms);
         CREATE INDEX IF NOT EXISTS idx_focus_events_type ON focus_events(event_type);

--- a/src/main/services/focusCapture.ts
+++ b/src/main/services/focusCapture.ts
@@ -7,19 +7,51 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { app } from 'electron'
 import { getDb } from './database'
+const FOCUS_EVENT_SCHEMA_VERSION = 1
+const FOCUS_EVENT_TYPES = [
+  'app_activated',
+  'app_deactivated',
+  'space_changed',
+  'sleep',
+  'wake',
+  'lock',
+  'unlock',
+  'tab_changed',
+  'tab_sampled',
+] as const
+const FOCUS_EVENT_SOURCES = ['nsworkspace_event', 'apple_events_tab'] as const
+const FOCUS_EVENT_CONFIDENCES = ['observed', 'unknown'] as const
+
+type FocusEventType = typeof FOCUS_EVENT_TYPES[number]
+type FocusEventSource = typeof FOCUS_EVENT_SOURCES[number]
+type FocusEventConfidence = typeof FOCUS_EVENT_CONFIDENCES[number]
+
+const FOCUS_EVENT_TYPE_SET = new Set<string>(FOCUS_EVENT_TYPES)
+const FOCUS_EVENT_SOURCE_SET = new Set<string>(FOCUS_EVENT_SOURCES)
+const FOCUS_EVENT_CONFIDENCE_SET = new Set<string>(FOCUS_EVENT_CONFIDENCES)
+const WORKSPACE_EVENT_TYPES = new Set<FocusEventType>([
+  'app_activated',
+  'app_deactivated',
+  'space_changed',
+  'sleep',
+  'wake',
+  'lock',
+  'unlock',
+])
+const TAB_EVENT_TYPES = new Set<FocusEventType>(['tab_changed', 'tab_sampled'])
 
 interface HelperEvent {
   ts_ms: number
   mono_ns: number
-  event_type: string
+  event_type: FocusEventType
   app_bundle_id?: string | null
   app_name?: string | null
   pid?: number | null
   window_title?: string | null
   url?: string | null
   page_title?: string | null
-  source: string
-  confidence: string
+  source: FocusEventSource
+  confidence: FocusEventConfidence
   platform?: string | null
   schema_ver?: number | null
 }
@@ -38,6 +70,66 @@ function helperPath(): string {
   return app.isPackaged
     ? path.join(process.resourcesPath, 'build', 'capture-helper')
     : path.join(__dirname, '..', '..', 'build', 'capture-helper')
+}
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isNullableString(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === 'string'
+}
+
+function isNullableNumber(value: unknown): value is number | null | undefined {
+  return value === undefined || value === null || (typeof value === 'number' && Number.isFinite(value))
+}
+
+function normalizeHelperEvent(raw: unknown): HelperEvent | null {
+  if (!isObject(raw)) return null
+  const eventType = raw.event_type
+  const source = raw.source
+  const confidence = raw.confidence
+  const schemaVersion = raw.schema_ver ?? FOCUS_EVENT_SCHEMA_VERSION
+  if (typeof raw.ts_ms !== 'number' || !Number.isFinite(raw.ts_ms)) return null
+  if (typeof raw.mono_ns !== 'number' || !Number.isFinite(raw.mono_ns)) return null
+  if (typeof eventType !== 'string' || !FOCUS_EVENT_TYPE_SET.has(eventType)) return null
+  if (typeof source !== 'string' || !FOCUS_EVENT_SOURCE_SET.has(source)) return null
+  if (typeof confidence !== 'string' || !FOCUS_EVENT_CONFIDENCE_SET.has(confidence)) return null
+  if (schemaVersion !== FOCUS_EVENT_SCHEMA_VERSION) return null
+  if (!isNullableString(raw.app_bundle_id)) return null
+  if (!isNullableString(raw.app_name)) return null
+  if (!isNullableNumber(raw.pid)) return null
+  if (!isNullableString(raw.window_title)) return null
+  if (!isNullableString(raw.url)) return null
+  if (!isNullableString(raw.page_title)) return null
+  if (!isNullableString(raw.platform)) return null
+
+  const typedEventType = eventType as FocusEventType
+  const typedSource = source as FocusEventSource
+  const typedConfidence = confidence as FocusEventConfidence
+  const url = raw.url ?? null
+  const pageTitle = raw.page_title ?? null
+
+  if (typedSource === 'nsworkspace_event' && !WORKSPACE_EVENT_TYPES.has(typedEventType)) return null
+  if (typedSource === 'apple_events_tab' && !TAB_EVENT_TYPES.has(typedEventType)) return null
+  if (typedConfidence === 'unknown' && (url !== null || pageTitle !== null)) return null
+  if (typedSource === 'apple_events_tab' && typedConfidence === 'observed' && !url) return null
+  if (typedSource === 'nsworkspace_event' && (url !== null || pageTitle !== null)) return null
+
+  return {
+    ts_ms: raw.ts_ms,
+    mono_ns: raw.mono_ns,
+    event_type: typedEventType,
+    app_bundle_id: raw.app_bundle_id ?? null,
+    app_name: raw.app_name ?? null,
+    pid: raw.pid ?? null,
+    window_title: raw.window_title ?? null,
+    url,
+    page_title: pageTitle,
+    source: typedSource,
+    confidence: typedConfidence,
+    platform: raw.platform ?? 'darwin',
+    schema_ver: FOCUS_EVENT_SCHEMA_VERSION,
+  }
 }
 
 function insertEvent(ev: HelperEvent): void {
@@ -66,13 +158,14 @@ function insertEvent(ev: HelperEvent): void {
 function handleLine(line: string): void {
   const trimmed = line.trim()
   if (!trimmed) return
-  let ev: HelperEvent
+  let parsed: unknown
   try {
-    ev = JSON.parse(trimmed) as HelperEvent
+    parsed = JSON.parse(trimmed)
   } catch {
     return
   }
-  if (!ev.event_type || !ev.source || !ev.confidence) return
+  const ev = normalizeHelperEvent(parsed)
+  if (!ev) return
   try {
     insertEvent(ev)
   } catch (err) {


### PR DESCRIPTION
## Summary
- Add an ADR documenting `focus_events` as a raw capture contract for future projections.
- Validate helper NDJSON before persistence with explicit v1 event/source/confidence/schema rules.
- Mirror those constraints in fresh v27 `focus_events` table creation where SQLite can express them.

## Validation
- `npm run typecheck`
- `node --loader ./tests/support/ts-loader.mjs --test ./tests/databaseBootstrap.test.ts`

Co-Authored-By: Oz <oz-agent@warp.dev>

_Conversation: https://app.warp.dev/conversation/063ea5da-bbce-459b-b58d-d99ef1fde57d_
_Run: https://oz.warp.dev/runs/019e6b42-4f01-7aba-862c-dd85903136ba_
_This PR was generated with [Oz](https://warp.dev/oz)._
