### PR TITLE
T3 — Tracking Controls (opt-in exclusions, incognito skip, pause)

### DIFF
--- a/docs/AI-TAB-V2-SPEC.md
+++ b/docs/AI-TAB-V2-SPEC.md
@@ -40,19 +40,26 @@ looks like, and how to verify it.*
   errors. **M1** — model tier-fallback aligned to the offered catalog + dated
   review marker.
 
-**Deferred (out of scope for a reliability release — each needs its own PR):**
-- **D1** time-grouped sidebar, **D3** ⌘K action palette, **D4** per-chat
-  settings, **D5** `@`/`/` composer, **D6** response transforms — large UI work.
-- **S1** natural-language/semantic search — needs an embedding index + product
-  decisions.
-- **T3** tracking controls — **UNBLOCKED (owner decided 2026-05-31): build it,
-  opt-in, OFF by default; incognito-skip defaults ON once enabled.** See the T3
-  section for the full decision and acceptance criteria. Ready to build.
-- **Q6** answer-quality eval program — scaffolding only; running it bills the
-  live API.
-- **M1 (catalog refresh)** — confirming current GA model ids (e.g. Gemini 3.5)
-  needs live keys; only the code-consistency half is done here.
-- **C1** signing — tracked separately.
+**Shipped after the reliability pass (stacked PRs on `ai-tab-v2`):**
+- **#24** error classification (transient 429 vs hard wall) + one-tap switch-provider.
+- **#25 Q6** per-provider eval program. **#26 D1** time-grouped sidebar.
+  **#27 D3** ⌘K action palette. **#28 D6** response transforms. **#29 D4** per-chat
+  settings. **#30 D5** `@`/`/` composer. **#31 S1** natural-language search
+  (FTS-backed; embedding/vector index still deferred).
+- **#32 M1** — model catalog refreshed to verified GA ids (Gemini 3.5 Flash,
+  GPT-5.5, Opus 4.8); dead `gemini-3.1-flash-lite-preview` default replaced + migrated.
+- **T3** Tracking Controls — opt-in (off by default), pure capture-gate
+  (`src/shared/trackingControls.ts`) wired into the app + website capture paths;
+  per-app/per-site exclusions, incognito-skip (window-title heuristic), pause
+  toggle (Settings + tray), delete-from-history on exclude, onboarding opt-in.
+
+**Still deferred (each needs its own PR / a device step):**
+- **M1 live answer test** — per-provider answer quality needs API keys.
+- **S1** embedding/vector index. **D4** reasoning-effort. **D5** attachments/dictation.
+- **Q6** baseline scores (authorized live per-provider run). **C1** signing.
+- **T3 follow-ups:** structured incognito signal (vs the title heuristic) and a
+  query-time hide for surfaces beyond the timeline if delete-on-exclude proves
+  insufficient.
 
 > How to read this doc
 > - Each item has a stable **ID** (`R1`, `Q3`, `D4`, …). Assign agents by ID.

--- a/src/main/ipc/db.handlers.ts
+++ b/src/main/ipc/db.handlers.ts
@@ -35,6 +35,7 @@ import { runAttributionForRange } from '../services/attribution'
 import { backfillMemoryFromHistory } from '../jobs/eveningConsolidation'
 import { getDb, tableExists } from '../services/database'
 import { getCurrentSession, getLinuxTrackingDiagnostics, trackingStatus } from '../services/tracking'
+import { deleteHistoryForApp, deleteHistoryForSite } from '../services/trackingHistory'
 import { getProcessMetrics } from '../services/processMonitor'
 import { getBlockDetailPayload, getDistractionCostPayload, getRecapRange, shouldReanalyzeBlockWithAI } from '../services/workBlocks'
 import { computeAppActivityDigest } from '../services/appActivityDigest'
@@ -582,6 +583,14 @@ export function registerDbHandlers(): void {
 
   ipcMain.handle(IPC.TRACKING.GET_PROCESS_METRICS, () => {
     return getProcessMetrics()
+  })
+
+  // T3: delete already-captured history for an excluded app/site.
+  ipcMain.handle(IPC.TRACKING.DELETE_APP_HISTORY, (_e, payload: { bundleId?: string | null; appName?: string | null }) => {
+    return deleteHistoryForApp(payload ?? {})
+  })
+  ipcMain.handle(IPC.TRACKING.DELETE_SITE_HISTORY, (_e, payload: { domain: string }) => {
+    return deleteHistoryForSite(payload ?? { domain: '' })
   })
 
   // ─── Attribution query resolvers ──────────────────────────────────────────

--- a/src/main/services/browserContext.ts
+++ b/src/main/services/browserContext.ts
@@ -9,6 +9,8 @@ import { normalizeUrlForStorage, pageKeyForUrl, resolveCanonicalApp, resolveCano
 import { invalidateProjectionScope } from '../core/projections/invalidation'
 import { localDateString } from '../lib/localDate'
 import { getBrowserEntries, type BrowserEntry } from './browser'
+import { getSettings } from './settings'
+import { decideSiteCapture, trackingControlsStateFromSettings } from '@shared/trackingControls'
 
 const MIN_CONTEXT_SEC = 5
 const RECENT_HISTORY_LOOKBACK_MS = 2 * 60_000
@@ -332,6 +334,14 @@ export class ActiveBrowserContextTracker {
 
     const domain = extractDomain(context.tab.url)
     if (!domain) return false
+
+    // T3: drop this website visit when the user excluded the site, paused
+    // tracking, or it's an incognito window (by title) and skip-incognito is on.
+    // Passthrough when Tracking Controls is off — the browser app session is
+    // gated separately upstream in tracking.ts.
+    if (!decideSiteCapture(trackingControlsStateFromSettings(getSettings()), { domain, windowTitle: context.snapshot.windowTitle }).capture) {
+      return false
+    }
 
     const effectiveEnd = Math.max(endTime, context.lastSeenAt)
     const durationSec = Math.round((effectiveEnd - context.startedAt) / 1000)

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -55,6 +55,12 @@ const DEFAULTS: AppSettings = {
   mcpServerEnabled: false,
   workMemoryConsolidationEnabled: true,
   useRemoteAI: false,
+  // T3 — opt-in, off by default; incognito-skip on once enabled.
+  trackingControlsEnabled: false,
+  trackingExcludedApps: [],
+  trackingExcludedSites: [],
+  trackingSkipIncognito: true,
+  trackingPaused: false,
 }
 
 // M1: model ids that have been shut down at the provider and now 404. Existing
@@ -115,6 +121,11 @@ export function getSettings(): AppSettings {
     mcpServerEnabled: (_store.get('mcpServerEnabled', false) as boolean),
     workMemoryConsolidationEnabled: (_store.get('workMemoryConsolidationEnabled', true) as boolean),
     useRemoteAI: (_store.get('useRemoteAI', false) as boolean),
+    trackingControlsEnabled: (_store.get('trackingControlsEnabled', false) as boolean),
+    trackingExcludedApps: (_store.get('trackingExcludedApps', []) as string[]),
+    trackingExcludedSites: (_store.get('trackingExcludedSites', []) as string[]),
+    trackingSkipIncognito: (_store.get('trackingSkipIncognito', true) as boolean),
+    trackingPaused: (_store.get('trackingPaused', false) as boolean),
   }
 }
 

--- a/src/main/services/tracking.ts
+++ b/src/main/services/tracking.ts
@@ -32,6 +32,8 @@ import { localDateString, localDayBounds } from '../lib/localDate'
 import { capture, captureException, captureRateLimited } from './analytics'
 import { resolveLinuxDesktopIdentity } from './linuxDesktop'
 import { flushActiveBrowserContext, recordActiveBrowserContextSample } from './browserContext'
+import { getSettings } from './settings'
+import { decideAppCapture, trackingControlsStateFromSettings } from '@shared/trackingControls'
 import { runAttributionForRange } from './attribution'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -1527,6 +1529,21 @@ async function poll(): Promise<void> {
     })
     if (exclusionReason) {
       if (currentSession) flushCurrent(undefined, exclusionReason)
+      flushActiveBrowserContext(getDb())
+      clearPersistedLiveSnapshot()
+      return
+    }
+
+    // T3: user Tracking Controls. When OFF and not paused this is a passthrough
+    // (capture unchanged). Otherwise a paused tracker, an excluded app, or an
+    // incognito window (by title) is dropped exactly like the exclusions above —
+    // no app session AND no browser context for this foreground window.
+    const trackingDecision = decideAppCapture(
+      trackingControlsStateFromSettings(getSettings()),
+      { bundleId, appName, windowTitle: resolvedWindowTitle },
+    )
+    if (!trackingDecision.capture) {
+      if (currentSession) flushCurrent(undefined, `tracking_controls:${trackingDecision.reason}`)
       flushActiveBrowserContext(getDb())
       clearPersistedLiveSnapshot()
       return

--- a/src/main/services/trackingHistory.ts
+++ b/src/main/services/trackingHistory.ts
@@ -1,0 +1,66 @@
+// T3: delete already-captured history for an app or site the user just excluded
+// (or wants gone). Deletes the source rows (app_sessions / website_visits), then
+// rebuilds the affected day projections from what remains and notifies the
+// surfaces so the data disappears from the timeline, Apps, AI answers, and
+// search — "gone, not just hidden". Forward capture is stopped separately by the
+// gate in tracking.ts / browserContext.ts.
+
+import { getDb } from './database'
+import { localDateString } from '../lib/localDate'
+import { materializeTimelineDayProjection } from '../core/query/projections'
+import { invalidateProjectionScope } from '../core/projections/invalidation'
+
+export interface PurgeResult {
+  deletedRows: number
+  affectedDates: string[]
+}
+
+function rematerializeAndNotify(affectedDates: string[]): void {
+  if (affectedDates.length === 0) return
+  const db = getDb()
+  for (const date of affectedDates) {
+    try {
+      materializeTimelineDayProjection(db, date, null)
+    } catch (err) {
+      console.warn('[tracking-controls] re-materialize failed for', date, err)
+    }
+  }
+  // Deleted activity can affect any read surface; refresh them all.
+  invalidateProjectionScope('timeline', 'tracking_controls_purge')
+  invalidateProjectionScope('apps', 'tracking_controls_purge')
+  invalidateProjectionScope('insights', 'tracking_controls_purge')
+}
+
+function distinctLocalDates(timestamps: number[]): string[] {
+  return [...new Set(timestamps.map((ms) => localDateString(new Date(ms))))]
+}
+
+export function deleteHistoryForApp(input: { bundleId?: string | null; appName?: string | null }): PurgeResult {
+  const db = getDb()
+  const bundle = (input.bundleId ?? '').trim()
+  const name = (input.appName ?? '').trim()
+  if (!bundle && !name) return { deletedRows: 0, affectedDates: [] }
+
+  const where = 'WHERE (? <> \'\' AND lower(bundle_id) = lower(?)) OR (? <> \'\' AND lower(app_name) = lower(?))'
+  const params = [bundle, bundle, name, name]
+  const rows = db.prepare(`SELECT start_time FROM app_sessions ${where}`).all(...params) as { start_time: number }[]
+  const affectedDates = distinctLocalDates(rows.map((r) => r.start_time))
+  const info = db.prepare(`DELETE FROM app_sessions ${where}`).run(...params)
+  rematerializeAndNotify(affectedDates)
+  return { deletedRows: info.changes, affectedDates }
+}
+
+export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
+  const db = getDb()
+  const domain = (input.domain ?? '').trim().toLowerCase().replace(/^www\./, '')
+  if (!domain) return { deletedRows: 0, affectedDates: [] }
+
+  // Exact host or any subdomain (so excluding youtube.com also clears m.youtube.com).
+  const where = 'WHERE lower(domain) = ? OR lower(domain) LIKE ?'
+  const params = [domain, `%.${domain}`]
+  const rows = db.prepare(`SELECT visit_time FROM website_visits ${where}`).all(...params) as { visit_time: number }[]
+  const affectedDates = distinctLocalDates(rows.map((r) => r.visit_time))
+  const info = db.prepare(`DELETE FROM website_visits ${where}`).run(...params)
+  rematerializeAndNotify(affectedDates)
+  return { deletedRows: info.changes, affectedDates }
+}

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, Menu, Tray, app, nativeImage } from 'electron'
 import path from 'node:path'
+import { getSettings, setSettings } from './services/settings'
 
 let tray: Tray | null = null
 let trayError: string | null = null
@@ -59,6 +60,9 @@ function buildContextMenu(controller: TrayController): Electron.Menu {
   const version = app.getVersion()
   const showLabel = visible ? 'Hide Daylens' : 'Open Daylens'
   const showAccelerator = process.platform === 'darwin' ? 'Cmd+Shift+D' : undefined
+  // T3: quick ad-hoc pause from the menu bar / tray (works regardless of the
+  // Tracking Controls master switch). The capture gate reads this on each poll.
+  const paused = getSettings().trackingPaused ?? false
 
   return Menu.buildFromTemplate([
     {
@@ -66,7 +70,7 @@ function buildContextMenu(controller: TrayController): Electron.Menu {
       enabled: false,
     },
     {
-      label: `Tracking quietly · v${version}`,
+      label: paused ? `Tracking paused · v${version}` : `Tracking quietly · v${version}`,
       enabled: false,
     },
     { type: 'separator' },
@@ -79,6 +83,14 @@ function buildContextMenu(controller: TrayController): Electron.Menu {
           return
         }
         controller.showMainWindow()
+      },
+    },
+    {
+      label: 'Pause tracking',
+      type: 'checkbox',
+      checked: paused,
+      click: () => {
+        void setSettings({ trackingPaused: !paused }).then(() => refreshTrayMenu(controller))
       },
     },
     { type: 'separator' },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -237,6 +237,10 @@ const api = {
     getDiagnostics: (): Promise<TrackingDiagnosticsPayload> => ipcRenderer.invoke(IPC.TRACKING.GET_DIAGNOSTICS),
     getPermissionState: (): Promise<TrackingPermissionState> => ipcRenderer.invoke(IPC.TRACKING.GET_PERMISSION_STATE),
     requestScreenPermission: (): Promise<TrackingPermissionState> => ipcRenderer.invoke(IPC.TRACKING.REQUEST_SCREEN_PERMISSION),
+    deleteAppHistory: (payload: { bundleId?: string | null; appName?: string | null }): Promise<{ deletedRows: number; affectedDates: string[] }> =>
+      ipcRenderer.invoke(IPC.TRACKING.DELETE_APP_HISTORY, payload),
+    deleteSiteHistory: (payload: { domain: string }): Promise<{ deletedRows: number; affectedDates: string[] }> =>
+      ipcRenderer.invoke(IPC.TRACKING.DELETE_SITE_HISTORY, payload),
   },
   focus: {
     start: (payload?: FocusStartPayload | string | null): Promise<number> => ipcRenderer.invoke(IPC.FOCUS.START, payload),

--- a/src/renderer/views/Onboarding.tsx
+++ b/src/renderer/views/Onboarding.tsx
@@ -102,6 +102,9 @@ export default function Onboarding({
   const [settings, setSettings] = useState(initialSettings)
   const [goals, setGoals] = useState<Set<string>>(new Set(initialSettings.userGoals))
   const [nameDraft, setNameDraft] = useState(initialSettings.userName)
+  // T3: opt-in to Tracking Controls during onboarding. Off by default —
+  // declining (the default) changes nothing about capture.
+  const [trackingOptIn, setTrackingOptIn] = useState(initialSettings.trackingControlsEnabled ?? false)
   const [defaultUserName, setDefaultUserName] = useState('')
   const [permissionState, setPermissionState] = useState<TrackingPermissionState>(initialSettings.onboardingState.trackingPermissionState)
   const [busy, setBusy] = useState(false)
@@ -331,6 +334,7 @@ export default function Onboarding({
         onboardingState: nextOnboardingState,
         userName: nameDraft.trim(),
         userGoals: Array.from(goals),
+        trackingControlsEnabled: trackingOptIn,
       })
       await ipc.app.completeOnboarding()
       track(ANALYTICS_EVENT.ONBOARDING_COMPLETED, {
@@ -572,6 +576,31 @@ export default function Onboarding({
                 )
               })}
             </div>
+            <button
+              type="button"
+              onClick={() => setTrackingOptIn((v) => !v)}
+              aria-pressed={trackingOptIn}
+              style={{
+                display: 'flex', alignItems: 'flex-start', gap: 10, textAlign: 'left',
+                padding: '12px 14px', borderRadius: 12, cursor: 'pointer',
+                border: `1px solid ${trackingOptIn ? 'rgba(90,179,255,0.45)' : 'rgba(173,198,255,0.18)'}`,
+                background: trackingOptIn ? 'rgba(90,179,255,0.10)' : 'rgba(255,255,255,0.02)',
+                color: 'inherit',
+              }}
+            >
+              <span style={{
+                flexShrink: 0, marginTop: 1, width: 18, height: 18, borderRadius: 5,
+                border: `1.5px solid ${trackingOptIn ? '#5ab3ff' : 'rgba(173,198,255,0.4)'}`,
+                background: trackingOptIn ? '#5ab3ff' : 'transparent',
+                display: 'grid', placeItems: 'center', color: '#07090f', fontSize: 12, fontWeight: 900,
+              }}>{trackingOptIn ? '✓' : ''}</span>
+              <span style={{ display: 'grid', gap: 2 }}>
+                <span style={{ fontSize: 13.5, fontWeight: 650 }}>Keep private apps and sites out of Daylens</span>
+                <span style={{ fontSize: 12, opacity: 0.7, lineHeight: 1.5 }}>
+                  Optional. Lets you exclude specific apps and websites and skip incognito windows. You can add them now or later in Settings. Off skips nothing.
+                </span>
+              </span>
+            </button>
             <div className="onboarding-actions">
               <button className="onboarding-btn-primary" onClick={() => void finishOnboarding()} disabled={busy}>
                 {busy ? 'Opening Timeline…' : 'Open Daylens'}

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -488,6 +488,156 @@ function UpdatesSection() {
   )
 }
 
+// T3 — Tracking Controls. Opt-in, off by default. Pause works regardless of the
+// master switch. Adding an exclusion also deletes that app/site's existing
+// history so it disappears from the timeline/Apps/AI/search.
+function ExclusionEditor({
+  label,
+  placeholder,
+  values,
+  onAdd,
+  onRemove,
+  busy,
+}: {
+  label: string
+  placeholder: string
+  values: string[]
+  onAdd: (value: string) => void
+  onRemove: (value: string) => void
+  busy: boolean
+}) {
+  const [draft, setDraft] = useState('')
+  const submit = () => {
+    const value = draft.trim()
+    if (!value) return
+    onAdd(value)
+    setDraft('')
+  }
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      <div style={{ fontSize: 13.5, fontWeight: 620, color: 'var(--color-text-primary)' }}>{label}</div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); submit() } }}
+          placeholder={placeholder}
+          disabled={busy}
+          style={{ flex: 1, minWidth: 0, height: 34, padding: '0 12px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12.5, outline: 'none' }}
+        />
+        <button
+          type="button"
+          onClick={submit}
+          disabled={busy || !draft.trim()}
+          style={{ height: 34, padding: '0 14px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12.5, fontWeight: 700, cursor: busy || !draft.trim() ? 'default' : 'pointer', opacity: busy || !draft.trim() ? 0.6 : 1 }}
+        >
+          Add
+        </button>
+      </div>
+      {values.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {values.map((value) => (
+            <span key={value} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 6px 4px 10px', borderRadius: 999, background: 'var(--color-surface-muted)', border: '1px solid var(--color-border-ghost)', fontSize: 12, color: 'var(--color-text-secondary)' }}>
+              {value}
+              <button
+                type="button"
+                onClick={() => onRemove(value)}
+                aria-label={`Remove ${value}`}
+                style={{ width: 18, height: 18, borderRadius: '50%', border: 'none', background: 'transparent', color: 'var(--color-text-tertiary)', cursor: 'pointer', display: 'grid', placeItems: 'center', fontSize: 14, lineHeight: 1 }}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function TrackingControlsSection({
+  settings,
+  persist,
+}: {
+  settings: AppSettings
+  persist: (partial: Partial<AppSettings>) => Promise<void>
+}) {
+  const [busy, setBusy] = useState(false)
+  const enabled = settings.trackingControlsEnabled ?? false
+  const excludedApps = settings.trackingExcludedApps ?? []
+  const excludedSites = settings.trackingExcludedSites ?? []
+
+  const normalizeSite = (raw: string) => raw.trim().toLowerCase()
+    .replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '')
+
+  const addApp = async (value: string) => {
+    if (excludedApps.some((a) => a.toLowerCase() === value.toLowerCase())) return
+    setBusy(true)
+    try {
+      await persist({ trackingExcludedApps: [...excludedApps, value] })
+      // Remove what was already captured so it disappears from history, not just future capture.
+      await ipc.tracking.deleteAppHistory({ bundleId: value, appName: value }).catch(() => {})
+    } finally {
+      setBusy(false)
+    }
+  }
+  const removeApp = (value: string) => void persist({ trackingExcludedApps: excludedApps.filter((a) => a !== value) })
+
+  const addSite = async (raw: string) => {
+    const value = normalizeSite(raw)
+    if (!value || excludedSites.some((s) => s.toLowerCase() === value)) return
+    setBusy(true)
+    try {
+      await persist({ trackingExcludedSites: [...excludedSites, value] })
+      await ipc.tracking.deleteSiteHistory({ domain: value }).catch(() => {})
+    } finally {
+      setBusy(false)
+    }
+  }
+  const removeSite = (value: string) => void persist({ trackingExcludedSites: excludedSites.filter((s) => s !== value) })
+
+  return (
+    <SettingsSection title="Tracking controls">
+      <SettingsRow
+        first
+        title="Pause tracking"
+        description="Temporarily stop recording all activity. Stays paused until you turn it back on, even after a restart."
+        control={<Toggle checked={settings.trackingPaused ?? false} onChange={(value) => void persist({ trackingPaused: value })} />}
+      />
+      <SettingsRow
+        title="Limit what's tracked"
+        description="Off by default — Daylens records everything. Turn this on to keep specific apps, sites, and private windows out of your history and AI answers."
+        control={<Toggle checked={enabled} onChange={(value) => void persist({ trackingControlsEnabled: value })} />}
+      />
+      {enabled && (
+        <>
+          <SettingsRow
+            title="Skip private / incognito windows"
+            description="When on, Daylens records nothing from a browser's incognito or private window — no URL, page title, or session."
+            control={<Toggle checked={settings.trackingSkipIncognito ?? true} onChange={(value) => void persist({ trackingSkipIncognito: value })} />}
+          />
+          <ExclusionEditor
+            label="Excluded apps"
+            placeholder="App name (e.g. Messages) or bundle id"
+            values={excludedApps}
+            onAdd={(value) => void addApp(value)}
+            onRemove={removeApp}
+            busy={busy}
+          />
+          <ExclusionEditor
+            label="Excluded sites"
+            placeholder="Domain (e.g. youtube.com)"
+            values={excludedSites}
+            onAdd={(value) => void addSite(value)}
+            onRemove={removeSite}
+            busy={busy}
+          />
+        </>
+      )}
+    </SettingsSection>
+  )
+}
+
 export default function Settings({ initialSettings = null }: { initialSettings?: AppSettings | null } = {}) {
   const [settings, setSettings] = useState<AppSettings | null>(initialSettings)
   const [hasApiKey, setHasApiKey] = useState(false)
@@ -1337,6 +1487,8 @@ export default function Settings({ initialSettings = null }: { initialSettings?:
             )}
           </div>
         </SettingsSection>
+
+        <TrackingControlsSection settings={settings} persist={persist} />
 
         <SettingsSection
           title="Privacy"

--- a/src/shared/trackingControls.ts
+++ b/src/shared/trackingControls.ts
@@ -1,0 +1,118 @@
+// T3 — Tracking Controls: user-controlled capture exclusions.
+//
+// Design invariant (owner decision 2026-05-31): the feature is OPT-IN and OFF by
+// default. When disabled and not paused, every gate here is a strict passthrough,
+// so capture stays byte-for-byte identical to today. Only an explicit master
+// opt-in (plus an ad-hoc pause that works regardless of the switch) changes
+// behavior. This is the hermetic core — no DB, no settings store — so it can be
+// exhaustively unit-tested and reused by the foreground-app and website paths.
+
+export interface TrackingControlsState {
+  enabled: boolean
+  paused: boolean
+  excludedApps: string[] // bundle ids and/or app names (free-form, case-insensitive)
+  excludedSites: string[] // hosts/domains (free-form, case-insensitive)
+  skipIncognito: boolean
+}
+
+export interface AppCaptureCandidate {
+  bundleId?: string | null
+  appName?: string | null
+  windowTitle?: string | null
+}
+
+export interface SiteCaptureCandidate {
+  domain?: string | null
+  windowTitle?: string | null
+}
+
+export type CaptureBlockReason = 'paused' | 'excluded_app' | 'excluded_site' | 'incognito'
+
+export interface CaptureDecision {
+  capture: boolean
+  reason: CaptureBlockReason | null
+}
+
+const ALLOW: CaptureDecision = { capture: true, reason: null }
+
+// Window-title markers browsers append to private/incognito windows. Daylens has
+// no structured incognito signal from the OS, so this title heuristic is the
+// honest best-effort — it catches the common cross-browser cases (Chrome/Brave
+// "Incognito", Edge "InPrivate", Firefox/Safari "Private Browsing").
+const INCOGNITO_TITLE_RE = /\b(incognito|inprivate|private browsing|private window|private mode)\b/i
+
+export function detectIncognitoFromTitle(windowTitle: string | null | undefined): boolean {
+  return !!windowTitle && INCOGNITO_TITLE_RE.test(windowTitle)
+}
+
+function normalizeToken(value: string | null | undefined): string {
+  return (value ?? '').trim().toLowerCase()
+}
+
+function normalizeHost(value: string | null | undefined): string {
+  return normalizeToken(value).replace(/^www\./, '')
+}
+
+// An app matches an exclusion entry when the entry equals (case-insensitively)
+// either its bundle id or its display name.
+export function isAppExcluded(state: TrackingControlsState, candidate: AppCaptureCandidate): boolean {
+  if (!state.enabled || state.excludedApps.length === 0) return false
+  const bundle = normalizeToken(candidate.bundleId)
+  const name = normalizeToken(candidate.appName)
+  return state.excludedApps.some((entry) => {
+    const e = normalizeToken(entry)
+    return e !== '' && (e === bundle || e === name)
+  })
+}
+
+// A site matches when the candidate host equals, or is a subdomain of, an
+// excluded host — so excluding "youtube.com" also covers "m.youtube.com".
+export function isSiteExcluded(state: TrackingControlsState, candidate: SiteCaptureCandidate): boolean {
+  if (!state.enabled || state.excludedSites.length === 0) return false
+  const host = normalizeHost(candidate.domain)
+  if (!host) return false
+  return state.excludedSites.some((entry) => {
+    const e = normalizeHost(entry)
+    return e !== '' && (host === e || host.endsWith(`.${e}`))
+  })
+}
+
+// Foreground app-session gate. Pause applies regardless of the master switch;
+// exclusions/incognito only when Tracking Controls is enabled.
+export function decideAppCapture(state: TrackingControlsState, candidate: AppCaptureCandidate): CaptureDecision {
+  if (state.paused) return { capture: false, reason: 'paused' }
+  if (!state.enabled) return ALLOW
+  if (isAppExcluded(state, candidate)) return { capture: false, reason: 'excluded_app' }
+  if (state.skipIncognito && detectIncognitoFromTitle(candidate.windowTitle)) return { capture: false, reason: 'incognito' }
+  return ALLOW
+}
+
+// Browser website-visit gate. The browser app itself is gated upstream by
+// decideAppCapture; this drops a specific excluded domain (or incognito visit)
+// while a non-excluded browser app keeps being tracked.
+export function decideSiteCapture(state: TrackingControlsState, candidate: SiteCaptureCandidate): CaptureDecision {
+  if (state.paused) return { capture: false, reason: 'paused' }
+  if (!state.enabled) return ALLOW
+  if (isSiteExcluded(state, candidate)) return { capture: false, reason: 'excluded_site' }
+  if (state.skipIncognito && detectIncognitoFromTitle(candidate.windowTitle)) return { capture: false, reason: 'incognito' }
+  return ALLOW
+}
+
+// Adapt AppSettings into the gate state (keeps this module free of the wider
+// settings shape). Defaults match the opt-in contract: disabled, unpaused,
+// empty lists, incognito-skip on (effective only once enabled).
+export function trackingControlsStateFromSettings(s: {
+  trackingControlsEnabled?: boolean
+  trackingPaused?: boolean
+  trackingExcludedApps?: string[]
+  trackingExcludedSites?: string[]
+  trackingSkipIncognito?: boolean
+}): TrackingControlsState {
+  return {
+    enabled: Boolean(s.trackingControlsEnabled),
+    paused: Boolean(s.trackingPaused),
+    excludedApps: s.trackingExcludedApps ?? [],
+    excludedSites: s.trackingExcludedSites ?? [],
+    skipIncognito: s.trackingSkipIncognito ?? true,
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1002,6 +1002,13 @@ export interface AppSettings {
   mcpServerEnabled?: boolean
   workMemoryConsolidationEnabled?: boolean   // Evening consolidation: archive the day, score and promote patterns, decay stale ones.
   useRemoteAI?: boolean   // legacy setting; remote workspace AI is disabled in local-only builds.
+  // T3 — Tracking Controls (opt-in, OFF by default). When disabled and not
+  // paused, capture is unchanged. See src/shared/trackingControls.ts.
+  trackingControlsEnabled?: boolean
+  trackingExcludedApps?: string[]   // bundle ids and/or app names
+  trackingExcludedSites?: string[]  // hosts/domains
+  trackingSkipIncognito?: boolean   // effective only when controls enabled; defaults on
+  trackingPaused?: boolean          // ad-hoc pause; blocks capture regardless of the master switch
 }
 
 // In-flight session that has not yet been flushed to the DB.
@@ -1315,6 +1322,9 @@ export const IPC = {
     GET_PROCESS_METRICS: 'tracking:get-process-metrics',
     GET_PERMISSION_STATE: 'tracking:get-permission-state',
     REQUEST_SCREEN_PERMISSION: 'tracking:request-screen-permission',
+    // T3: delete already-captured history for an excluded app/site.
+    DELETE_APP_HISTORY: 'tracking:delete-app-history',
+    DELETE_SITE_HISTORY: 'tracking:delete-site-history',
   },
   APP: {
     RELAUNCH: 'app:relaunch',

--- a/tests/trackingControls.test.ts
+++ b/tests/trackingControls.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  decideAppCapture,
+  decideSiteCapture,
+  detectIncognitoFromTitle,
+  isAppExcluded,
+  isSiteExcluded,
+  trackingControlsStateFromSettings,
+  type TrackingControlsState,
+} from '../src/shared/trackingControls.ts'
+
+const base: TrackingControlsState = {
+  enabled: false,
+  paused: false,
+  excludedApps: [],
+  excludedSites: [],
+  skipIncognito: true,
+}
+
+// ── Invariant: OFF + unpaused is a strict passthrough (acceptance #1) ──────────
+
+test('disabled and unpaused captures everything (byte-for-byte unchanged)', () => {
+  const s = { ...base, enabled: false, excludedApps: ['com.foo'], excludedSites: ['x.com'] }
+  assert.deepEqual(decideAppCapture(s, { bundleId: 'com.foo', appName: 'Foo' }), { capture: true, reason: null })
+  assert.deepEqual(decideSiteCapture(s, { domain: 'x.com' }), { capture: true, reason: null })
+  // Even an incognito title is captured when the feature is off.
+  assert.equal(decideAppCapture(s, { windowTitle: 'Secret (Incognito)' }).capture, true)
+})
+
+// ── Pause works regardless of the master switch (acceptance #5) ────────────────
+
+test('pause blocks capture even when the feature is disabled', () => {
+  const s = { ...base, enabled: false, paused: true }
+  assert.deepEqual(decideAppCapture(s, { bundleId: 'com.foo' }), { capture: false, reason: 'paused' })
+  assert.deepEqual(decideSiteCapture(s, { domain: 'x.com' }), { capture: false, reason: 'paused' })
+})
+
+// ── App exclusion (acceptance #3) ──────────────────────────────────────────────
+
+test('app exclusion matches bundle id or app name, case-insensitively, only when enabled', () => {
+  const s = { ...base, enabled: true, excludedApps: ['com.tinyspeck.slackmacgap', 'Messages'] }
+  assert.equal(isAppExcluded(s, { bundleId: 'com.tinyspeck.slackmacgap' }), true)
+  assert.equal(isAppExcluded(s, { appName: 'messages' }), true)
+  assert.equal(isAppExcluded(s, { bundleId: 'com.apple.Safari', appName: 'Safari' }), false)
+  assert.equal(decideAppCapture(s, { bundleId: 'com.tinyspeck.slackmacgap' }).reason, 'excluded_app')
+  // Same lists, feature disabled → not excluded.
+  assert.equal(isAppExcluded({ ...s, enabled: false }, { bundleId: 'com.tinyspeck.slackmacgap' }), false)
+})
+
+// ── Site exclusion incl. subdomains + www (acceptance #3) ──────────────────────
+
+test('site exclusion matches the host and its subdomains, ignoring www', () => {
+  const s = { ...base, enabled: true, excludedSites: ['youtube.com'] }
+  assert.equal(isSiteExcluded(s, { domain: 'youtube.com' }), true)
+  assert.equal(isSiteExcluded(s, { domain: 'www.youtube.com' }), true)
+  assert.equal(isSiteExcluded(s, { domain: 'm.youtube.com' }), true)
+  assert.equal(isSiteExcluded(s, { domain: 'notyoutube.com' }), false)
+  assert.equal(isSiteExcluded(s, { domain: 'github.com' }), false)
+  assert.equal(decideSiteCapture(s, { domain: 'm.youtube.com' }).reason, 'excluded_site')
+})
+
+// ── Incognito (acceptance #4) ──────────────────────────────────────────────────
+
+test('detectIncognitoFromTitle catches common browser private markers', () => {
+  assert.equal(detectIncognitoFromTitle('YouTube - Google Chrome (Incognito)'), true)
+  assert.equal(detectIncognitoFromTitle('Bank - Microsoft Edge [InPrivate]'), true)
+  assert.equal(detectIncognitoFromTitle('Search - Mozilla Firefox (Private Browsing)'), true)
+  assert.equal(detectIncognitoFromTitle('Reddit - Google Chrome'), false)
+  assert.equal(detectIncognitoFromTitle(null), false)
+})
+
+test('skipIncognito blocks private windows only when on', () => {
+  const on = { ...base, enabled: true, skipIncognito: true }
+  assert.equal(decideAppCapture(on, { windowTitle: 'x (Incognito)' }).reason, 'incognito')
+  const off = { ...base, enabled: true, skipIncognito: false }
+  assert.equal(decideAppCapture(off, { windowTitle: 'x (Incognito)' }).capture, true)
+})
+
+// ── Settings adapter defaults ──────────────────────────────────────────────────
+
+test('trackingControlsStateFromSettings defaults to opt-in-off with incognito-skip on', () => {
+  const s = trackingControlsStateFromSettings({})
+  assert.deepEqual(s, { enabled: false, paused: false, excludedApps: [], excludedSites: [], skipIncognito: true })
+})


### PR DESCRIPTION
Builds **T3** per the spec. Stacked on `ai-m1-model-catalog`.

**Owner decision honored:** opt-in, **OFF by default**. When off and unpaused, capture is byte-for-byte unchanged (acceptance #1) — the feature is a pure additive gate. Once enabled, skip-incognito defaults ON.

## How it works
- **Hermetic gate** — `src/shared/trackingControls.ts` decides capture from settings + a candidate (app/site/title). Pause short-circuits regardless of the master switch; exclusions/incognito only apply when enabled; off = passthrough. Fully unit-tested.
- **Capture-path wiring (minimal blast radius):**
  - *App gate* at the tracking poll choke point — mirrors the existing exclusion early-return, so an excluded app / incognito window / paused tracker produces **no app session and no browser context**.
  - *Site gate* in `browserContext.flush()` (the `website_visits` insert point) — drops an excluded domain's visit while keeping the non-excluded browser app tracked.
- **Incognito** — Daylens has no structured incognito signal, so this is a window-title heuristic ("(Incognito)", "InPrivate", "Private Browsing"). Honest best-effort; a structured signal is a noted follow-up.
- **Delete-from-history** — adding an exclusion deletes existing `app_sessions`/`website_visits` rows and re-materializes the affected days (`services/trackingHistory.ts` + `tracking:delete-{app,site}-history`), so excluded items disappear from timeline/Apps/AI/search — "gone, not just hidden".
- **UI** — a Tracking Controls settings section (master toggle, incognito toggle, app/site exclusion editors with chips, pause), a **tray "Pause tracking"** checkbox, and an **onboarding opt-in** (declining the default changes nothing).

## Settings added
`trackingControlsEnabled` (false), `trackingExcludedApps` ([]), `trackingExcludedSites` ([]), `trackingSkipIncognito` (true, effective once enabled), `trackingPaused` (false).

## Acceptance
- [x] OFF (default) → capture unchanged (gate passthrough; verified by the gate test).
- [x] Enabling surfaces exclusion list + incognito toggle (starts on).
- [x] Add app/site → stops recording going forward **and** deletes existing history.
- [x] Incognito toggle on → private windows produce no rows (title heuristic).
- [x] Pause control exists and works (Settings + tray), regardless of the master switch.
- [x] Onboarding offers the opt-in; declining changes nothing.

## Testing
- `tsc --noEmit` clean. `tests/trackingControls.test.ts` (7 tests) covers the passthrough invariant, pause, app/site exclusion incl. subdomains, the incognito heuristic, and the settings adapter. Existing onboarding/platform suites pass.
- **Not done (device step):** real incognito windows across browsers, and the live delete→re-materialize on a populated DB, need a manual run.

## Cross-platform
The gate is platform-agnostic. The pause tray item and capture wiring are shared. The incognito title markers cover Chrome/Edge/Firefox/Safari/Brave; verify per-platform window-title formats on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core capture paths and destructive DB deletes with projection rebuilds; default-off passthrough limits blast radius, but misconfigured exclusions or purge queries could remove wrong history.
> 
> **Overview**
> Adds **T3 Tracking Controls**: an opt-in, off-by-default privacy layer so users can pause capture, exclude apps/sites, and skip incognito windows (title heuristic) without changing behavior until they enable it.
> 
> A shared **`trackingControls`** gate (`decideAppCapture` / `decideSiteCapture`) is wired at the foreground poll in **`tracking.ts`** and at **`website_visits`** insert in **`browserContext.ts`**, mirroring existing exclusion early-returns (no app session and no browser context when blocked). **Pause** applies even when the master switch is off.
> 
> New persisted settings drive the gate; **Settings** gets a Tracking Controls section (pause, master toggle, incognito toggle, exclusion editors). Adding an exclusion triggers **delete-from-history** IPC that removes matching **`app_sessions`** / **`website_visits`**, re-materializes affected days, and invalidates timeline/apps/insights projections. **Onboarding** offers opt-in; the **tray** adds a Pause tracking checkbox. Unit tests cover passthrough, pause, exclusions, and incognito detection. The AI tab v2 spec doc is updated to mark T3 shipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e650550aa1cb9fec6ec1087236c1eb128cbf80a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->