### PR TITLE
D6: response transforms (Turn into… shorter / checklist / report)

### DIFF
--- a/src/renderer/views/insights/AIWorkspace.tsx
+++ b/src/renderer/views/insights/AIWorkspace.tsx
@@ -12,7 +12,7 @@ import { HistorySearch } from './HistorySearch'
 import { MessageList } from './MessageList'
 import { IconNewChat, IconSidebar, IconSparkle } from './icons'
 import { useAIChat } from './useAIChat'
-import type { ThreadMessage } from './types'
+import { ANSWER_TRANSFORMS, type ThreadMessage } from './types'
 
 const SIDEBAR_COLLAPSED_KEY = 'daylens.ai.sidebarCollapsed'
 
@@ -58,6 +58,7 @@ export default function AIWorkspace() {
     handlePromptChipClick,
     switchProviderAndRetry,
     alternateProviders,
+    transformAnswer,
     analyticsContext,
   } = chat
 
@@ -145,9 +146,13 @@ export default function AIWorkspace() {
       })
       list.push({ id: 'good', label: 'Good Response', accelerator: accel('=', true), perform: () => handleRate(target.message, target.message.rating === 'up' ? null : 'up') })
       list.push({ id: 'bad', label: 'Bad Response', accelerator: accel('-', true), perform: () => handleRate(target.message, target.message.rating === 'down' ? null : 'down') })
+      // D6: transforms in the palette as well as the inline "Turn into…" menu.
+      for (const transform of ANSWER_TRANSFORMS) {
+        list.push({ id: `transform-${transform.kind}`, label: transform.label, hint: 'Transform the answer', perform: () => transformAnswer(transform.kind) })
+      }
     }
     return list
-  }, [latestAssistant, alternateProviders, accel, handleCopy, handleRetry, handleRate, switchProviderAndRetry, copyChat])
+  }, [latestAssistant, alternateProviders, accel, handleCopy, handleRetry, handleRate, switchProviderAndRetry, copyChat, transformAnswer])
 
   // Read the latest action context from a ref so the global key listener binds
   // once instead of rebinding every render.
@@ -330,6 +335,7 @@ export default function AIWorkspace() {
                 onRetry={handleRetry}
                 onErrorRetry={handleErrorRetry}
                 onSwitchProvider={switchProviderAndRetry}
+                onTransform={transformAnswer}
                 onMessageAction={handleMessageAction}
                 onFollowUpClick={onFollowUpClick}
                 scrollToBottom={scrollToBottom}

--- a/src/renderer/views/insights/MessageList.tsx
+++ b/src/renderer/views/insights/MessageList.tsx
@@ -16,7 +16,9 @@ import {
 import {
   actionFeedbackKey,
   messageActionKey,
+  ANSWER_TRANSFORMS,
   type ActionFeedbackEntry,
+  type AnswerTransform,
   type MessageActionStateEntry,
   type ThreadMessage,
 } from './types'
@@ -74,9 +76,50 @@ export interface MessageListProps {
   onRetry: (index: number, message: ThreadMessage) => void
   onErrorRetry: (message: ThreadMessage) => void
   onSwitchProvider: (message: ThreadMessage, provider: AIProviderMode) => void
+  onTransform: (kind: AnswerTransform) => void
   onMessageAction: (messageId: string | number, action: AIMessageAction, options?: { reviewNote?: string }) => void
   onFollowUpClick: (message: ThreadMessage, suggestionText: string, source: string) => void
   scrollToBottom: () => void
+}
+
+// D6: "Turn into…" — post-answer transforms on the latest answer (Raycast Img
+// 21/22). Each runs a canned re-prompt; the menu is a small hover-light popover.
+function TransformMenu({ onTransform }: { onTransform: (kind: AnswerTransform) => void }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Turn this answer into…"
+        style={{ height: 30, padding: '0 10px', borderRadius: 999, border: '1px solid var(--color-border-ghost)', background: open ? 'var(--color-accent-dim)' : 'transparent', color: 'var(--color-text-secondary)', cursor: 'pointer', fontSize: 12, fontWeight: 600 }}
+      >
+        Turn into…
+      </button>
+      {open && (
+        <>
+          <div style={{ position: 'fixed', inset: 0, zIndex: 19 }} onClick={() => setOpen(false)} />
+          <div role="menu" style={{ position: 'absolute', bottom: 'calc(100% + 6px)', left: 0, zIndex: 20, minWidth: 180, background: 'var(--color-surface)', border: '1px solid var(--color-border-ghost)', borderRadius: 10, boxShadow: '0 8px 24px rgba(0,0,0,0.16)', padding: 5 }}>
+            {ANSWER_TRANSFORMS.map((transform) => (
+              <button
+                key={transform.kind}
+                role="menuitem"
+                type="button"
+                onClick={() => { setOpen(false); onTransform(transform.kind) }}
+                style={{ display: 'block', width: '100%', textAlign: 'left', padding: '7px 10px', border: 'none', borderRadius: 6, background: 'transparent', color: 'var(--color-text-primary)', fontSize: 12.5, cursor: 'pointer' }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--color-surface-muted)' }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}
+              >
+                {transform.label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
 }
 
 // R4: branded header label per error class — never a raw provider/channel string.
@@ -100,6 +143,7 @@ function MessageListImpl({
   onRetry,
   onErrorRetry,
   onSwitchProvider,
+  onTransform,
   onMessageAction,
   onFollowUpClick,
   scrollToBottom,
@@ -300,6 +344,7 @@ function MessageListImpl({
                         <IconRetry />
                       </IconActionButton>
                     )}
+                    {message.id === latestCompletedAssistantId && <TransformMenu onTransform={onTransform} />}
                   </div>
                 </>
               )}

--- a/src/renderer/views/insights/types.ts
+++ b/src/renderer/views/insights/types.ts
@@ -27,6 +27,17 @@ export type ThreadMessage = Omit<AIThreadMessage, 'id'> & {
 
 export type MessageAction = 'copy' | 'up' | 'down' | 'retry'
 
+// D6: post-answer transforms. Implemented as canned re-prompts through the
+// normal send pipeline (thread memory already holds the answer being
+// transformed), so there is no new main-process surface.
+export type AnswerTransform = 'shorter' | 'checklist' | 'bullets' | 'report'
+export const ANSWER_TRANSFORMS: { kind: AnswerTransform; label: string }[] = [
+  { kind: 'shorter', label: 'Make it shorter' },
+  { kind: 'checklist', label: 'Turn into a checklist' },
+  { kind: 'bullets', label: 'Turn into bullets' },
+  { kind: 'report', label: 'Turn into a report' },
+]
+
 export interface ActionFeedbackEntry {
   pulseNonce: number
   success: boolean

--- a/src/renderer/views/insights/useAIChat.ts
+++ b/src/renderer/views/insights/useAIChat.ts
@@ -22,10 +22,20 @@ import {
   threadMessagesFromHistory,
   type ActionFeedbackEntry,
   type AltProvider,
+  type AnswerTransform,
   type MessageAction,
   type MessageActionStateEntry,
   type ThreadMessage,
 } from './types'
+
+// D6: each transform is a canned instruction the model applies to its previous
+// answer (thread memory holds it), so transforms ride the normal send path.
+const TRANSFORM_PROMPTS: Record<AnswerTransform, string> = {
+  shorter: 'Rewrite your previous answer as a shorter, tighter version — keep the key facts and numbers, drop the preamble.',
+  checklist: 'Reformat your previous answer as a concise checklist of action items, one per line, no preamble.',
+  bullets: 'Reformat your previous answer as a tight bulleted summary, leading with the most important point.',
+  report: 'Expand your previous answer into a short shareable report: a heading, a few labelled sections, and the supporting numbers. No filler.',
+}
 
 // Providers we can offer as a one-tap switch on a hard wall. CLI providers are
 // only surfaced when actually detected on the machine (see the load probe).
@@ -674,6 +684,17 @@ export function useAIChat() {
     void handleSend(prompt, { trigger: 'suggested' })
   }, [hasApiKey, analyticsContext, handleSend])
 
+  // D6: re-prompt the model to transform its previous answer (shorter,
+  // checklist, bullets, report). No new main-process call shape — it is a
+  // normal turn that leans on thread memory.
+  const transformAnswer = useCallback((kind: AnswerTransform) => {
+    if (!hasApiKey || loadingRef.current) return
+    const prompt = TRANSFORM_PROMPTS[kind]
+    if (!prompt) return
+    track(ANALYTICS_EVENT.AI_OUTPUT_REQUESTED, analyticsContext({ export_type: kind, trigger: 'transform' }))
+    void handleSend(prompt, { trigger: 'suggested' })
+  }, [hasApiKey, analyticsContext, handleSend])
+
   return {
     // state
     messages,
@@ -712,6 +733,7 @@ export function useAIChat() {
     handlePromptChipClick,
     switchProviderAndRetry,
     alternateProviders,
+    transformAnswer,
     analyticsContext,
   }
 }


### PR DESCRIPTION
## Why
Spec **D6**: Raycast offers post-answer "turn this into…" actions (Img 21/22). Daylens had copy/rate/retry; this adds the useful transforms.

## What
- On the latest answer: a **"Turn into…"** menu with **Make it shorter / checklist / bullets / report**.
- Same four also appear in the **⌘K palette** (D3 integration).
- Each transform is a **canned re-prompt** through the normal send pipeline — thread memory holds the answer, so the model rewrites it. **No new main-process surface**, nothing to maintain server-side, and it inherits R1 throttling + R4 error handling for free.

## Verification
`typecheck` ✅, `build:renderer` ✅.

## DO NOT REGRESS (spec §2)
Additive — copy/rate/retry and follow-up chips unchanged. Transforms reuse `handleSend`, so multi-turn memory and the Thinking caret behave exactly as before.

Base: `ai-d3-action-palette` — fifth in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive renderer-only UX that reuses existing chat send, throttling, and error handling; no auth, IPC shape, or data-model changes.
> 
> **Overview**
> Adds **post-answer transforms** on the latest assistant reply: **Make it shorter**, checklist, bullets, and report.
> 
> Users reach them via a **"Turn into…"** popover on that message’s action row and the same four actions in the **⌘K chat palette**. Each choice sends a **canned re-prompt** through the existing `handleSend` path (thread history supplies the prior answer), with **no new main-process API**. Analytics records transforms as `AI_OUTPUT_REQUESTED` with `trigger: 'transform'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6715d364b0a45aa981e9e2a8e216dabd539472e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->