### PR TITLE
D3: in-chat ⌘K action palette + message accelerators

### DIFF
--- a/src/renderer/views/insights/AIWorkspace.tsx
+++ b/src/renderer/views/insights/AIWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ANALYTICS_EVENT } from '@shared/analytics'
 import { track } from '../../lib/analytics'
 import { ipc } from '../../lib/ipc'
@@ -6,6 +6,7 @@ import { AI_PROVIDER_META } from '../../lib/aiProvider'
 import ConnectAI from '../../components/ConnectAI'
 import type { DaylensSearchResult } from '../../../preload/index'
 import { AICompose, type AIComposeHandle } from './AICompose'
+import { ChatActionPalette, type ChatPaletteAction } from './ChatActionPalette'
 import { ConversationSidebar } from './ConversationSidebar'
 import { HistorySearch } from './HistorySearch'
 import { MessageList } from './MessageList'
@@ -56,6 +57,7 @@ export default function AIWorkspace() {
     archiveThread,
     handlePromptChipClick,
     switchProviderAndRetry,
+    alternateProviders,
     analyticsContext,
   } = chat
 
@@ -97,6 +99,89 @@ export default function AIWorkspace() {
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [onNewChat])
+
+  // ── D3: ⌘K action palette + direct accelerators on the focused message ──────
+  const [paletteOpen, setPaletteOpen] = useState(false)
+  const isMac = useMemo(() => navigator.platform.toLowerCase().includes('mac'), [])
+  const accel = useCallback(
+    (key: string, shift = false) => (isMac ? `${shift ? '⇧' : ''}⌘${key}` : `Ctrl+${shift ? 'Shift+' : ''}${key}`),
+    [isMac],
+  )
+
+  const copyChat = useCallback(async () => {
+    const text = messages
+      .filter((m) => m.state !== 'pending')
+      .map((m) => `${m.role === 'user' ? 'You' : 'Daylens'}: ${m.content}`)
+      .join('\n\n')
+    if (!text.trim()) return
+    try { await navigator.clipboard.writeText(text) } catch { /* clipboard unsupported */ }
+  }, [messages])
+
+  // The "focused message" the palette acts on is the latest completed answer.
+  const latestAssistant = useMemo(() => {
+    const index = messages.findIndex((m) => m.id === latestCompletedAssistantId)
+    return index >= 0 ? { message: messages[index], index } : null
+  }, [messages, latestCompletedAssistantId])
+
+  const paletteActions = useMemo<ChatPaletteAction[]>(() => {
+    const list: ChatPaletteAction[] = []
+    const target = latestAssistant
+    if (target) {
+      list.push({ id: 'copy-response', label: 'Copy Response', accelerator: accel('C', true), perform: () => handleCopy(target.message.id, target.message.content, target.message.answerKind) })
+    }
+    list.push({ id: 'copy-chat', label: 'Copy Chat', hint: 'Copy the whole conversation', perform: () => copyChat() })
+    if (target) {
+      list.push({ id: 'regenerate', label: 'Regenerate', accelerator: accel('R'), perform: () => handleRetry(target.index, target.message) })
+      // "Regenerate with Model" (⇧⌘R) — one entry per other configured provider
+      // (reuses R2's switch-provider path; useful for the rate-limit story).
+      alternateProviders.forEach((alt, i) => {
+        list.push({
+          id: `regen-${alt.provider}`,
+          label: `Regenerate with ${alt.label}`,
+          hint: 'Switch provider and rerun',
+          accelerator: i === 0 ? accel('R', true) : undefined,
+          perform: () => switchProviderAndRetry(target.message, alt.provider),
+        })
+      })
+      list.push({ id: 'good', label: 'Good Response', accelerator: accel('=', true), perform: () => handleRate(target.message, target.message.rating === 'up' ? null : 'up') })
+      list.push({ id: 'bad', label: 'Bad Response', accelerator: accel('-', true), perform: () => handleRate(target.message, target.message.rating === 'down' ? null : 'down') })
+    }
+    return list
+  }, [latestAssistant, alternateProviders, accel, handleCopy, handleRetry, handleRate, switchProviderAndRetry, copyChat])
+
+  // Read the latest action context from a ref so the global key listener binds
+  // once instead of rebinding every render.
+  const accelStateRef = useRef({ hasApiKey, paletteOpen, latestAssistant, alternateProviders, handleCopy, handleRetry, handleRate, switchProviderAndRetry })
+  accelStateRef.current = { hasApiKey, paletteOpen, latestAssistant, alternateProviders, handleCopy, handleRetry, handleRate, switchProviderAndRetry }
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const state = accelStateRef.current
+      if (!state.hasApiKey) return
+      if (!(event.metaKey || event.ctrlKey) || event.altKey) return
+      const key = event.key.toLowerCase()
+      if (!event.shiftKey && key === 'k') { event.preventDefault(); setPaletteOpen((open) => !open); return }
+      if (state.paletteOpen) return // the palette owns its keys while open
+      const target = state.latestAssistant
+      // preventDefault only when we actually act, so an empty chat still allows
+      // the platform default (e.g. ⌘R reload during development).
+      if (!event.shiftKey && key === 'r') { if (target) { event.preventDefault(); void state.handleRetry(target.index, target.message) } return }
+      if (event.shiftKey && key === 'r') {
+        if (target) {
+          event.preventDefault()
+          const alt = state.alternateProviders[0]
+          if (alt) void state.switchProviderAndRetry(target.message, alt.provider)
+          else void state.handleRetry(target.index, target.message)
+        }
+        return
+      }
+      if (event.shiftKey && key === 'c') { if (target) { event.preventDefault(); void state.handleCopy(target.message.id, target.message.content, target.message.answerKind) } return }
+      if (event.shiftKey && (event.code === 'Equal' || key === '=' || key === '+')) { if (target) { event.preventDefault(); void state.handleRate(target.message, target.message.rating === 'up' ? null : 'up') } return }
+      if (event.shiftKey && (event.code === 'Minus' || key === '-' || key === '_')) { if (target) { event.preventDefault(); void state.handleRate(target.message, target.message.rating === 'down' ? null : 'down') } return }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
 
   const onSelectThread = useCallback((threadId: number) => {
     selectThread(threadId)
@@ -196,6 +281,15 @@ export default function AIWorkspace() {
         <HistorySearch onResultClick={handleSearchResultClick} />
         <button
           type="button"
+          onClick={() => setPaletteOpen(true)}
+          title="Chat actions"
+          aria-label="Chat actions"
+          style={{ height: 34, padding: '0 10px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-tertiary)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', fontSize: 11.5, fontWeight: 700, flexShrink: 0, letterSpacing: '0.02em' }}
+        >
+          {isMac ? '⌘K' : 'Ctrl K'}
+        </button>
+        <button
+          type="button"
           onClick={onNewChat}
           title="New chat (⌘N)"
           aria-label="New chat"
@@ -285,6 +379,7 @@ export default function AIWorkspace() {
         </div>
       )}
       </div>
+      <ChatActionPalette isOpen={paletteOpen} actions={paletteActions} onClose={() => setPaletteOpen(false)} />
     </div>
   )
 }

--- a/src/renderer/views/insights/ChatActionPalette.tsx
+++ b/src/renderer/views/insights/ChatActionPalette.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+// D3: an in-chat ⌘K action palette scoped to the focused (latest) message.
+// Mirrors the global CommandPalette's interaction model (fuzzy filter, arrow /
+// enter / esc, same modal chrome) but operates on chat actions passed in by
+// AIWorkspace, so the chat state stays where it lives. The accelerators shown
+// here are also wired as direct shortcuts in AIWorkspace.
+
+export interface ChatPaletteAction {
+  id: string
+  label: string
+  hint?: string
+  accelerator?: string
+  perform: () => void | Promise<void>
+}
+
+function fuzzyScore(haystack: string, needle: string): number {
+  if (!needle) return 1
+  const h = haystack.toLowerCase()
+  const n = needle.toLowerCase()
+  if (h.startsWith(n)) return 4
+  if (h.includes(` ${n}`)) return 3
+  if (h.includes(n)) return 2
+  let i = 0
+  for (const ch of h) {
+    if (ch === n[i]) i += 1
+    if (i === n.length) return 1
+  }
+  return 0
+}
+
+export function ChatActionPalette({
+  isOpen,
+  actions,
+  onClose,
+}: {
+  isOpen: boolean
+  actions: ChatPaletteAction[]
+  onClose: () => void
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [query, setQuery] = useState('')
+  const [highlightIdx, setHighlightIdx] = useState(0)
+
+  useEffect(() => {
+    if (!isOpen) return
+    setQuery('')
+    setHighlightIdx(0)
+    requestAnimationFrame(() => inputRef.current?.focus())
+  }, [isOpen])
+
+  const close = useCallback(() => { onClose(); setQuery('') }, [onClose])
+
+  const filtered = useMemo(() => {
+    const q = query.trim()
+    return actions
+      .map((action) => ({
+        action,
+        score: Math.max(fuzzyScore(action.label, q), action.hint ? fuzzyScore(action.hint, q) : 0),
+      }))
+      .filter((entry) => q.length === 0 || entry.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map((entry) => entry.action)
+  }, [actions, query])
+
+  useEffect(() => {
+    if (highlightIdx >= filtered.length) setHighlightIdx(0)
+  }, [filtered.length, highlightIdx])
+
+  const handleKey = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setHighlightIdx((idx) => Math.min(filtered.length - 1, idx + 1))
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setHighlightIdx((idx) => Math.max(0, idx - 1))
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      const target = filtered[highlightIdx]
+      if (target) void Promise.resolve(target.perform()).finally(close)
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      close()
+    }
+  }, [filtered, highlightIdx, close])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Chat actions"
+      onClick={close}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(7, 10, 16, 0.55)', backdropFilter: 'blur(6px)', display: 'flex', alignItems: 'flex-start', justifyContent: 'center', paddingTop: '14vh' }}
+    >
+      <div
+        onClick={(event) => event.stopPropagation()}
+        style={{ width: 'min(520px, 92vw)', maxHeight: '64vh', display: 'flex', flexDirection: 'column', background: 'var(--color-surface, #0f141c)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 12, boxShadow: '0 24px 80px rgba(0,0,0,0.5)', overflow: 'hidden' }}
+      >
+        <div style={{ padding: '12px 16px', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => { setQuery(event.target.value); setHighlightIdx(0) }}
+            onKeyDown={handleKey}
+            placeholder="Chat actions…"
+            style={{ width: '100%', background: 'transparent', border: 'none', outline: 'none', color: 'var(--color-text-primary)', fontSize: 15, letterSpacing: '-0.01em' }}
+          />
+        </div>
+        <div style={{ overflowY: 'auto', padding: '6px 0' }}>
+          {filtered.length === 0 ? (
+            <div style={{ padding: '18px 16px', fontSize: 13, color: 'var(--color-text-tertiary)' }}>No matching actions.</div>
+          ) : (
+            filtered.map((action, idx) => {
+              const isActive = idx === highlightIdx
+              return (
+                <button
+                  key={action.id}
+                  type="button"
+                  onMouseEnter={() => setHighlightIdx(idx)}
+                  onClick={() => { void Promise.resolve(action.perform()).finally(close) }}
+                  style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', padding: '9px 16px', background: isActive ? 'rgba(173,198,255,0.08)' : 'transparent', color: 'var(--color-text-primary)', border: 'none', textAlign: 'left', cursor: 'pointer', fontFamily: 'inherit', fontSize: 13 }}
+                >
+                  <span style={{ display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0 }}>
+                    <span style={{ fontWeight: 600 }}>{action.label}</span>
+                    {action.hint && <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>{action.hint}</span>}
+                  </span>
+                  {action.accelerator && (
+                    <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginLeft: 12, flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
+                      {action.accelerator}
+                    </span>
+                  )}
+                </button>
+              )
+            })
+          )}
+        </div>
+        <div style={{ padding: '8px 16px', borderTop: '1px solid rgba(255,255,255,0.06)', fontSize: 11, color: 'var(--color-text-tertiary)' }}>
+          ↑ ↓ to move · ↵ to run · esc to close
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Why
Spec **D3**: Raycast's ⌘K action palette (Img 23) — Copy Response, Copy Chat, Regenerate, **Regenerate with Model**, Good/Bad Response — scoped to the focused message. "Regenerate with Model" is the practical fix for the rate-limit story: bounce a stuck answer to another provider without leaving the keyboard.

## What
- **`ChatActionPalette.tsx`** — a fuzzy ⌘K palette mirroring the global `CommandPalette` interaction model (arrow / enter / esc, same modal chrome), acting on chat actions passed in by `AIWorkspace`.
- Actions on the latest answer: **Copy Response** (⇧⌘C), **Copy Chat**, **Regenerate** (⌘R), **Regenerate with &lt;Provider&gt;** (⇧⌘R — one per other configured provider, reusing R2's switch-provider path), **Good Response** (⇧⌘=), **Bad Response** (⇧⌘-).
- Direct accelerators wired on the AI tab via one window listener (read through a ref so it binds once). Target-dependent shortcuts only `preventDefault` when they actually act, so an empty chat still allows the platform default (e.g. ⌘R reload in dev).
- Header **⌘K** affordance for discoverability; labels are platform-aware.

## Verification
`typecheck` ✅, `build:renderer` ✅.

## DO NOT REGRESS (spec §2)
Additive. Copy/rate/retry on the message row are unchanged; the palette reuses the same handlers. No change to the caret, memory, composer, or search.

Base: `ai-d1-sidebar` — fourth in the stack (#24 → #25 → #26 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only additions that delegate to existing copy, retry, rate, and provider-switch handlers; shortcut handling is scoped and avoids preventDefault when no message is focused.
> 
> **Overview**
> Adds an **in-chat ⌘K / Ctrl+K action palette** on the AI workspace so reviewers can run chat operations from the keyboard without using message-row controls.
> 
> **`ChatActionPalette`** is a new fuzzy-search modal (arrow / enter / esc) that lists actions built in **`AIWorkspace`**: copy latest response, copy full thread, regenerate, regenerate with each alternate configured provider (reusing **`switchProviderAndRetry`**), and thumbs up/down on the **latest completed assistant** message. A header **⌘K** button opens the palette; **⌘K** also toggles it when an API key is present.
> 
> Direct **Ctrl/Cmd** shortcuts are registered once via a ref-backed window listener: regenerate, shift-regenerate with first alternate provider, shift-copy response, and shift rating keys only call **`preventDefault`** when there is a target message, so empty chats do not steal browser defaults like reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77a5e45e19d2ff412189ca80b31b7a369d7e4115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->