### PR TITLE
D1: time-grouped conversation sidebar (search + archive + collapsible)

### DIFF
--- a/src/renderer/views/insights/AIWorkspace.tsx
+++ b/src/renderer/views/insights/AIWorkspace.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Trash2 } from 'lucide-react'
 import { ANALYTICS_EVENT } from '@shared/analytics'
 import { track } from '../../lib/analytics'
 import { ipc } from '../../lib/ipc'
@@ -7,11 +6,14 @@ import { AI_PROVIDER_META } from '../../lib/aiProvider'
 import ConnectAI from '../../components/ConnectAI'
 import type { DaylensSearchResult } from '../../../preload/index'
 import { AICompose, type AIComposeHandle } from './AICompose'
+import { ConversationSidebar } from './ConversationSidebar'
 import { HistorySearch } from './HistorySearch'
 import { MessageList } from './MessageList'
-import { IconChevronDown, IconNewChat, IconSparkle, relativeTime } from './icons'
+import { IconNewChat, IconSidebar, IconSparkle } from './icons'
 import { useAIChat } from './useAIChat'
 import type { ThreadMessage } from './types'
+
+const SIDEBAR_COLLAPSED_KEY = 'daylens.ai.sidebarCollapsed'
 
 const STARTER_PROMPTS = [
   'What did I work on today?',
@@ -51,6 +53,7 @@ export default function AIWorkspace() {
     handleNewChat,
     selectThread,
     deleteThread,
+    archiveThread,
     handlePromptChipClick,
     switchProviderAndRetry,
     analyticsContext,
@@ -58,9 +61,17 @@ export default function AIWorkspace() {
 
   const bottomRef = useRef<HTMLDivElement>(null)
   const composerRef = useRef<AIComposeHandle>(null)
-  const [historyOpen, setHistoryOpen] = useState(false)
-  const [hoveredThreadId, setHoveredThreadId] = useState<number | null>(null)
-  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    try { return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1' } catch { return false }
+  })
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((collapsed) => {
+      const next = !collapsed
+      try { localStorage.setItem(SIDEBAR_COLLAPSED_KEY, next ? '1' : '0') } catch { /* ignore */ }
+      return next
+    })
+  }, [])
 
   const scrollToBottom = useCallback(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'auto' })
@@ -72,8 +83,6 @@ export default function AIWorkspace() {
 
   const onNewChat = useCallback(() => {
     handleNewChat()
-    setHistoryOpen(false)
-    setDeleteConfirmId(null)
     composerRef.current?.focus()
   }, [handleNewChat])
 
@@ -91,8 +100,6 @@ export default function AIWorkspace() {
 
   const onSelectThread = useCallback((threadId: number) => {
     selectThread(threadId)
-    setHistoryOpen(false)
-    setDeleteConfirmId(null)
     composerRef.current?.focus()
   }, [selectThread])
 
@@ -146,10 +153,35 @@ export default function AIWorkspace() {
   const hasMessages = messages.length > 0
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-      {/* ── Top bar: thread title + model subline (left, U2/D2), search +
-            thread controls (right). No centered floating label. ── */}
+    <div style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+      {/* ── D1: time-grouped, searchable conversation list with Archive. ── */}
+      {hasApiKey && !sidebarCollapsed && (
+        <ConversationSidebar
+          threads={threads}
+          activeThreadId={activeThreadId}
+          onSelect={onSelectThread}
+          onNewChat={onNewChat}
+          onDelete={deleteThread}
+          onArchive={archiveThread}
+          onCollapse={toggleSidebar}
+        />
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, height: '100%', overflow: 'hidden' }}>
+      {/* ── Top bar: sidebar toggle + thread title + model subline (U2/D2),
+            search + new chat. No centered floating label. ── */}
       <header style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 12, padding: '12px 24px', borderBottom: '1px solid var(--color-border-ghost)' }}>
+        {hasApiKey && (
+          <button
+            type="button"
+            onClick={toggleSidebar}
+            title={sidebarCollapsed ? 'Show chat list' : 'Hide chat list'}
+            aria-label={sidebarCollapsed ? 'Show chat list' : 'Hide chat list'}
+            aria-pressed={!sidebarCollapsed}
+            style={{ width: 34, height: 34, padding: 0, borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: sidebarCollapsed ? 'var(--color-surface)' : 'var(--color-surface-high)', color: 'var(--color-text-secondary)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}
+          >
+            <IconSidebar />
+          </button>
+        )}
         <div style={{ minWidth: 0, flexShrink: 1, overflow: 'hidden' }}>
           <div style={{ fontSize: 13, fontWeight: 680, color: 'var(--color-text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {activeThreadLabel ?? 'New chat'}
@@ -162,75 +194,15 @@ export default function AIWorkspace() {
         </div>
         <div style={{ flex: 1, minWidth: 8 }} />
         <HistorySearch onResultClick={handleSearchResultClick} />
-        <div style={{ position: 'relative', display: 'flex', gap: 6, alignItems: 'center', flexShrink: 0 }}>
-          {threads.length > 0 && (
-            <button
-              type="button"
-              onClick={() => { setHistoryOpen((v) => !v); setDeleteConfirmId(null) }}
-              aria-haspopup="listbox"
-              aria-expanded={historyOpen}
-              title="Recent chats"
-              style={{ display: 'inline-flex', alignItems: 'center', gap: 5, height: 34, padding: '0 10px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: historyOpen ? 'var(--color-surface-high)' : 'var(--color-surface)', color: 'var(--color-text-secondary)', fontSize: 12, fontWeight: 600, cursor: 'pointer' }}
-            >
-              History
-              <IconChevronDown />
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={onNewChat}
-            title="New chat (⌘N)"
-            aria-label="New chat"
-            style={{ width: 34, height: 34, padding: 0, borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-secondary)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
-          >
-            <IconNewChat />
-          </button>
-
-          {historyOpen && threads.length > 0 && (
-            <>
-              <div style={{ position: 'fixed', inset: 0, zIndex: 19 }} onClick={() => { setHistoryOpen(false); setDeleteConfirmId(null) }} />
-              <div role="listbox" style={{ position: 'absolute', top: 'calc(100% + 6px)', right: 0, zIndex: 20, width: 320, maxHeight: 380, overflowY: 'auto', background: 'var(--color-surface)', border: '1px solid var(--color-border-ghost)', borderRadius: 10, boxShadow: '0 8px 24px rgba(0,0,0,0.14)', padding: 6 }}>
-                {threads.map((thread) => (
-                  <div
-                    key={thread.id}
-                    role="option"
-                    aria-selected={thread.id === activeThreadId}
-                    onMouseEnter={() => setHoveredThreadId(thread.id)}
-                    onMouseLeave={() => setHoveredThreadId(null)}
-                    style={{ display: 'flex', alignItems: 'center', gap: 4, borderRadius: 6, background: thread.id === activeThreadId ? 'var(--color-surface-muted)' : 'transparent', marginBottom: 2 }}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => onSelectThread(thread.id)}
-                      style={{ display: 'block', flex: 1, minWidth: 0, textAlign: 'left', padding: '9px 10px', border: 'none', background: 'transparent', color: 'var(--color-text-primary)', fontSize: 12.5, cursor: 'pointer' }}
-                    >
-                      <div style={{ fontWeight: 680, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{thread.title}</div>
-                      <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 2 }}>{relativeTime(thread.lastMessageAt)}</div>
-                    </button>
-                    {deleteConfirmId === thread.id ? (
-                      <button
-                        type="button"
-                        onClick={() => { void deleteThread(thread); setDeleteConfirmId(null) }}
-                        style={{ flexShrink: 0, padding: '4px 8px', marginRight: 4, border: 'none', borderRadius: 4, background: 'rgba(239,68,68,0.12)', color: '#ef4444', fontSize: 11.5, fontWeight: 700, cursor: 'pointer' }}
-                      >
-                        Delete?
-                      </button>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => setDeleteConfirmId(thread.id)}
-                        aria-label={`Delete ${thread.title}`}
-                        style={{ width: 28, flexShrink: 0, marginRight: 4, border: 'none', borderRadius: 5, background: 'transparent', color: 'var(--color-text-tertiary)', cursor: 'pointer', display: 'grid', placeItems: 'center', padding: 4, opacity: hoveredThreadId === thread.id ? 1 : 0, transition: 'opacity 100ms ease' }}
-                      >
-                        <Trash2 size={13} strokeWidth={1.9} aria-hidden="true" />
-                      </button>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
-        </div>
+        <button
+          type="button"
+          onClick={onNewChat}
+          title="New chat (⌘N)"
+          aria-label="New chat"
+          style={{ width: 34, height: 34, padding: 0, borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-secondary)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}
+        >
+          <IconNewChat />
+        </button>
       </header>
 
       {/* ── Conversation ──────────────────────────────────────────────────── */}
@@ -312,6 +284,7 @@ export default function AIWorkspace() {
           </div>
         </div>
       )}
+      </div>
     </div>
   )
 }

--- a/src/renderer/views/insights/ConversationSidebar.tsx
+++ b/src/renderer/views/insights/ConversationSidebar.tsx
@@ -1,0 +1,241 @@
+import { memo, useMemo, useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import type { AIThreadSummary } from '@shared/types'
+import { IconArchive, IconNewChat, IconSearch, IconSidebar, relativeTime } from './icons'
+
+// D1: a proper conversation list — grouped by recency, searchable, with an
+// Archive section and the current chat highlighted. Replaces the old History
+// dropdown. Collapsible to preserve the minimal feel at rest.
+
+export interface ConversationSidebarProps {
+  threads: AIThreadSummary[]
+  activeThreadId: number | null
+  onSelect: (id: number) => void
+  onNewChat: () => void
+  onDelete: (thread: AIThreadSummary) => void
+  onArchive: (thread: AIThreadSummary, archived: boolean) => void
+  onCollapse: () => void
+}
+
+const GROUP_ORDER = ['Today', 'Yesterday', 'Previous 7 Days', 'Previous 30 Days', 'Older'] as const
+type GroupLabel = (typeof GROUP_ORDER)[number]
+
+const DAY_MS = 86_400_000
+
+function recencyGroupOf(ms: number): GroupLabel {
+  const now = new Date()
+  const startToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+  if (ms >= startToday) return 'Today'
+  if (ms >= startToday - DAY_MS) return 'Yesterday'
+  if (ms >= startToday - 7 * DAY_MS) return 'Previous 7 Days'
+  if (ms >= startToday - 30 * DAY_MS) return 'Previous 30 Days'
+  return 'Older'
+}
+
+function matches(thread: AIThreadSummary, query: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  return thread.title.toLowerCase().includes(q) || (thread.lastSnippet ?? '').toLowerCase().includes(q)
+}
+
+function ThreadRow({
+  thread,
+  active,
+  archived,
+  hovered,
+  confirmingDelete,
+  onSelect,
+  onHover,
+  onArchive,
+  onRequestDelete,
+  onConfirmDelete,
+}: {
+  thread: AIThreadSummary
+  active: boolean
+  archived: boolean
+  hovered: boolean
+  confirmingDelete: boolean
+  onSelect: () => void
+  onHover: (hovering: boolean) => void
+  onArchive: () => void
+  onRequestDelete: () => void
+  onConfirmDelete: () => void
+}) {
+  return (
+    <div
+      onMouseEnter={() => onHover(true)}
+      onMouseLeave={() => onHover(false)}
+      style={{ display: 'flex', alignItems: 'center', gap: 2, borderRadius: 7, background: active ? 'var(--color-surface-muted)' : 'transparent', marginBottom: 1 }}
+    >
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-current={active ? 'true' : undefined}
+        title={thread.title}
+        style={{ display: 'block', flex: 1, minWidth: 0, textAlign: 'left', padding: '7px 9px', border: 'none', background: 'transparent', color: 'var(--color-text-primary)', fontSize: 12.5, cursor: 'pointer' }}
+      >
+        <div style={{ fontWeight: active ? 700 : 560, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: archived ? 0.75 : 1 }}>
+          {thread.title || 'New chat'}
+        </div>
+        <div style={{ fontSize: 10.5, color: 'var(--color-text-tertiary)', marginTop: 1 }}>{relativeTime(thread.lastMessageAt)}</div>
+      </button>
+      {confirmingDelete ? (
+        <button
+          type="button"
+          onClick={onConfirmDelete}
+          style={{ flexShrink: 0, padding: '3px 7px', marginRight: 4, border: 'none', borderRadius: 4, background: 'rgba(239,68,68,0.12)', color: '#ef4444', fontSize: 11, fontWeight: 700, cursor: 'pointer' }}
+        >
+          Delete?
+        </button>
+      ) : (hovered || active) ? (
+        <div style={{ display: 'flex', flexShrink: 0, marginRight: 3 }}>
+          <button
+            type="button"
+            onClick={onArchive}
+            aria-label={archived ? `Unarchive ${thread.title}` : `Archive ${thread.title}`}
+            title={archived ? 'Unarchive' : 'Archive'}
+            style={{ width: 24, height: 24, border: 'none', borderRadius: 5, background: 'transparent', color: 'var(--color-text-tertiary)', cursor: 'pointer', display: 'grid', placeItems: 'center' }}
+          >
+            <IconArchive size={12} />
+          </button>
+          <button
+            type="button"
+            onClick={onRequestDelete}
+            aria-label={`Delete ${thread.title}`}
+            title="Delete"
+            style={{ width: 24, height: 24, border: 'none', borderRadius: 5, background: 'transparent', color: 'var(--color-text-tertiary)', cursor: 'pointer', display: 'grid', placeItems: 'center' }}
+          >
+            <Trash2 size={12} strokeWidth={1.9} aria-hidden="true" />
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function ConversationSidebarImpl({
+  threads,
+  activeThreadId,
+  onSelect,
+  onNewChat,
+  onDelete,
+  onArchive,
+  onCollapse,
+}: ConversationSidebarProps) {
+  const [query, setQuery] = useState('')
+  const [hoveredId, setHoveredId] = useState<number | null>(null)
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
+  const [archiveOpen, setArchiveOpen] = useState(false)
+
+  const { groups, archived } = useMemo(() => {
+    const active = threads.filter((t) => !t.archived && matches(t, query))
+    const arch = threads.filter((t) => t.archived && matches(t, query))
+    const byGroup = new Map<GroupLabel, AIThreadSummary[]>()
+    for (const thread of [...active].sort((a, b) => b.lastMessageAt - a.lastMessageAt)) {
+      const label = recencyGroupOf(thread.lastMessageAt)
+      const bucket = byGroup.get(label) ?? []
+      bucket.push(thread)
+      byGroup.set(label, bucket)
+    }
+    const ordered = GROUP_ORDER
+      .map((label) => ({ label, items: byGroup.get(label) ?? [] }))
+      .filter((g) => g.items.length > 0)
+    return { groups: ordered, archived: arch.sort((a, b) => b.lastMessageAt - a.lastMessageAt) }
+  }, [threads, query])
+
+  const totalActive = threads.filter((t) => !t.archived).length
+
+  const renderRow = (thread: AIThreadSummary, isArchived: boolean) => (
+    <ThreadRow
+      key={thread.id}
+      thread={thread}
+      active={thread.id === activeThreadId}
+      archived={isArchived}
+      hovered={hoveredId === thread.id}
+      confirmingDelete={confirmDeleteId === thread.id}
+      onSelect={() => { setConfirmDeleteId(null); onSelect(thread.id) }}
+      onHover={(hovering) => setHoveredId(hovering ? thread.id : null)}
+      onArchive={() => { setConfirmDeleteId(null); onArchive(thread, !isArchived) }}
+      onRequestDelete={() => setConfirmDeleteId(thread.id)}
+      onConfirmDelete={() => { setConfirmDeleteId(null); void onDelete(thread) }}
+    />
+  )
+
+  return (
+    <aside
+      style={{ flexShrink: 0, width: 248, display: 'flex', flexDirection: 'column', height: '100%', borderRight: '1px solid var(--color-border-ghost)', background: 'var(--color-surface-low)' }}
+      aria-label="Conversations"
+    >
+      <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 6, padding: '12px 10px 8px' }}>
+        <button
+          type="button"
+          onClick={onCollapse}
+          title="Hide chat list"
+          aria-label="Hide chat list"
+          style={{ width: 30, height: 30, padding: 0, borderRadius: 8, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-secondary)', cursor: 'pointer', display: 'grid', placeItems: 'center' }}
+        >
+          <IconSidebar />
+        </button>
+        <div style={{ flex: 1, fontSize: 12.5, fontWeight: 700, color: 'var(--color-text-secondary)' }}>Chats</div>
+        <button
+          type="button"
+          onClick={onNewChat}
+          title="New chat (⌘N)"
+          aria-label="New chat"
+          style={{ width: 30, height: 30, padding: 0, borderRadius: 8, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-secondary)', cursor: 'pointer', display: 'grid', placeItems: 'center' }}
+        >
+          <IconNewChat />
+        </button>
+      </div>
+
+      <div style={{ flexShrink: 0, padding: '0 10px 8px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7, height: 32, padding: '0 9px', borderRadius: 8, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)' }}>
+          <span style={{ color: 'var(--color-text-tertiary)', display: 'inline-flex', flexShrink: 0 }}><IconSearch size={13} /></span>
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search chats"
+            aria-label="Search chats"
+            style={{ flex: 1, minWidth: 0, border: 'none', background: 'transparent', outline: 'none', color: 'var(--color-text-primary)', fontSize: 12 }}
+          />
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 8px 12px' }}>
+        {totalActive === 0 && archived.length === 0 ? (
+          <div style={{ padding: '14px 8px', fontSize: 12, color: 'var(--color-text-tertiary)', lineHeight: 1.5 }}>
+            No chats yet. Ask Daylens anything to start one.
+          </div>
+        ) : groups.length === 0 && archived.length === 0 ? (
+          <div style={{ padding: '14px 8px', fontSize: 12, color: 'var(--color-text-tertiary)' }}>No matches.</div>
+        ) : (
+          groups.map((group) => (
+            <div key={group.label} style={{ marginTop: 8 }}>
+              <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', padding: '2px 9px 4px' }}>
+                {group.label}
+              </div>
+              {group.items.map((thread) => renderRow(thread, false))}
+            </div>
+          ))
+        )}
+
+        {archived.length > 0 && (
+          <div style={{ marginTop: 12, borderTop: '1px solid var(--color-border-ghost)', paddingTop: 8 }}>
+            <button
+              type="button"
+              onClick={() => setArchiveOpen((v) => !v)}
+              style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%', padding: '4px 9px', border: 'none', background: 'transparent', color: 'var(--color-text-tertiary)', cursor: 'pointer', fontSize: 10, fontWeight: 700, letterSpacing: '0.06em', textTransform: 'uppercase' }}
+            >
+              <IconArchive size={12} />
+              Archived ({archived.length})
+              <span style={{ marginLeft: 'auto', fontSize: 11 }}>{archiveOpen ? '–' : '+'}</span>
+            </button>
+            {archiveOpen && <div style={{ marginTop: 2 }}>{archived.map((thread) => renderRow(thread, true))}</div>}
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+}
+
+export const ConversationSidebar = memo(ConversationSidebarImpl)

--- a/src/renderer/views/insights/icons.tsx
+++ b/src/renderer/views/insights/icons.tsx
@@ -83,6 +83,26 @@ export function IconSearch({ size = 14 }: { size?: number }) {
   )
 }
 
+// D1: sidebar toggle — a panel with a divider, reads as "show/hide the list".
+export function IconSidebar({ size = 15 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="2" y="2.5" width="12" height="11" rx="2" />
+      <path d="M6.2 2.7v10.6" />
+    </svg>
+  )
+}
+
+export function IconArchive({ size = 13 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="2" y="2.5" width="12" height="3" rx="1" />
+      <path d="M3 5.5v6A1.5 1.5 0 0 0 4.5 13h7A1.5 1.5 0 0 0 13 11.5v-6" />
+      <path d="M6.5 8h3" />
+    </svg>
+  )
+}
+
 export function IconExternal() {
   return (
     <svg width="13" height="13" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">

--- a/src/renderer/views/insights/useAIChat.ts
+++ b/src/renderer/views/insights/useAIChat.ts
@@ -32,6 +32,12 @@ import {
 const SWITCHABLE_PROVIDERS: AIProviderMode[] = ['anthropic', 'openai', 'google', 'openrouter', 'claude-cli', 'codex-cli']
 const API_PROVIDERS: AIProviderMode[] = ['anthropic', 'openai', 'google', 'openrouter']
 
+// D1: the thread list now includes archived threads (the sidebar shows an
+// Archive section), so "adopt a thread" must skip archived ones.
+function firstActiveThreadId(rows: AIThreadSummary[]): number | null {
+  return rows.find((row) => !row.archived)?.id ?? null
+}
+
 type SendOptions = {
   contextOverride?: ThreadMessage['contextSnapshot']
   trigger?: 'freeform' | 'suggested' | 'retry'
@@ -237,11 +243,11 @@ export function useAIChat() {
     const deepLinkThreadId = Number(new URLSearchParams(location.search).get('threadId'))
     const hasDeepLink = Number.isFinite(deepLinkThreadId) && deepLinkThreadId > 0
     let cancelled = false
-    ipc.ai.listThreads({ includeArchived: false }).then((rows) => {
+    ipc.ai.listThreads({ includeArchived: true }).then((rows) => {
       if (cancelled) return
       setThreads(rows)
-      const first = rows[0]
-      if (first && !hasDeepLink) void loadThread(first.id)
+      const firstId = firstActiveThreadId(rows)
+      if (firstId != null && !hasDeepLink) void loadThread(firstId)
     }).catch(() => { /* best-effort */ })
     return () => { cancelled = true }
   }, [loadThread, location.search])
@@ -307,9 +313,9 @@ export function useAIChat() {
     // sendMessage auto-creates a thread server-side when none is passed. Adopt
     // the newest row so follow-up turns (and retries) stay linked to it.
     try {
-      const refreshed = await ipc.ai.listThreads({ includeArchived: false })
+      const refreshed = await ipc.ai.listThreads({ includeArchived: true })
       setThreads(refreshed)
-      setActiveThreadId((current) => current ?? refreshed[0]?.id ?? null)
+      setActiveThreadId((current) => current ?? firstActiveThreadId(refreshed))
     } catch { /* best-effort */ }
   }, [])
 
@@ -601,13 +607,13 @@ export function useAIChat() {
   const deleteThread = useCallback(async (thread: AIThreadSummary) => {
     try {
       await ipc.ai.deleteThread(thread.id)
-      const refreshed = await ipc.ai.listThreads({ includeArchived: false })
+      const refreshed = await ipc.ai.listThreads({ includeArchived: true })
       setThreads(refreshed)
       if (thread.id === activeThreadId) {
-        const next = refreshed[0]
-        if (next) {
+        const nextId = firstActiveThreadId(refreshed)
+        if (nextId != null) {
           resetComposerState()
-          void loadThread(next.id)
+          void loadThread(nextId)
         } else {
           setActiveThreadId(null)
           resetComposerState()
@@ -615,6 +621,29 @@ export function useAIChat() {
       }
     } catch (error) {
       console.error('[ai] failed to delete thread', error)
+    }
+  }, [activeThreadId, resetComposerState, loadThread])
+
+  // D1: archive / unarchive a thread. Archiving the active thread moves focus
+  // to the next active one (like delete), so the body never strands on a thread
+  // the user just tucked away.
+  const archiveThread = useCallback(async (thread: AIThreadSummary, archived: boolean) => {
+    try {
+      await ipc.ai.archiveThread(thread.id, archived)
+      const refreshed = await ipc.ai.listThreads({ includeArchived: true })
+      setThreads(refreshed)
+      if (archived && thread.id === activeThreadId) {
+        const nextId = firstActiveThreadId(refreshed)
+        if (nextId != null) {
+          resetComposerState()
+          void loadThread(nextId)
+        } else {
+          setActiveThreadId(null)
+          resetComposerState()
+        }
+      }
+    } catch (error) {
+      console.error('[ai] failed to archive thread', error)
     }
   }, [activeThreadId, resetComposerState, loadThread])
 
@@ -629,7 +658,7 @@ export function useAIChat() {
     routedReportKeyRef.current = routeKey
 
     void (async () => {
-      const refreshed = await ipc.ai.listThreads({ includeArchived: false }).catch(() => null)
+      const refreshed = await ipc.ai.listThreads({ includeArchived: true }).catch(() => null)
       if (refreshed) setThreads(refreshed)
       resetComposerState()
       await loadThread(threadId)
@@ -678,6 +707,7 @@ export function useAIChat() {
     handleNewChat,
     selectThread,
     deleteThread,
+    archiveThread,
     triggerActionFeedback,
     handlePromptChipClick,
     switchProviderAndRetry,


### PR DESCRIPTION
## Why
Spec **D1**: Daylens only had a History dropdown. Raycast (Img 20) shows a left list with **Search chats**, recency groups, the current chat highlighted, and an **Archive**. This builds that.

## What
- **`ConversationSidebar.tsx`** — left list grouping active threads by recency (**Today / Yesterday / Previous 7 Days / Previous 30 Days / Older**), current chat highlighted.
- **Search chats** — filters by title + last snippet.
- **Archive** — archive/unarchive per thread; archived threads collapse into their own section and are never auto-adopted as the active thread.
- **Collapsible** — header toggle, state persisted to `localStorage`, so the tab stays minimal at rest.
- Per-row hover actions: archive + delete-with-confirm (carried over from the dropdown).
- `useAIChat` lists with `includeArchived` and adopts the first **active** thread (`firstActiveThreadId`) on hydrate / after a turn / after delete. New `archiveThread()` mirrors delete for focus handling.

## Verification
`typecheck` ✅, `build:renderer` ✅ (Insights bundle includes the sidebar). Pure renderer change.

## DO NOT REGRESS (spec §2)
- U1 thread-load logic unchanged (still `loadThread` with the stale-guard).
- Thinking caret, multi-turn memory, fast composer untouched.
- HistorySearch (keyword search with highlighted excerpts) stays in the header.

Base: `ai-q6-eval-program` — third in the stack (#24 → #25 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Renderer-only UI and client thread-selection logic; archive/delete use existing IPC with no auth or data-model changes in this diff.
> 
> **Overview**
> Replaces the AI tab’s **History** dropdown with a collapsible **`ConversationSidebar`**: active chats grouped by recency (Today → Older), inline **Search chats** (title + last snippet), per-row **archive/unarchive** and delete-with-confirm, and a collapsible **Archived** section.
> 
> **`AIWorkspace`** uses a horizontal layout (sidebar + main column), persists show/hide via `localStorage` (`daylens.ai.sidebarCollapsed`), and adds a header **sidebar toggle**; **HistorySearch** stays in the header.
> 
> **`useAIChat`** loads threads with `includeArchived: true`, adds **`archiveThread`** (same focus handoff as delete when archiving the active thread), and adopts the first **non-archived** thread via **`firstActiveThreadId`** on hydrate, after turns, and after delete/archive.
> 
> New **`IconSidebar`** / **`IconArchive`** in `icons.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fde01abaa02ab2ab2c47f2a9c297a3ed0decb073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->