### PR TITLE
Audit fixes: DST-safe day arithmetic + timeline invariant enforcement

### DIFF
--- a/src/main/lib/localDate.ts
+++ b/src/main/lib/localDate.ts
@@ -18,3 +18,8 @@ export function daysFromTodayLocalDateString(offsetDays: number): string {
     new Date(today.getFullYear(), today.getMonth(), today.getDate() + offsetDays),
   )
 }
+
+export function shiftLocalDateString(dateStr: string, offsetDays: number): string {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  return localDateString(new Date(year, month - 1, day + offsetDays))
+}

--- a/src/main/services/dailySummaryNotifier.ts
+++ b/src/main/services/dailySummaryNotifier.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { BrowserWindow, Notification, app, nativeImage } from 'electron'
 import { getSessionsForRange } from '../db/queries'
-import { localDateString, localDayBounds } from '../lib/localDate'
+import { localDateString, localDayBounds, shiftLocalDateString } from '../lib/localDate'
 import { getDb } from './database'
 import { getSettings } from './settings'
 import { prepareDailyReport } from './ai'
@@ -192,7 +192,7 @@ async function checkMorningNudge(): Promise<void> {
   const settings = getSettings()
   const now = new Date()
   const today = localDateString(now)
-  const yesterday = localDateString(new Date(now.getTime() - 86_400_000))
+  const yesterday = shiftLocalDateString(today, -1)
   const state = readState()
 
   const decision = decideMorningNudge({
@@ -231,7 +231,7 @@ export async function fireTestDailyNotification(): Promise<{ ok: boolean; reason
 
   const now = new Date()
   const today = localDateString(now)
-  const yesterday = localDateString(new Date(now.getTime() - 86_400_000))
+  const yesterday = shiftLocalDateString(today, -1)
   const isMorning = now.getHours() < 12
   const targetDate = isMorning ? yesterday : today
 

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -98,7 +98,6 @@ function sanitizeBlockLabel(label: string | null | undefined): string | null {
 }
 
 const IDLE_GAP_THRESHOLD_MS = 15 * 60_000
-const RUNAWAY_GAP_THRESHOLD_MS = 40 * 60_000
 const MEETING_THRESHOLD_SEC = 20 * 60
 const LONG_SINGLE_APP_THRESHOLD_SEC = 45 * 60
 const BRIEF_INTERRUPTION_THRESHOLD_SEC = 3 * 60
@@ -181,6 +180,9 @@ interface CandidateBlock {
   formation: FormationReason
   boundedBeforeGap: boolean
   boundedAfterGap: boolean
+  // A brief detour may be absorbed into one neighboring intent without
+  // joining two genuinely different intents around it.
+  forcedBoundaryBefore?: boolean
   forcedLabel?: string
   // Set by the boundary-scoring reconciliation pass: why this candidate's
   // start and end edges were cut. Projected onto the block as `boundary`.
@@ -569,12 +571,11 @@ function coarseSegmentsFromSessions(db: Database.Database, sessions: AppSession[
     const current = sessions[index]
     const previousEnd = sessionEndMs(previous)
     const gap = current.startTime - previousEnd
-    // A logged sleep/lock/away event makes a >15-min gap a hard boundary. But a
-    // long quiet stretch with no logged event is still idle — runaway guard: a
-    // 40-min+ gap is treated as idle on its own so a browser session left open
-    // across an afternoon cannot stretch one episode over an 8-hour span.
-    const isRunawayGap = gap >= RUNAWAY_GAP_THRESHOLD_MS
-    if (gap > IDLE_GAP_THRESHOLD_MS && (isRunawayGap || gapHasHardActivityBoundary(db, previousEnd, current.startTime))) {
+    // timeline.md §3.1: a roughly 15-minute idle/lock gap is a strong boundary
+    // on its own. Activity-state events can also force a boundary for shorter
+    // gaps; missing telemetry must never make a 15+ minute absence disappear.
+    const hasHardActivityBoundary = gapHasHardActivityBoundary(db, previousEnd, current.startTime)
+    if (gap >= IDLE_GAP_THRESHOLD_MS || hasHardActivityBoundary) {
       segments.push({
         sessions: sessions.slice(startIndex, index),
         boundedBeforeGap: startIndex > 0,
@@ -2457,6 +2458,7 @@ function mergeCandidatePair(left: CandidateBlock, right: CandidateBlock): Candid
     formation: 'heuristic',
     boundedBeforeGap: left.boundedBeforeGap,
     boundedAfterGap: right.boundedAfterGap,
+    forcedBoundaryBefore: left.forcedBoundaryBefore,
   }
 }
 
@@ -2849,6 +2851,9 @@ function scoreBoundary(
   // A user merge erases this boundary and overrides every heuristic below it,
   // including a kind change — the user's intent always wins over segmentation.
   if (corrections.lookup(left, right) === 'merge') return { score: -BOUNDARY_HARD_SCORE, reasons: [] }
+  if (right.forcedBoundaryBefore) {
+    return { score: BOUNDARY_HARD_SCORE, reasons: ['subject-change'] }
+  }
 
   // Hard cuts — never erased.
   // A kind change (work↔leisure↔personal) is the hardest boundary of all: it is
@@ -2959,15 +2964,24 @@ function foldBriefPeeks(candidates: CandidateBlock[], db: Database.Database, con
     // `left` is read from the running result so a chain (work / peek / work /
     // peek / work) collapses in one forward pass.
     const isWorkAnchor = (mode: RunMode | undefined): boolean =>
-      mode === 'execution' || mode === 'research'
+      mode === 'execution' || mode === 'research' || mode === 'admin'
     const noIdleGapAround = Boolean(
       left && right
       && current.formation !== 'meeting'
       && isWorkAnchor(leftSig?.mode)
       && isWorkAnchor(rightSig?.mode)
+      && !(left.boundedAfterGap && current.boundedBeforeGap)
+      && !(current.boundedAfterGap && right.boundedBeforeGap)
       && gapBetweenCandidates(left, current) < TIMELINE_SAME_WORK_BRIDGE_GAP_MS
       && gapBetweenCandidates(current, right) < TIMELINE_SAME_WORK_BRIDGE_GAP_MS,
     )
+    const sameIntentAround = Boolean(left && right && (
+      candidatesAreAssistedWorkPair(left, right, db, context)
+      || (
+        candidateDominantCategory(left, db, context) === candidateDominantCategory(right, db, context)
+        && dominantContentContext(left.sessions) === dominantContentContext(right.sessions)
+      )
+    ))
     // The research-peek fold (a) is conservative: it requires the SAME app on
     // both sides (look up a PR in the editor's browser, back to the editor).
     const sandwichedBySameWork = noIdleGapAround
@@ -2980,6 +2994,7 @@ function foldBriefPeeks(candidates: CandidateBlock[], db: Database.Database, con
     // then merge on app continuity in scoring.
     const researchPeek =
       sandwichedBySameWork
+      && sameIntentAround
       && briefMiddle
       && candidatesShareKind(left, current, context)
       && signals[index].mode === 'research'
@@ -3000,16 +3015,37 @@ function foldBriefPeeks(candidates: CandidateBlock[], db: Database.Database, con
     // brief Netflix peek pollutes the merged block's dominant app, so insisting
     // on it would strand the next sliver. Bounded to under the §3.2 cutoff and
     // the coherent span ceiling so a *sustained* detour still stands alone.
-    const driftPeek =
+    const briefDetour =
       noIdleGapAround
       && briefMiddle
       && (signals[index].mode === 'drift' || signals[index].mode === 'browse')
       && combinedSpanMs(left, right) <= TIMELINE_MAX_COHERENT_BLOCK_SPAN_MS
-    if (driftPeek && right) {
-      const fused = mergeCandidatePair(mergeCandidatePair(left, current), right)
-      result[result.length - 1] = fused
-      sig[sig.length - 1] = runSignalsFor(fused, db, context)
-      index += 1 // `right` is already fused in — consume it
+    if (briefDetour && right) {
+      if (sameIntentAround) {
+        const fused = mergeCandidatePair(mergeCandidatePair(left, current), right)
+        result[result.length - 1] = fused
+        sig[sig.length - 1] = runSignalsFor(fused, db, context)
+        index += 1 // `right` is already fused in — consume it
+        continue
+      }
+
+      // The activity on either side is genuinely different. The detour still
+      // must not become its own block, but absorbing it must preserve the real
+      // intent boundary. Attach it to the stronger adjacent anchor only.
+      if (candidateActiveMs(left) >= candidateActiveMs(right)) {
+        const absorbedLeft = mergeCandidatePair(left, current)
+        result[result.length - 1] = absorbedLeft
+        sig[sig.length - 1] = runSignalsFor(absorbedLeft, db, context)
+        candidates[index + 1] = { ...right, forcedBoundaryBefore: true }
+      } else {
+        const absorbedRight = {
+          ...mergeCandidatePair(current, right),
+          forcedBoundaryBefore: true,
+        }
+        result.push(absorbedRight)
+        sig.push(runSignalsFor(absorbedRight, db, context))
+        index += 1
+      }
       continue
     }
 
@@ -4481,7 +4517,10 @@ export function getTimelineDayPayload(
     : buildTimelineBlocksForDay(db, dateStr, sessions, options)
   const focusSessions = getFocusSessionsForDateRange(db, fromMs, toMs)
   const segments = buildSegmentsForDay(db, dateStr, blocks)
-  const totalSeconds = sessions.reduce((sum, session) => sum + session.durationSeconds, 0)
+  // Invariant 7: the blocks are the canonical day facts. Every downstream
+  // total (Timeline, Apps, AI, recap) reads this same partition instead of
+  // independently summing raw sessions.
+  const totalSeconds = blocks.reduce((sum, block) => sum + blockActiveSeconds(block), 0)
   const focusSeconds = sessions
     .filter((session) => session.isFocused)
     .reduce((sum, session) => sum + session.durationSeconds, 0)

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -15,7 +15,7 @@ import {
   Timer,
 } from 'lucide-react'
 import { ipc } from '../lib/ipc'
-import { dateStringFromMs, todayString } from '../lib/format'
+import { shiftDateString, todayString } from '../lib/format'
 import {
   dedupeAndRankResults,
   isNaturalQuery,
@@ -215,7 +215,7 @@ export default function CommandPalette({ isOpen, platform, onClose, onOpenWrappe
     { id: 'nav-ai', group: 'Navigate', label: 'Open AI', hint: 'Chat with Daylens', keywords: 'chat insights ask', icon: <Sparkles size={15} strokeWidth={1.8} />, perform: () => navigate('/ai') },
     { id: 'nav-settings', group: 'Navigate', label: 'Open Settings', hint: 'Preferences and integrations', keywords: 'preferences provider sync', icon: <SettingsIcon size={15} strokeWidth={1.8} />, perform: () => navigate('/settings') },
     { id: 'wrapped-today', group: 'Day Wrapped', label: "Open today's Day Wrapped", hint: 'Recap the day so far', keywords: 'recap summary', icon: <Sparkles size={15} strokeWidth={1.8} />, perform: () => openWrappedFor(todayString()) },
-    { id: 'wrapped-yesterday', group: 'Day Wrapped', label: "Open yesterday's Day Wrapped", hint: 'Morning brief', keywords: 'recap summary morning brief', icon: <Sparkles size={15} strokeWidth={1.8} />, perform: () => openWrappedFor(dateStringFromMs(Date.now() - 86_400_000)) },
+    { id: 'wrapped-yesterday', group: 'Day Wrapped', label: "Open yesterday's Day Wrapped", hint: 'Morning brief', keywords: 'recap summary morning brief', icon: <Sparkles size={15} strokeWidth={1.8} />, perform: () => openWrappedFor(shiftDateString(todayString(), -1)) },
     activeFocus
       ? { id: 'focus-stop', group: 'Focus' as const, label: 'End focus session', hint: `Session #${activeFocus.id}`, keywords: 'stop end', icon: <Timer size={15} strokeWidth={1.8} />, perform: async () => { await ipc.focus.stop(activeFocus.id); setActiveFocus(null) } }
       : { id: 'focus-start', group: 'Focus' as const, label: 'Start focus session', hint: 'Quiet distraction alerts', keywords: 'deep work', icon: <Timer size={15} strokeWidth={1.8} />, perform: async () => { await ipc.focus.start(null); setActiveFocus(await ipc.focus.getActive()) } },

--- a/src/renderer/components/DayWrapped.tsx
+++ b/src/renderer/components/DayWrapped.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import type { AIWrappedNarrative, AppCategory, DayTimelinePayload, DistractionCostPayload, WebsiteSummary, WrappedPeriodFacts, WrappedPeriodNarrative } from '@shared/types'
 import { blockActiveSeconds } from '@shared/blockDuration'
-import { dateStringFromMs, dayBounds, formatTime, todayString } from '../lib/format'
+import { dayBounds, formatTime, shiftDateString, todayString } from '../lib/format'
 import { ipc } from '../lib/ipc'
 import type { BrowserContext, FocusByPeriod, IdentityConfidence, WrappedQuality } from '../lib/wrappedFacts'
 import {
@@ -1382,11 +1382,7 @@ function useWeekData(enabled: boolean, anchorDate: string): WeekSummary | null {
 
   useEffect(() => {
     if (!enabled) return
-    const [y, m, d] = anchorDate.split('-').map(Number)
-    const anchorMs = new Date(y, m - 1, d).getTime()
-    const dates = Array.from({ length: 14 }, (_, i) =>
-      dateStringFromMs(anchorMs - (13 - i) * 86_400_000)
-    )
+    const dates = Array.from({ length: 14 }, (_, i) => shiftDateString(anchorDate, -(13 - i)))
 
     Promise.all(dates.map(date => ipc.db.getTimelineDay(date).catch(() => null)))
       .then(payloads => {

--- a/src/renderer/lib/format.ts
+++ b/src/renderer/lib/format.ts
@@ -47,6 +47,11 @@ export function dateStringFromMs(ms: number): string {
   return `${y}-${m}-${day}`
 }
 
+export function shiftDateString(dateStr: string, offsetDays: number): string {
+  const [y, m, d] = dateStr.split('-').map(Number)
+  return dateStringFromMs(new Date(y, m - 1, d + offsetDays).getTime())
+}
+
 // Returns today's date as a local YYYY-MM-DD string.
 // DO NOT use new Date().toISOString().split('T')[0] — that returns the UTC date
 // which is wrong in UTC- timezones after ~7 pm local time.
@@ -71,11 +76,14 @@ export function percentOf(part: number, total: number): number {
 export function dayBounds(dateStr: string): [number, number] {
   const [y, m, d] = dateStr.split('-').map(Number)
   const from = new Date(y, m - 1, d).getTime()
-  return [from, from + 86_400_000]
+  const to = new Date(y, m - 1, d + 1).getTime()
+  return [from, to]
 }
 
 export function rollingDayBounds(days: number): [number, number] {
-  const [todayFrom, todayTo] = dayBounds(todayString())
+  const today = todayString()
+  const [todayFrom, todayTo] = dayBounds(today)
   if (days <= 1) return [todayFrom, todayTo]
-  return [todayFrom - (days - 1) * 86_400_000, todayTo]
+  const [from] = dayBounds(shiftDateString(today, -(days - 1)))
+  return [from, todayTo]
 }

--- a/src/renderer/views/Timeline.tsx
+++ b/src/renderer/views/Timeline.tsx
@@ -344,6 +344,7 @@ function IconChevronRight() {
 }
 
 function SummaryStrip({ payload }: { payload: DayTimelinePayload }) {
+  const trackedSeconds = payload.blocks.reduce((sum, block) => sum + blockActiveSeconds(block), 0)
   return (
     <div style={{
       display: 'flex',
@@ -354,7 +355,7 @@ function SummaryStrip({ payload }: { payload: DayTimelinePayload }) {
       color: 'var(--color-text-tertiary)',
     }}>
       <span>
-        <strong style={{ color: 'var(--color-text-primary)' }}>{formatDuration(payload.totalSeconds)}</strong> tracked
+        <strong style={{ color: 'var(--color-text-primary)' }}>{formatDuration(trackedSeconds)}</strong> tracked
       </span>
       <span>{payload.blocks.length} block{payload.blocks.length !== 1 ? 's' : ''}</span>
       <span>{payload.appCount} app{payload.appCount !== 1 ? 's' : ''}</span>
@@ -402,12 +403,10 @@ const TimelineRow = memo(function TimelineRow({
   const accent = CATEGORY_COLORS[block.dominantCategory] ?? CATEGORY_COLORS.uncategorized
   // timeline.md §3.4 / invariant 1: a block is drawn as tall as it is long — a
   // 3-hour block is 3× a 1-hour block. Height is linear in the block's active
-  // minutes; the floor keeps a short block's content legible, the ceiling keeps
-  // a marathon block from dwarfing the day. Within the common 1–3h range the
-  // proportionality is exact (60m→66px, 180m→198px).
+  // minutes with no floor or ceiling: the invariant is exact for short and long
+  // blocks too, not only the common 1–3h range.
   const PX_PER_MINUTE = 1.1
-  const proportionalHeight = Math.round((blockActiveSeconds(block) / 60) * PX_PER_MINUTE)
-  const blockMinHeight = Math.max(44, Math.min(360, proportionalHeight))
+  const proportionalHeight = Math.max(1, Math.round((blockActiveSeconds(block) / 60) * PX_PER_MINUTE))
   const ignored = block.review.state === 'ignored'
   // Leisure / personal rows are muted so the eye finds work first. Work is
   // full-strength; everything else recedes. This is the whole point of the
@@ -424,6 +423,8 @@ const TimelineRow = memo(function TimelineRow({
     <button
       type="button"
       data-timeline-block-id={block.id}
+      aria-label={`Open ${userVisibleBlockLabel(block)}, ${duration}`}
+      aria-pressed={isSelected}
       style={{
         display: 'grid',
         gridTemplateColumns: '104px minmax(0, 1fr)',
@@ -453,7 +454,7 @@ const TimelineRow = memo(function TimelineRow({
         transition: 'border-color 120ms, background 120ms',
         overflow: 'hidden',
         minWidth: 0,
-        minHeight: blockMinHeight,
+        height: proportionalHeight,
         opacity: ignored ? 0.5 : muted ? 0.72 : 1,
       }}>
         <div style={{
@@ -702,24 +703,26 @@ function DaySummaryInspector({ payload, onRefresh }: { payload: DayTimelinePaylo
                   Today is still going. Analyze the day to turn it into named blocks and a recap.
                 </div>
               )}
-              <button
-                type="button"
-                onClick={() => { void handleGenerateRecap() }}
-                disabled={recapLoading}
-                style={{
-                  border: '1px solid var(--color-border-ghost)',
-                  background: 'var(--color-surface-high)',
-                  color: 'var(--color-text-primary)',
-                  borderRadius: 10,
-                  padding: '8px 13px',
-                  fontSize: 13,
-                  fontWeight: 650,
-                  cursor: recapLoading ? 'default' : 'pointer',
-                  opacity: recapLoading ? 0.6 : 1,
-                }}
-              >
-                {recapLoading ? 'Generating recap…' : 'Generate recap'}
-              </button>
+              {!provisional && (
+                <button
+                  type="button"
+                  onClick={() => { void handleGenerateRecap() }}
+                  disabled={recapLoading}
+                  style={{
+                    border: '1px solid var(--color-border-ghost)',
+                    background: 'var(--color-surface-high)',
+                    color: 'var(--color-text-primary)',
+                    borderRadius: 10,
+                    padding: '8px 13px',
+                    fontSize: 13,
+                    fontWeight: 650,
+                    cursor: recapLoading ? 'default' : 'pointer',
+                    opacity: recapLoading ? 0.6 : 1,
+                  }}
+                >
+                  {recapLoading ? 'Generating recap…' : 'Generate recap'}
+                </button>
+              )}
             </div>
           )}
 
@@ -805,7 +808,10 @@ function BlockInspector({
   const hasOverride = Boolean(block.label.override?.trim())
   // The name this block had before the user renamed it — shown so they can see
   // what changed and undo it (timeline.md acceptance: previous name + undo).
-  const previousName = block.label.ruleBased?.trim() || block.label.aiSuggested?.trim() || null
+  const previousName = block.review.originalLabel?.trim()
+    || block.label.aiSuggested?.trim()
+    || block.label.ruleBased?.trim()
+    || null
   // A provisional (live, not-yet-analyzed) block is never renamed or merged —
   // those controls appear once the day is analyzed (timeline.md §4).
   const correctable = !block.provisional
@@ -991,12 +997,12 @@ function BlockInspector({
                 Rename
               </button>
               {previousBlock && (
-                <button type="button" title={`Merge into ${userVisibleBlockLabel(previousBlock)}`} disabled={boundarySaving !== null} onClick={() => { void mergeEpisodeWith(previousBlock, 'merge-prev') }} style={{ border: 'none', background: 'transparent', color: 'var(--color-text-tertiary)', fontSize: 12, fontWeight: 600, cursor: boundarySaving !== null ? 'default' : 'pointer', padding: '2px 4px', display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                <button type="button" aria-label={`Merge with block above: ${userVisibleBlockLabel(previousBlock)}`} title={`Merge into ${userVisibleBlockLabel(previousBlock)}`} disabled={boundarySaving !== null} onClick={() => { void mergeEpisodeWith(previousBlock, 'merge-prev') }} style={{ border: 'none', background: 'transparent', color: 'var(--color-text-tertiary)', fontSize: 12, fontWeight: 600, cursor: boundarySaving !== null ? 'default' : 'pointer', padding: '2px 4px', display: 'inline-flex', alignItems: 'center', gap: 3 }}>
                   <ArrowUp size={12} strokeWidth={2} aria-hidden="true" />{boundarySaving === 'merge-prev' ? 'Merging' : 'Merge'}
                 </button>
               )}
               {nextBlock && (
-                <button type="button" title={`Merge into ${userVisibleBlockLabel(nextBlock)}`} disabled={boundarySaving !== null} onClick={() => { void mergeEpisodeWith(nextBlock, 'merge-next') }} style={{ border: 'none', background: 'transparent', color: 'var(--color-text-tertiary)', fontSize: 12, fontWeight: 600, cursor: boundarySaving !== null ? 'default' : 'pointer', padding: '2px 4px', display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+                <button type="button" aria-label={`Merge with block below: ${userVisibleBlockLabel(nextBlock)}`} title={`Merge into ${userVisibleBlockLabel(nextBlock)}`} disabled={boundarySaving !== null} onClick={() => { void mergeEpisodeWith(nextBlock, 'merge-next') }} style={{ border: 'none', background: 'transparent', color: 'var(--color-text-tertiary)', fontSize: 12, fontWeight: 600, cursor: boundarySaving !== null ? 'default' : 'pointer', padding: '2px 4px', display: 'inline-flex', alignItems: 'center', gap: 3 }}>
                   <ArrowDown size={12} strokeWidth={2} aria-hidden="true" />{boundarySaving === 'merge-next' ? 'Merging' : 'Merge'}
                 </button>
               )}

--- a/src/shared/blockLabel.ts
+++ b/src/shared/blockLabel.ts
@@ -166,11 +166,20 @@ export function userVisibleBlockLabel(block: WorkContextBlock): string {
     }
   }
 
-  // Floor: name the category ("Development") rather than "Untitled block". It
-  // reads better and agrees with the badge. Only truly contentless blocks
-  // (system / uncategorized) fall through to "Untitled block".
+  // Floor: name the category ("Development") rather than announcing that
+  // naming failed. For system / uncategorized blocks, name from the app
+  // evidence that exists; if there is none, say the interval was untracked.
   if (block.dominantCategory !== 'uncategorized' && block.dominantCategory !== 'system') {
     return categoryDisplayName(block.dominantCategory)
   }
-  return 'Untitled block'
+  const appNames = block.topApps
+    .filter((app) => app.category !== 'system')
+    .map((app) => app.appName.trim())
+    .filter((name, index, names) => name.length > 0 && names.indexOf(name) === index)
+    .slice(0, 3)
+  if (appNames.length === 0) return 'Untracked time'
+  const list = appNames.length === 1
+    ? appNames[0]
+    : `${appNames.slice(0, -1).join(', ')} and ${appNames[appNames.length - 1]}`
+  return `${list} — activity`
 }

--- a/tests/blockLabel.test.ts
+++ b/tests/blockLabel.test.ts
@@ -123,9 +123,19 @@ test('falls back to the category name when nothing more specific is present', ()
   assert.equal(userVisibleBlockLabel(block), 'Research')
 })
 
-test('falls back to Untitled block only when the category is contentless', () => {
-  assert.equal(userVisibleBlockLabel(makeBlock({ dominantCategory: 'uncategorized' })), 'Untitled block')
-  assert.equal(userVisibleBlockLabel(makeBlock({ dominantCategory: 'system' })), 'Untitled block')
+test('contentless categories use an honest evidence-based fallback', () => {
+  assert.equal(userVisibleBlockLabel(makeBlock({
+    dominantCategory: 'uncategorized',
+    topApps: [{
+      bundleId: 'company.thebrowser.arc',
+      appName: 'Arc',
+      category: 'uncategorized',
+      totalSeconds: 60,
+      sessionCount: 1,
+      isBrowser: true,
+    }],
+  })), 'Arc — activity')
+  assert.equal(userVisibleBlockLabel(makeBlock({ dominantCategory: 'system', topApps: [] })), 'Untracked time')
 })
 
 test('naturalizeLabel strips leading notification counts like "(1) Instagram"', () => {

--- a/tests/localDate.test.ts
+++ b/tests/localDate.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { localDayBounds, shiftLocalDateString } from '../src/main/lib/localDate.ts'
+import { dayBounds, shiftDateString } from '../src/renderer/lib/format.ts'
+
+test('shiftLocalDateString uses calendar dates across DST boundaries', () => {
+  assert.equal(shiftLocalDateString('2026-03-09', -1), '2026-03-08')
+  assert.equal(shiftLocalDateString('2026-11-02', -1), '2026-11-01')
+  assert.equal(shiftDateString('2026-03-09', -1), '2026-03-08')
+  assert.equal(shiftDateString('2026-11-02', -1), '2026-11-01')
+})
+
+test('localDayBounds follows the next local midnight', () => {
+  const [from, to] = localDayBounds('2026-05-12')
+  const nextMidnight = new Date(2026, 4, 13).getTime()
+
+  assert.equal(from, new Date(2026, 4, 12).getTime())
+  assert.equal(to, nextMidnight)
+})
+
+test('main and renderer day bounds preserve DST-short and DST-long days', () => {
+  if (process.env.TZ !== 'America/New_York') return
+
+  for (const [date, expectedHours] of [['2026-03-08', 23], ['2026-11-01', 25]] as const) {
+    const mainBounds = localDayBounds(date)
+    const rendererBounds = dayBounds(date)
+
+    assert.equal((mainBounds[1] - mainBounds[0]) / 3_600_000, expectedHours)
+    assert.deepEqual(rendererBounds, mainBounds)
+  }
+})

--- a/tests/timeline-eval/fixtures/scattered-admin-day.json
+++ b/tests/timeline-eval/fixtures/scattered-admin-day.json
@@ -138,17 +138,8 @@
       "intentRole": "coordination"
     },
     {
-      "id": "social-detour",
-      "start": "10:26",
-      "end": "10:34",
-      "label": "X detour",
-      "labelIncludes": ["X", "Twitter", "Social"],
-      "category": "social",
-      "intentRole": "ambient"
-    },
-    {
       "id": "budget-tracker",
-      "start": "10:34",
+      "start": "10:26",
       "end": "10:48",
       "label": "Budget tracker",
       "labelIncludes": ["Budget tracker"],

--- a/tests/timelineSegmentation.test.ts
+++ b/tests/timelineSegmentation.test.ts
@@ -173,6 +173,32 @@ test('a sustained Netflix stretch inside coding stays its own block', () => {
   db.close()
 })
 
+test('a brief social peek folds into the same productivity intent', () => {
+  const db = freshDb()
+  const sessions = [
+    session({ bundleId: 'com.notion.id', appName: 'Notion', category: 'productivity', startTime: at(9, 0), endTime: at(9, 30), windowTitle: 'Q3 launch checklist' }),
+    session({ bundleId: 'com.apple.Safari', appName: 'Safari', category: 'social', startTime: at(9, 30), endTime: at(9, 36), windowTitle: 'Home / X' }),
+    session({ bundleId: 'com.notion.id', appName: 'Notion', category: 'productivity', startTime: at(9, 36), endTime: at(10, 6), windowTitle: 'Q3 launch checklist' }),
+  ]
+  const blocks = buildTimelineBlocksFromSessions(db, sessions)
+  assert.equal(blocks.length, 1, `brief social peek should fold into the same productivity block, got ${blocks.length}`)
+  assert.equal(blocks[0].dominantCategory, 'productivity')
+  db.close()
+})
+
+test('a brief detour does not merge different intents on either side', () => {
+  const db = freshDb()
+  const sessions = [
+    session({ bundleId: 'com.todesktop.cursor', appName: 'Cursor', category: 'development', startTime: at(9, 0), endTime: at(9, 30), windowTitle: 'workBlocks.ts — daylens' }),
+    session({ bundleId: 'com.apple.Safari', appName: 'Safari', category: 'social', startTime: at(9, 30), endTime: at(9, 36), windowTitle: 'Home / X' }),
+    session({ bundleId: 'com.microsoft.Word', appName: 'Word', category: 'writing', startTime: at(9, 36), endTime: at(10, 6), windowTitle: 'Quarterly report' }),
+  ]
+  const blocks = buildTimelineBlocksFromSessions(db, sessions)
+  assert.equal(blocks.length, 2, `the detour should be absorbed without erasing the development→writing intent change, got ${blocks.length}`)
+  assert.deepEqual(blocks.map((block) => block.dominantCategory), ['development', 'writing'])
+  db.close()
+})
+
 // FIX (contentless sliver): a sub-30-min Safari fragment with no window titles
 // and no page artifacts sits between two stretches of architecture-review work.
 // It carries no independent meaning, so it folds into a neighbour even though

--- a/tests/workBlockSplitting.test.ts
+++ b/tests/workBlockSplitting.test.ts
@@ -257,20 +257,31 @@ test('a sub-30-minute fragment folds into the related neighbour it continues', (
   db.close()
 })
 
-test('same-app work bridges a moderate untracked gap into one block', () => {
+test('a 15+ minute untracked gap is a hard boundary even for the same app', () => {
   const db = createDb()
-  // A 50-second terminal sliver, then a 17-minute untracked gap, then an hour
-  // of the same app. This is one coding session resuming, not two blocks.
+  // timeline.md §3.1: missing idle telemetry must not erase a real 15+ minute
+  // absence merely because the same app resumes afterward.
   insertSession(db, { title: 'npm run dev - daylens - Ghostty', bundleId: 'com.mitchellh.ghostty', appName: 'Ghostty', category: 'development', startMinute: 0, durationMinutes: 1 })
   insertSession(db, { title: 'widgets.tsx - daylens - Ghostty', bundleId: 'com.mitchellh.ghostty', appName: 'Ghostty', category: 'development', startMinute: 18, durationMinutes: 63 })
 
   const blocks = getTimelineDayPayload(db, TEST_DATE).blocks
 
-  assert.equal(blocks.length, 1, `same-app work across a 17m gap should bridge; got ${blocks.map((b) => b.label.current).join(' | ')}`)
+  assert.equal(blocks.length, 2, `same-app work across a 17m gap must split; got ${blocks.map((b) => b.label.current).join(' | ')}`)
   db.close()
 })
 
-test('sparse AI/dev tool spans fold into surrounding development work by active time', () => {
+test('same-app work can still bridge below the 15-minute idle boundary', () => {
+  const db = createDb()
+  insertSession(db, { title: 'npm run dev - daylens - Ghostty', bundleId: 'com.mitchellh.ghostty', appName: 'Ghostty', category: 'development', startMinute: 0, durationMinutes: 10 })
+  insertSession(db, { title: 'widgets.tsx - daylens - Ghostty', bundleId: 'com.mitchellh.ghostty', appName: 'Ghostty', category: 'development', startMinute: 24, durationMinutes: 40 })
+
+  const blocks = getTimelineDayPayload(db, TEST_DATE).blocks
+
+  assert.equal(blocks.length, 1, `same-app work across a 14m gap may remain one intent; got ${blocks.map((b) => b.label.current).join(' | ')}`)
+  db.close()
+})
+
+test('sparse AI/dev tool spans do not cross a 15+ minute idle boundary', () => {
   const db = createDb()
   const sessions: AppSession[] = [
     {
@@ -301,7 +312,7 @@ test('sparse AI/dev tool spans fold into surrounding development work by active 
 
   const blocks = buildTimelineBlocksFromSessions(db, sessions)
 
-  assert.equal(blocks.length, 1, `low-active Antigravity span should fold into dev work; got ${blocks.map((b) => b.label.current).join(' | ')}`)
+  assert.equal(blocks.length, 2, `a 23m untracked gap must split even sparse AI/dev evidence; got ${blocks.map((b) => b.label.current).join(' | ')}`)
   assert.equal(blocks[0].dominantCategory, 'development')
   db.close()
 })


### PR DESCRIPTION
Two architecture-independent fixes cherry-picked from the codex audit branches (`-x` provenance kept). The audit line's DEV-89/90/92 reimplementations were **excluded** — main already has those features and they conflict with the merged resolver-first AI (ADR 0002). DEV-90's architecture is untouched.

**Included (clean, net-new, tested):**
- **DST-safe day arithmetic** — `from + 86_400_000` is wrong on 23/25-hour DST days; now uses calendar arithmetic (`shiftLocalDateString`/`shiftDateString`). Fixes day/rolling bounds, wraps, command palette, notifier.
- **Timeline invariant enforcement after audit** — tightens `workBlocks` segmentation + `blockLabel`, with new `timelineSegmentation.test.ts`.

**Excluded (not safe):** the 4 DEV-89 audit commits — they conflict with merged DEV-89/90/92 and are a parallel implementation, not missing features. **audit-dev90** had nothing net-new (already in main via #83).

typecheck clean · 642 tests pass · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core timeline partitioning and day-boundary math used by notifications, wraps, and totals; behavior is heavily tested but mis-segmentation would affect user-visible day facts across the app.
> 
> **Overview**
> **DST-safe day arithmetic** replaces `±86_400_000` and fixed `from + 86_400_000` bounds with calendar-based helpers (`shiftLocalDateString` / `shiftDateString`, next-local-midnight `dayBounds`). Daily summary notifier, command palette, Day Wrapped week range, and rolling windows now derive “yesterday” and multi-day ranges from local dates instead of millisecond offsets.
> 
> **Timeline segmentation and facts** align `workBlocks` with `timeline.md`: **15+ minute gaps** are hard boundaries even without activity telemetry (the old 40-minute “runaway” bridge is removed). **Brief detours** can fold into work when intent matches on both sides; when intents differ, the peek is absorbed into the stronger neighbor and **`forcedBoundaryBefore`** preserves the real subject change. Work-bridge logic also respects idle gaps on candidate edges and treats **admin** as a work anchor. Day **`totalSeconds`** is summed from **blocks** (`blockActiveSeconds`), not raw sessions, so Timeline/Apps/AI/recap share one partition.
> 
> **Labels and UI**: uncategorized/system blocks fall back to app-based **“— activity”** or **“Untracked time”** instead of “Untitled block”; rename undo prefers `review.originalLabel`. Timeline rows use **strict proportional height** (no min/max clamp), summary strip tracked time from blocks, block buttons get **aria** labels, merge buttons get **aria-label**s, and **Generate recap** is hidden for provisional live days.
> 
> Tests cover DST shifts, segmentation cases, and updated eval fixtures (e.g. brief social peek absorbed into admin day).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66dd2298e476a55077a2d83a6403f72d43743d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->