### PR TITLE
fix(linux): correct .deb package identity and chrome-sandbox permissions

### DIFF
--- a/build/linux/after-install.sh
+++ b/build/linux/after-install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Custom Debian post-install script for Daylens.
+#
+# Setting deb.afterInstall in electron-builder REPLACES the default postinst, so this
+# script reproduces the default behaviour (PATH symlink + desktop/mime refresh) and
+# then hardens the Chromium sandbox.
+#
+# Fixes GitHub issue #17: the app aborts at launch with
+#   "The SUID sandbox helper binary was found, but is not configured correctly ...
+#    /opt/Daylens/chrome-sandbox is owned by root and has mode 4755"
+# unless chrome-sandbox is root-owned with the setuid bit.
+
+set -e
+
+INSTALL_DIR='/opt/Daylens'
+EXECUTABLE='daylens'
+
+# Link the executable onto the PATH (default electron-builder behaviour).
+ln -sf "${INSTALL_DIR}/${EXECUTABLE}" "/usr/bin/${EXECUTABLE}"
+
+# Refresh MIME / desktop databases so the App Center identifies the package correctly.
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime || true
+fi
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications || true
+fi
+
+# SUID chrome-sandbox for Electron. Chromium refuses to start without sandboxing
+# unless this helper is owned by root and carries mode 4755.
+sandbox="${INSTALL_DIR}/chrome-sandbox"
+if [[ -f "$sandbox" ]]; then
+    chown root:root "$sandbox" || true
+    chmod 4755 "$sandbox" || true
+fi
+
+exit 0

--- a/build/linux/after-remove.sh
+++ b/build/linux/after-remove.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Custom Debian post-remove script for Daylens.
+#
+# Mirrors electron-builder's default after-remove: drop the PATH symlink and refresh
+# the desktop database on uninstall.
+
+set -e
+
+EXECUTABLE='daylens'
+
+if [ -L "/usr/bin/${EXECUTABLE}" ]; then
+    rm -f "/usr/bin/${EXECUTABLE}"
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications &>/dev/null || true
+fi
+
+exit 0

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -112,9 +112,17 @@ module.exports = {
   appx,
   linux,
   deb: {
+    // Force the Debian Package field to "daylens". Without this electron-builder
+    // derives it from package.json "name" (currently "daylens-windows"), which is
+    // why the App Center listed the package as daylens-windows (issue #18).
+    packageName: 'daylens',
     depends: ['libgtk-3-0', 'libnotify4', 'libnss3', 'libxss1', 'libxtst6', 'xdg-utils', 'libatspi2.0-0', 'libuuid1', 'libsecret-1-0'],
+    // Guarantee the Chromium SUID sandbox is root-owned with mode 4755 (issue #17).
+    afterInstall: 'build/linux/after-install.sh',
+    afterRemove: 'build/linux/after-remove.sh',
   },
   rpm: {
+    packageName: 'daylens',
     depends: ['gtk3', 'libnotify', 'nss', 'libXScrnSaver', '(libXtst or libXtst6)', 'xdg-utils', 'at-spi2-core', '(libuuid or libuuid1)', 'libsecret'],
   },
   nsis: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "daylens-windows",
+  "name": "daylens",
   "version": "1.0.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "daylens-windows",
+      "name": "daylens",
       "version": "1.0.40",
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "daylens-windows",
+  "name": "daylens",
   "productName": "Daylens",
   "version": "1.0.40",
   "description": "Cross-platform activity tracker that turns your laptop history into a searchable, AI-ready work timeline.",


### PR DESCRIPTION
Fixes #17 and #18 — both Linux `.deb` packaging bugs.

## #18 — package shown as `daylens-windows` in the App Center
The Debian `Package` field is derived from `package.json` `name`, which had been set to `daylens-windows`. That string propagated into the `.deb` metadata, so the App Center listed the Linux package as `daylens-windows`.

- Renamed `name` to `daylens` (and the two mirrored fields in `package-lock.json`).
- Pinned `deb.packageName` and `rpm.packageName` to `daylens` so the package identity is correct regardless of the npm package name.

## #17 — app aborts on launch (`chrome-sandbox` not setuid-root)
Chromium refuses to start unless `/opt/Daylens/chrome-sandbox` is owned by root with mode `4755`. The config had no Debian maintainer scripts, so this was never set.

- Added `deb.afterInstall` (`build/linux/after-install.sh`) and `deb.afterRemove` (`build/linux/after-remove.sh`).
- `after-install.sh` reproduces electron-builder's default postinst (PATH symlink, desktop/mime refresh) and additionally runs `chown root:root` + `chmod 4755` on the sandbox helper. This removes the need for the manual `sudo chmod 4755` workaround in the issue.

## Notes
- `electron-builder.config.js` already had a full `linux` target (AppImage/deb/rpm/tar.gz) and `deb.depends`; this PR only adds the package-name pinning and maintainer scripts.
- Config loads cleanly under electron-builder 25.1.8.
- Verified no functional `daylens-windows` references remain; the leftover hits are unrelated test fixtures and a cosmetic Google client header.
- A real `.deb` build on Linux/CI is still the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to package naming and install/uninstall maintainer scripts; no runtime app logic or security-sensitive application code is modified.
> 
> **Overview**
> Fixes Linux **`.deb`** install issues: the package is identified as **`daylens`** (not **`daylens-windows`**) and **`chrome-sandbox`** is configured for Chromium on install.
> 
> **Package identity (#18):** Renames npm **`name`** from `daylens-windows` to `daylens` in `package.json` / lockfile and sets **`deb.packageName`** and **`rpm.packageName`** to `daylens` so Debian/RPM metadata and app stores show the correct name.
> 
> **Launch / sandbox (#17):** Adds **`build/linux/after-install.sh`** and **`after-remove.sh`**, wired via **`deb.afterInstall`** / **`deb.afterRemove`**. Post-install mirrors electron-builder defaults (PATH symlink to `/usr/bin/daylens`, MIME/desktop DB refresh) and **`chown root:root`** + **`chmod 4755`** on `/opt/Daylens/chrome-sandbox` so the app can start without manual sandbox fixes. Post-remove removes the symlink and refreshes the desktop DB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f77c9ea8d839d9f89b6b0c4a18032102877d232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Linux installation and uninstallation experience with automated application command-line integration, system database updates, and thorough cleanup procedures.
  * Implemented advanced security hardening to strengthen sandbox isolation specifically for Linux deployments.
  * Standardized and consolidated package naming conventions across all supported platforms and build targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irachrist1/daylens/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->