### PR TITLE
DEV-87: enforce exclusion privacy at the AI, MCP, and capture boundaries

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -11,6 +11,7 @@ import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprot
 import os from 'node:os'
 import path from 'node:path'
 import { executeTool } from '../../../src/main/services/aiTools'
+import type { TrackingControlsState } from '../../../src/shared/trackingControls'
 import { anthropicTools } from './tools'
 
 const dbPath =
@@ -20,6 +21,27 @@ const dbPath =
 const db = new Database(dbPath, { readonly: true })
 db.pragma('journal_mode = WAL')
 db.pragma('busy_timeout = 5000')
+
+// The subprocess can't reach the Electron settings store, so the current
+// exclusion set is handed in by env (see mcpServer.ts). Without this the MCP
+// boundary would have no exclusion list and excluded apps/sites could leave the
+// machine through an MCP client. System noise is stripped regardless.
+function envList(name: string): string[] {
+  try {
+    const parsed = JSON.parse(process.env[name] ?? '[]') as unknown
+    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+const trackingControls: TrackingControlsState = {
+  enabled: process.env.DAYLENS_TRACKING_CONTROLS_ENABLED === '1',
+  paused: false,
+  excludedApps: envList('DAYLENS_TRACKING_EXCLUDED_APPS'),
+  excludedSites: envList('DAYLENS_TRACKING_EXCLUDED_SITES'),
+  skipIncognito: true,
+}
 
 process.on('exit', () => { try { db.close() } catch { /* ignore */ } })
 process.on('SIGTERM', () => { db.close(); process.exit(0) })
@@ -45,6 +67,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       name as Parameters<typeof executeTool>[0],
       (args ?? {}) as Record<string, unknown>,
       db,
+      trackingControls,
     )
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],

--- a/src/main/ai/resolvers.ts
+++ b/src/main/ai/resolvers.ts
@@ -97,14 +97,16 @@ export interface GetRangeResult {
   days: RangeDaySummary[]
   /** Block labels rolled up across the whole range, by total seconds. */
   topActivities: Array<{ label: string; totalSeconds: number }>
-  /** Apps rolled up across the range, by total seconds. */
-  topApps: Array<{ appName: string; totalSeconds: number }>
+  /** Apps rolled up across the range, by total seconds. bundleId is carried so
+   *  the privacy filter can drop apps excluded by bundle id, not only by name. */
+  topApps: Array<{ appName: string; bundleId: string | null; totalSeconds: number }>
 }
 
 function getRange(from: string, to: string, db: Database.Database): GetRangeResult {
   const days: RangeDaySummary[] = []
   const activitySeconds = new Map<string, number>()
   const appSeconds = new Map<string, number>()
+  const appBundleIds = new Map<string, string | null>()
   let totalTrackedSeconds = 0
 
   // The effective window may be narrower than requested for very long spans
@@ -135,6 +137,7 @@ function getRange(from: string, to: string, db: Database.Database): GetRangeResu
     }
     for (const app of summary._evidence.topApps) {
       appSeconds.set(app.appName, (appSeconds.get(app.appName) ?? 0) + app.totalSeconds)
+      if (!appBundleIds.has(app.appName)) appBundleIds.set(app.appName, app.bundleId ?? null)
     }
   }
 
@@ -143,7 +146,7 @@ function getRange(from: string, to: string, db: Database.Database): GetRangeResu
     .sort((a, b) => b.totalSeconds - a.totalSeconds)
     .slice(0, 12)
   const topApps = [...appSeconds.entries()]
-    .map(([appName, totalSeconds]) => ({ appName, totalSeconds }))
+    .map(([appName, totalSeconds]) => ({ appName, bundleId: appBundleIds.get(appName) ?? null, totalSeconds }))
     .sort((a, b) => b.totalSeconds - a.totalSeconds)
     .slice(0, 12)
 

--- a/src/main/ai/resolvers.ts
+++ b/src/main/ai/resolvers.ts
@@ -9,6 +9,9 @@
 // them. New question types are served by ADDING a resolver here, never by
 // loosening the model.
 import type Database from 'better-sqlite3'
+import { filterTrackingExcludedEvidence } from '@shared/evidencePrivacy'
+import { trackingControlsStateFromSettings, type TrackingControlsState } from '@shared/trackingControls'
+import { getSettings } from '../services/settings'
 import {
   execGetAppUsage,
   execGetBlockAtTime,
@@ -230,7 +233,11 @@ function isEmptyResult(query: ResolverQuery, data: unknown): boolean {
   }
 }
 
-export function runResolverQuery(query: ResolverQuery, db: Database.Database): ResolvedFact {
+export function runResolverQuery(
+  query: ResolverQuery,
+  db: Database.Database,
+  controls: TrackingControlsState = trackingControlsStateFromSettings(getSettings()),
+): ResolvedFact {
   let data: unknown
   switch (query.resolver) {
     case 'getDay':
@@ -255,11 +262,20 @@ export function runResolverQuery(query: ResolverQuery, db: Database.Database): R
       data = execListClients({ startDate: query.from, endDate: query.to }, db)
       break
   }
-  return { query, data, isEmpty: isEmptyResult(query, data) }
+  // Last-line privacy boundary: nothing excluded (or system-noise) is allowed
+  // into a fact before it is serialized and handed to the model. isEmpty stays
+  // on the raw result so "the day had activity" is reported honestly even when
+  // every surfaced row was an excluded one.
+  const filtered = filterTrackingExcludedEvidence(data, controls)
+  return { query, data: filtered, isEmpty: isEmptyResult(query, data) }
 }
 
-export function runResolverQueries(queries: ResolverQuery[], db: Database.Database): ResolvedFact[] {
-  return queries.map((query) => runResolverQuery(query, db))
+export function runResolverQueries(
+  queries: ResolverQuery[],
+  db: Database.Database,
+  controls: TrackingControlsState = trackingControlsStateFromSettings(getSettings()),
+): ResolvedFact[] {
+  return queries.map((query) => runResolverQuery(query, db, controls))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/db/queries.ts
+++ b/src/main/db/queries.ts
@@ -23,6 +23,7 @@ import { localDayBounds } from '../lib/localDate'
 import { resolveCanonicalApp, type CanonicalAppIdentity } from '../lib/appIdentity'
 import { resolveBrowserApplication } from '../services/browserRegistry'
 import { learnFromBlockOverride } from '../services/workMemory'
+import { isSystemNoiseApp } from '@shared/systemNoise'
 
 function resolveDisplayName(bundleId: string, fallbackName: string): string {
   return resolveCanonicalApp(bundleId, fallbackName).displayName
@@ -99,6 +100,9 @@ function normalizedNoiseIdentity(value: string | null | undefined): string {
 }
 
 function isUxNoise(row: Pick<AppSessionRow, 'bundle_id' | 'app_name' | 'raw_app_name' | 'canonical_app_id'>): boolean {
+  // Shared invisible-OS-identity policy first (bundle-id list lives in one
+  // place); then the read-layer's own product-noise names/substrings.
+  if (isSystemNoiseApp({ bundleId: row.bundle_id, appName: row.app_name })) return true
   const values = [row.bundle_id, row.app_name, row.raw_app_name, row.canonical_app_id]
     .filter((value): value is string => Boolean(value?.trim()))
   const normalizedExactNames = new Set([...UX_NOISE_EXACT_NAMES].map(normalizedNoiseIdentity))

--- a/src/main/services/aiTools.ts
+++ b/src/main/services/aiTools.ts
@@ -24,6 +24,9 @@ import {
 import { searchFileMentions as execSearchFileMentions, type SearchFileMentionsResult } from '../lib/windowTitleFilenames'
 import { getTimelineDayPayload, userVisibleLabelForBlock } from './workBlocks'
 import { sanitizeToolResult } from '@shared/aiSanitize'
+import { filterTrackingExcludedEvidence } from '@shared/evidencePrivacy'
+import { trackingControlsStateFromSettings, type TrackingControlsState } from '@shared/trackingControls'
+import { getSettings } from './settings'
 
 // ---------------------------------------------------------------------------
 // TypeScript parameter interfaces
@@ -1082,12 +1085,18 @@ export function executeTool(
   name: ToolName,
   params: Record<string, unknown>,
   db: Database.Database,
+  controls: TrackingControlsState = trackingControlsStateFromSettings(getSettings()),
 ): unknown {
-  // Every tool result passes through sanitizeToolResult before leaving the
-  // executor: deep-walks every string field and strips OAuth tokens, JWTs,
-  // hex blobs, base64 blobs, and URL query strings. This is the load-bearing
-  // defense against the OAuth-callback leak repro from V1-PHASE-6-AI §1.
-  // sanitizeForRender (renderer streaming path) is the second backstop.
+  // Every tool result passes through two boundaries before leaving the
+  // executor:
+  //   1. filterTrackingExcludedEvidence — drops excluded apps/sites and system
+  //      noise (and redacts excluded names embedded in free text). This is the
+  //      last line if capture-time deletion or projection cleanup missed a
+  //      stale row, and it is what makes exclusions hold over MCP.
+  //   2. sanitizeToolResult — deep-walks every string field and strips OAuth
+  //      tokens, JWTs, hex blobs, base64 blobs, and URL query strings. The
+  //      load-bearing defense against the OAuth-callback leak repro from
+  //      V1-PHASE-6-AI §1. sanitizeForRender (renderer path) is the backstop.
   const raw = (() => {
     switch (name) {
       case 'searchSessions': return execSearchSessions(params as unknown as SearchSessionsParams, db)
@@ -1101,5 +1110,5 @@ export function executeTool(
       case 'listClients': return execListClients(params as unknown as ListClientsParams, db)
     }
   })()
-  return sanitizeToolResult(raw)
+  return sanitizeToolResult(filterTrackingExcludedEvidence(raw, controls))
 }

--- a/src/main/services/focusCapture.ts
+++ b/src/main/services/focusCapture.ts
@@ -7,6 +7,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { app } from 'electron'
 import { getDb } from './database'
+import { getSettings } from './settings'
+import { resolveCanonicalApp } from '../lib/appIdentity'
+import { decideAppCapture, decideSiteCapture, trackingControlsStateFromSettings, type TrackingControlsState } from '@shared/trackingControls'
+import { isSystemNoiseApp } from '@shared/systemNoise'
 const FOCUS_EVENT_SCHEMA_VERSION = 1
 const FOCUS_EVENT_TYPES = [
   'app_activated',
@@ -185,7 +189,38 @@ function flushFocusEvents(): void {
   }
 }
 
+// Focus events get the same system-noise and exclusion gates as foreground
+// sessions, so a tab-switch or window-change for an excluded app/site (or a
+// system surface like loginwindow) is never even written to focus_events — and
+// so never reaches projections, Timeline, Apps, or the AI/MCP boundary. Pure
+// and exported so the gate is directly testable without spawning the helper.
+export function shouldCaptureFocusEvent(
+  ev: Pick<HelperEvent, 'app_bundle_id' | 'app_name' | 'window_title' | 'url'>,
+  controls: TrackingControlsState,
+): boolean {
+  if (ev.app_bundle_id || ev.app_name) {
+    if (isSystemNoiseApp({ bundleId: ev.app_bundle_id, appName: ev.app_name })) return false
+    const identity = resolveCanonicalApp(ev.app_bundle_id ?? '', ev.app_name ?? '')
+    if (!decideAppCapture(controls, {
+      bundleId: ev.app_bundle_id,
+      canonicalAppId: identity.canonicalAppId,
+      appName: ev.app_name,
+      windowTitle: ev.window_title,
+    }).capture) return false
+  }
+  if (ev.url) {
+    try {
+      const domain = new URL(ev.url).hostname
+      if (!decideSiteCapture(controls, { domain, windowTitle: ev.window_title }).capture) return false
+    } catch {
+      return false
+    }
+  }
+  return true
+}
+
 function enqueueEvent(ev: HelperEvent): void {
+  if (!shouldCaptureFocusEvent(ev, trackingControlsStateFromSettings(getSettings()))) return
   pendingEvents.push(ev)
   if (pendingEvents.length >= FOCUS_FLUSH_MAX_BATCH) {
     flushFocusEvents()

--- a/src/main/services/mcpServer.ts
+++ b/src/main/services/mcpServer.ts
@@ -7,6 +7,7 @@ import type { ChildProcess } from 'node:child_process'
 import { app } from 'electron'
 import path from 'node:path'
 import fs from 'node:fs'
+import { getSettings } from './settings'
 
 export interface McpServerConfig {
   command: string
@@ -49,6 +50,7 @@ export function getMcpServerConfig(): McpServerConfig | null {
   if (!paths) return null
 
   const dbPath = path.join(app.getPath('userData'), 'daylens.sqlite')
+  const settings = getSettings()
   const args = paths.loaderPath
     ? ['--loader', `file://${paths.loaderPath}`, paths.serverPath]
     : [paths.serverPath]
@@ -59,6 +61,13 @@ export function getMcpServerConfig(): McpServerConfig | null {
     env: {
       ELECTRON_RUN_AS_NODE: '1',
       DAYLENS_DB_PATH: dbPath,
+      // The MCP subprocess reads the same store read-only and has no access to
+      // the settings file, so the current exclusion set is handed in by env.
+      // The Daylens-managed subprocess is respawned with a fresh snapshot on
+      // every start, so exclusions stay current for the in-app server.
+      DAYLENS_TRACKING_CONTROLS_ENABLED: settings.trackingControlsEnabled ? '1' : '0',
+      DAYLENS_TRACKING_EXCLUDED_APPS: JSON.stringify(settings.trackingExcludedApps ?? []),
+      DAYLENS_TRACKING_EXCLUDED_SITES: JSON.stringify(settings.trackingExcludedSites ?? []),
     },
     isPackaged: app.isPackaged,
     dbPath,

--- a/src/main/services/tracking.ts
+++ b/src/main/services/tracking.ts
@@ -35,6 +35,7 @@ import { flushActiveBrowserContext, recordActiveBrowserContextSample } from './b
 import { resolveBrowserApplication } from './browserRegistry'
 import { getSettings } from './settings'
 import { decideAppCapture, trackingControlsStateFromSettings } from '@shared/trackingControls'
+import { isSystemNoiseApp } from '@shared/systemNoise'
 import { runAttributionForRange } from './attribution'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -987,39 +988,9 @@ function recentMacFocusEventWindow(maxAgeMs = 15 * 60_000): ActiveWinResult | nu
 // ─── OS noise filter ─────────────────────────────────────────────────────────
 // System processes that appear as "frontmost app" but are not user-initiated.
 // Writing these to the DB creates junk sessions that inflate totals and
-// pollute the category breakdown.
-
-const OS_NOISE_BUNDLE_IDS = new Set([
-  'com.apple.loginwindow',
-  'com.apple.dock',
-  'com.apple.systemuiserver',
-  'com.apple.notificationcenterui',
-  'com.apple.controlcenter',
-  'com.apple.screensaver.engine',
-  'com.apple.backgroundtaskmanagementagent',
-  'com.apple.usernotificationcenter',
-  'com.apple.finder',
-  'com.apple.siri',
-  'com.apple.siri.agent',
-  'com.apple.WindowManager',
-])
-
-// Lowercase app name exact matches (covers both macOS and Windows noise)
-const OS_NOISE_APP_NAMES = new Set([
-  'loginwindow',
-  'windowserver',
-  'universalaccessd',
-  'dock',
-  'systemuiserver',
-  'finder',
-  'siri',
-  'usernotificationcenter',
-  'notification center',
-  // Windows OS-level processes
-  'dwm.exe',
-  'csrss.exe',
-  'svchost.exe',
-])
+// pollute the category breakdown. The invisible-OS-identity list lives in
+// @shared/systemNoise so capture, queries, projections, and the AI/MCP
+// boundary all share one policy that can't drift between layers.
 
 // Self-exclusion: only this app's own exe names, not all Electron-based apps.
 // Previously matched 'electron' as a substring which filtered VS Code, Discord,
@@ -1104,9 +1075,8 @@ export function persistTrackedForegroundSession(
 }
 
 function isOsNoise(bundleId: string, appName: string, winPath?: string): boolean {
-  if (OS_NOISE_BUNDLE_IDS.has(bundleId)) return true
+  if (isSystemNoiseApp({ bundleId, appName })) return true
   const lowerName = appName.toLowerCase()
-  if (OS_NOISE_APP_NAMES.has(lowerName)) return true
   // Exact exe name match — allows VS Code, Discord, Slack etc. through
   const exeName = (winPath ? path.basename(winPath) : appName).toLowerCase()
   if (SELF_NOISE_EXE_NAMES.has(exeName)) return true
@@ -1650,7 +1620,7 @@ async function poll(): Promise<void> {
     // no app session AND no browser context for this foreground window.
     const trackingDecision = decideAppCapture(
       trackingControlsStateFromSettings(getSettings()),
-      { bundleId, appName, windowTitle: resolvedWindowTitle },
+      { bundleId, canonicalAppId: identity.canonicalAppId, appName, windowTitle: resolvedWindowTitle },
     )
     if (!trackingDecision.capture) {
       if (currentSession) flushCurrent(undefined, `tracking_controls:${trackingDecision.reason}`)

--- a/src/shared/evidencePrivacy.ts
+++ b/src/shared/evidencePrivacy.ts
@@ -15,16 +15,26 @@ function asString(record: JsonRecord, ...keys: string[]): string | null {
   return null
 }
 
+// A bare hostname: labels joined by dots, no scheme, no path, no spaces. Used
+// to recognise a domain that a resolver stuffed into an app-name-shaped field
+// (search "page" hits set appName = the visited domain), so a null-url page hit
+// for an excluded site is still caught by site exclusion.
+const BARE_HOST_RE = /^(?=.{4,253}$)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9-]+)+$/i
+
 function domainFromRecord(record: JsonRecord): string | null {
   const direct = asString(record, 'domain', 'host')
   if (direct) return direct
   const rawUrl = asString(record, 'url', 'normalizedUrl')
-  if (!rawUrl) return null
-  try {
-    return new URL(rawUrl).hostname
-  } catch {
-    return null
+  if (rawUrl) {
+    try {
+      return new URL(rawUrl).hostname
+    } catch {
+      // fall through to the app-name-as-host check
+    }
   }
+  const nameLike = asString(record, 'appName', 'application', 'ownerAppName', 'displayName')
+  if (nameLike && BARE_HOST_RE.test(nameLike)) return nameLike
+  return null
 }
 
 function escapeRegex(value: string): string {
@@ -48,12 +58,24 @@ function containsBoundedToken(value: string, rawToken: string): boolean {
 // keep only the full host to avoid nuking the parent brand (excluding
 // "docs.google.com" must not redact every "Google"). Bounded matching still
 // applies, so "youtube" never touches "youtuber".
+// Common second-level labels in compound public suffixes (bbc.co.uk,
+// abc.com.au, foo.co.jp). Not a full PSL — just enough that the registrable
+// brand label is found for the everyday ccTLD cases.
+const COMPOUND_SUFFIX_SLDS = new Set(['co', 'com', 'org', 'net', 'gov', 'edu', 'ac'])
+
 function siteExclusionTokens(entry: string): string[] {
   const host = entry.trim().toLowerCase().replace(/^www\./, '')
   if (!host) return []
   const tokens = [host]
   const labels = host.split('.')
-  if (labels.length === 2 && labels[0].length >= 3) tokens.push(labels[0])
+  // Registrable brand label: the label just left of the public suffix.
+  // "youtube.com" → youtube; "bbc.co.uk" → bbc; but a deeper subdomain the
+  // user explicitly targeted ("docs.google.com") keeps only the full host so
+  // we never redact the parent brand.
+  let brandIdx = -1
+  if (labels.length === 2) brandIdx = 0
+  else if (labels.length === 3 && labels[1].length <= 3 && COMPOUND_SUFFIX_SLDS.has(labels[1])) brandIdx = 0
+  if (brandIdx >= 0 && labels[brandIdx].length >= 3) tokens.push(labels[brandIdx])
   return tokens
 }
 

--- a/src/shared/evidencePrivacy.ts
+++ b/src/shared/evidencePrivacy.ts
@@ -1,0 +1,111 @@
+import {
+  isAppExcluded,
+  isSiteExcluded,
+  type TrackingControlsState,
+} from './trackingControls'
+import { isSystemNoiseApp } from './systemNoise'
+
+type JsonRecord = Record<string, unknown>
+
+function asString(record: JsonRecord, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) return value
+  }
+  return null
+}
+
+function domainFromRecord(record: JsonRecord): string | null {
+  const direct = asString(record, 'domain', 'host')
+  if (direct) return direct
+  const rawUrl = asString(record, 'url', 'normalizedUrl')
+  if (!rawUrl) return null
+  try {
+    return new URL(rawUrl).hostname
+  } catch {
+    return null
+  }
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// Bounded match so a short exclusion like "Arc" redacts "Arc was open" but
+// never "architecture". The token must sit on a word boundary (start/end or a
+// non-alphanumeric neighbour). Tokens under 3 chars are too noisy to redact.
+function containsBoundedToken(value: string, rawToken: string): boolean {
+  const token = rawToken.trim().toLowerCase().replace(/^www\./, '')
+  if (token.length < 3) return false
+  return new RegExp(`(^|[^a-z0-9])${escapeRegex(token)}(?=$|[^a-z0-9])`, 'i').test(value)
+}
+
+// A site exclusion has to redact more than the literal host: derived block
+// labels and page titles name the brand, not the domain ("Watching YouTube",
+// "… - YouTube"), so excluding "youtube.com" must also redact the bare token
+// "youtube". We expand a registrable 2-label host (brand.tld) to its leading
+// label; a multi-label host is a specific subdomain the user targeted, so we
+// keep only the full host to avoid nuking the parent brand (excluding
+// "docs.google.com" must not redact every "Google"). Bounded matching still
+// applies, so "youtube" never touches "youtuber".
+function siteExclusionTokens(entry: string): string[] {
+  const host = entry.trim().toLowerCase().replace(/^www\./, '')
+  if (!host) return []
+  const tokens = [host]
+  const labels = host.split('.')
+  if (labels.length === 2 && labels[0].length >= 3) tokens.push(labels[0])
+  return tokens
+}
+
+function containsExcludedText(value: string, controls: TrackingControlsState): boolean {
+  return controls.excludedApps.some((entry) => containsBoundedToken(value, entry))
+    || controls.excludedSites.some((entry) =>
+      siteExclusionTokens(entry).some((token) => containsBoundedToken(value, token)))
+}
+
+function filterValue(value: unknown, controls: TrackingControlsState): unknown {
+  if (typeof value === 'string') {
+    return containsExcludedText(value, controls) ? '[excluded]' : value
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => filterValue(entry, controls))
+      .filter((entry) => entry !== null)
+  }
+  if (!value || typeof value !== 'object') return value
+
+  const record = value as JsonRecord
+  const bundleId = asString(record, 'bundleId', 'appBundleId', 'browserBundleId', 'ownerBundleId')
+  const canonicalAppId = asString(record, 'canonicalAppId', 'canonicalBrowserId')
+  const appName = asString(record, 'appName', 'application', 'ownerAppName', 'displayName')
+  if (isSystemNoiseApp({ bundleId, appName })) return null
+  if (isAppExcluded(controls, { bundleId, canonicalAppId, appName })) return null
+
+  const domain = domainFromRecord(record)
+  if (domain && isSiteExcluded(controls, { domain })) return null
+
+  const filtered: JsonRecord = {}
+  for (const [key, entry] of Object.entries(record)) {
+    const next = filterValue(entry, controls)
+    if (next !== null) filtered[key] = next
+  }
+  return filtered
+}
+
+/**
+ * Last-line privacy boundary for anything leaving the local resolver layer.
+ * Capture-time deletion remains the source-of-truth fix; this prevents a purge
+ * miss, stale projection, or legacy row from reaching AI/MCP providers.
+ *
+ * System noise is always stripped (even with controls off); user exclusions
+ * apply only when Tracking Controls is enabled with a non-empty list.
+ */
+export function filterTrackingExcludedEvidence(
+  value: unknown,
+  controls: TrackingControlsState,
+): unknown {
+  if (!controls.enabled || (controls.excludedApps.length === 0 && controls.excludedSites.length === 0)) {
+    return filterValue(value, { ...controls, excludedApps: [], excludedSites: [] })
+  }
+  return filterValue(value, controls)
+}

--- a/src/shared/systemNoise.ts
+++ b/src/shared/systemNoise.ts
@@ -1,0 +1,47 @@
+// One source of truth for invisible OS identities. These appear as the
+// "frontmost app" or as historical rows but are never a user-initiated app:
+// counting them inflates totals, and surfacing them to the AI/MCP leaks the
+// shape of the machine. Capture, queries, projections, and the evidence
+// boundary all import this so the policy can never drift between layers.
+
+export interface AppIdentityCandidate {
+  bundleId?: string | null
+  appName?: string | null
+}
+
+const SYSTEM_NOISE_BUNDLE_IDS = new Set([
+  'com.apple.loginwindow',
+  'com.apple.dock',
+  'com.apple.systemuiserver',
+  'com.apple.notificationcenterui',
+  'com.apple.controlcenter',
+  'com.apple.screensaver.engine',
+  'com.apple.backgroundtaskmanagementagent',
+  'com.apple.usernotificationcenter',
+  'com.apple.finder',
+  'com.apple.siri',
+  'com.apple.siri.agent',
+  'com.apple.windowmanager',
+])
+
+const SYSTEM_NOISE_APP_NAMES = new Set([
+  'loginwindow',
+  'windowserver',
+  'universalaccessd',
+  'dock',
+  'systemuiserver',
+  'finder',
+  'siri',
+  'usernotificationcenter',
+  'notification center',
+  // Windows OS-level processes
+  'dwm.exe',
+  'csrss.exe',
+  'svchost.exe',
+])
+
+export function isSystemNoiseApp(candidate: AppIdentityCandidate): boolean {
+  const bundleId = candidate.bundleId?.trim().toLowerCase() ?? ''
+  const appName = candidate.appName?.trim().toLowerCase() ?? ''
+  return SYSTEM_NOISE_BUNDLE_IDS.has(bundleId) || SYSTEM_NOISE_APP_NAMES.has(appName)
+}

--- a/src/shared/trackingControls.ts
+++ b/src/shared/trackingControls.ts
@@ -17,6 +17,7 @@ export interface TrackingControlsState {
 
 export interface AppCaptureCandidate {
   bundleId?: string | null
+  canonicalAppId?: string | null
   appName?: string | null
   windowTitle?: string | null
 }
@@ -54,14 +55,19 @@ function normalizeHost(value: string | null | undefined): string {
 }
 
 // An app matches an exclusion entry when the entry equals (case-insensitively)
-// either its bundle id or its display name.
+// its bundle id, its bundle id without a browser-profile suffix
+// (`com.google.Chrome:Profile 1` → `com.google.chrome`), its canonical app id,
+// or its display name. Profile-aware matching means excluding "chrome" or the
+// base bundle drops every profile variant, not just the one currently open.
 export function isAppExcluded(state: TrackingControlsState, candidate: AppCaptureCandidate): boolean {
   if (!state.enabled || state.excludedApps.length === 0) return false
   const bundle = normalizeToken(candidate.bundleId)
+  const baseBundle = bundle.split(':', 1)[0]
+  const canonical = normalizeToken(candidate.canonicalAppId)
   const name = normalizeToken(candidate.appName)
   return state.excludedApps.some((entry) => {
     const e = normalizeToken(entry)
-    return e !== '' && (e === bundle || e === name)
+    return e !== '' && (e === bundle || e === baseBundle || e === canonical || e === name)
   })
 }
 

--- a/tests/captureFoundation.test.ts
+++ b/tests/captureFoundation.test.ts
@@ -5,6 +5,7 @@ import { SCHEMA_SQL } from '../src/main/db/schema.ts'
 import { getAppSummariesForRange, getSessionsForRange } from '../src/main/db/queries.ts'
 import { localDayBounds } from '../src/main/lib/localDate.ts'
 import { getTimelineDayPayload } from '../src/main/services/workBlocks.ts'
+import { isSystemNoiseApp } from '../src/shared/systemNoise.ts'
 
 function ensureFocusEventsTable(db: Database.Database): void {
   db.exec(`
@@ -159,6 +160,14 @@ test('legacy and current Zen identities collapse into one browsing row', () => {
   assert.equal(summaries[0].category, 'browsing')
   assert.equal(summaries[0].totalSeconds, 60 * 60)
   db.close()
+})
+
+test('shared system-noise policy covers bundle and display-name variants', () => {
+  assert.equal(isSystemNoiseApp({ bundleId: 'com.apple.loginwindow', appName: 'LoginWindow' }), true)
+  assert.equal(isSystemNoiseApp({ bundleId: 'com.apple.UserNotificationCenter', appName: 'Notifications' }), true)
+  assert.equal(isSystemNoiseApp({ bundleId: 'com.apple.WindowManager', appName: 'WindowManager' }), true)
+  assert.equal(isSystemNoiseApp({ bundleId: 'com.apple.finder', appName: 'Finder' }), true)
+  assert.equal(isSystemNoiseApp({ bundleId: 'com.microsoft.VSCode', appName: 'Cursor' }), false)
 })
 
 test('overlapping capture rows are coalesced before engagement totals are counted', () => {

--- a/tests/evidencePrivacy.test.ts
+++ b/tests/evidencePrivacy.test.ts
@@ -123,6 +123,54 @@ test('multi-label excluded host does not nuke the parent brand', () => {
   assert.equal(filtered.b, 'Google Search and Google Docs')
 })
 
+test('a page hit that carries the domain as appName (null url) is dropped by site exclusion', () => {
+  // recall/search "page" hits set appName = the visited domain and url can be
+  // null. Site exclusion must still catch it even though the host is not under
+  // a domain/url key.
+  const filtered = filterTrackingExcludedEvidence({
+    hits: [
+      { kind: 'page', appName: 'youtube.com', windowTitle: 'Some talk', url: null },
+      { kind: 'page', appName: 'github.com', windowTitle: 'a repo', url: null },
+      { kind: 'session', appName: 'Cursor', windowTitle: 'main.ts', url: null },
+    ],
+  }, {
+    ...controls,
+    excludedApps: [],
+    excludedSites: ['youtube.com'],
+  }) as { hits: Array<{ appName: string }> }
+
+  assert.deepEqual(filtered.hits.map((h) => h.appName), ['github.com', 'Cursor'])
+})
+
+test('a compound-TLD site exclusion redacts its brand (bbc.co.uk → "BBC")', () => {
+  const filtered = filterTrackingExcludedEvidence({
+    label: 'Watching BBC',
+    keep: 'Reading the news',
+  }, {
+    ...controls,
+    excludedApps: [],
+    excludedSites: ['bbc.co.uk'],
+  }) as Record<string, string>
+
+  assert.equal(filtered.label, '[excluded]')
+  assert.equal(filtered.keep, 'Reading the news')
+})
+
+test('an app excluded by bundle id is dropped even when the record also carries its name', () => {
+  const filtered = filterTrackingExcludedEvidence({
+    topApps: [
+      { appName: 'Zen', bundleId: 'app.zen-browser.zen', totalSeconds: 600 },
+      { appName: 'Cursor', bundleId: 'com.microsoft.VSCode', totalSeconds: 900 },
+    ],
+  }, {
+    ...controls,
+    excludedApps: ['app.zen-browser.zen'],
+    excludedSites: [],
+  }) as { topApps: Array<{ appName: string }> }
+
+  assert.deepEqual(filtered.topApps.map((a) => a.appName), ['Cursor'])
+})
+
 test('system noise is stripped even when tracking controls are disabled', () => {
   const filtered = filterTrackingExcludedEvidence({
     topApps: [

--- a/tests/evidencePrivacy.test.ts
+++ b/tests/evidencePrivacy.test.ts
@@ -1,0 +1,159 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { filterTrackingExcludedEvidence } from '../src/shared/evidencePrivacy.ts'
+import type { TrackingControlsState } from '../src/shared/trackingControls.ts'
+
+const controls: TrackingControlsState = {
+  enabled: true,
+  paused: false,
+  excludedApps: ['app.zen-browser.zen'],
+  excludedSites: ['private.example.com'],
+  skipIncognito: true,
+}
+
+test('AI evidence boundary removes excluded apps, sites, and system surfaces', () => {
+  const filtered = filterTrackingExcludedEvidence({
+    topApps: [
+      { bundleId: 'app.zen-browser.zen:work', appName: 'Zen', totalSeconds: 600 },
+      { bundleId: 'com.apple.loginwindow', appName: 'loginwindow', totalSeconds: 300 },
+      { bundleId: 'com.microsoft.VSCode', appName: 'Cursor', totalSeconds: 900 },
+    ],
+    pages: [
+      { domain: 'private.example.com', url: 'https://private.example.com/plan', pageTitle: 'Private plan' },
+      { domain: 'github.com', url: 'https://github.com/openai', pageTitle: 'OpenAI' },
+    ],
+  }, controls) as {
+    topApps: Array<{ appName: string }>
+    pages: Array<{ domain: string }>
+  }
+
+  assert.deepEqual(filtered.topApps.map((app) => app.appName), ['Cursor'])
+  assert.deepEqual(filtered.pages.map((page) => page.domain), ['github.com'])
+})
+
+test('AI evidence boundary redacts excluded values embedded in derived labels', () => {
+  const filtered = filterTrackingExcludedEvidence({
+    label: 'Planning on private.example.com',
+    narrative: 'Zen was open beside Cursor',
+  }, controls) as { label: string; narrative: string }
+
+  assert.equal(filtered.label, '[excluded]')
+  assert.equal(filtered.narrative, 'Zen was open beside Cursor')
+})
+
+test('short app exclusions do not corrupt unrelated words', () => {
+  const filtered = filterTrackingExcludedEvidence({
+    architecture: 'Architecture review',
+    diagram: 'Diagramming the resolver boundary',
+    exactArc: 'Arc was open',
+    exactDia: 'Dia was open',
+  }, {
+    ...controls,
+    excludedApps: ['Arc', 'Dia'],
+    excludedSites: [],
+  }) as Record<string, string>
+
+  assert.equal(filtered.architecture, 'Architecture review')
+  assert.equal(filtered.diagram, 'Diagramming the resolver boundary')
+  assert.equal(filtered.exactArc, '[excluded]')
+  assert.equal(filtered.exactDia, '[excluded]')
+})
+
+test('excluding a site redacts its brand in derived labels and page titles', () => {
+  // Found by driving real captured data: excluding "youtube.com" dropped the
+  // structured domain row but left "Watching YouTube" block labels and
+  // "… - YouTube" page titles naming the site to the AI/MCP. A site exclusion
+  // must redact the brand token, not only the literal host.
+  const filtered = filterTrackingExcludedEvidence({
+    blocks: [
+      { label: 'Watching YouTube', pageTitles: ['Some talk - YouTube', 'Keep me'] },
+      { label: 'On Pornhub & YouTube', pageTitles: [] },
+    ],
+    topWebsiteDomains: [
+      { domain: 'youtube.com', totalSeconds: 600 },
+      { domain: 'github.com', totalSeconds: 300 },
+    ],
+  }, {
+    ...controls,
+    excludedApps: [],
+    excludedSites: ['youtube.com'],
+  }) as {
+    blocks: Array<{ label: string; pageTitles: string[] }>
+    topWebsiteDomains: Array<{ domain: string }>
+  }
+
+  assert.equal(filtered.blocks[0].label, '[excluded]')
+  assert.equal(filtered.blocks[0].pageTitles[0], '[excluded]')
+  assert.equal(filtered.blocks[0].pageTitles[1], 'Keep me')
+  // A string mentioning the excluded brand is redacted whole — so even the
+  // surrounding "On Pornhub &" context goes with it, never leaving a hint.
+  assert.equal(filtered.blocks[1].label, '[excluded]')
+  assert.deepEqual(filtered.topWebsiteDomains.map((w) => w.domain), ['github.com'])
+})
+
+test('brand redaction stays word-bounded (no substring corruption)', () => {
+  const filtered = filterTrackingExcludedEvidence({
+    a: 'A YouTuber reviewed it',   // "youtuber" must NOT be redacted
+    b: 'media diagram review',      // unrelated to excluded "dia.com" brand "dia"
+    c: 'Watching YouTube now',      // exact brand → redacted
+  }, {
+    ...controls,
+    excludedApps: [],
+    excludedSites: ['youtube.com', 'dia.com'],
+  }) as Record<string, string>
+
+  assert.equal(filtered.a, 'A YouTuber reviewed it')
+  assert.equal(filtered.b, 'media diagram review')
+  assert.equal(filtered.c, '[excluded]')
+})
+
+test('multi-label excluded host does not nuke the parent brand', () => {
+  // Excluding a specific subdomain redacts the full host but must not redact
+  // every mention of the parent ("docs.google.com" ≠ hide all "Google").
+  const filtered = filterTrackingExcludedEvidence({
+    a: 'Opened docs.google.com',
+    b: 'Google Search and Google Docs',
+  }, {
+    ...controls,
+    excludedApps: [],
+    excludedSites: ['docs.google.com'],
+  }) as Record<string, string>
+
+  assert.equal(filtered.a, '[excluded]')
+  assert.equal(filtered.b, 'Google Search and Google Docs')
+})
+
+test('system noise is stripped even when tracking controls are disabled', () => {
+  const filtered = filterTrackingExcludedEvidence({
+    topApps: [
+      { bundleId: 'com.apple.finder', appName: 'Finder', totalSeconds: 120 },
+      { bundleId: 'com.microsoft.VSCode', appName: 'Cursor', totalSeconds: 900 },
+    ],
+  }, {
+    enabled: false,
+    paused: false,
+    excludedApps: ['app.zen-browser.zen'],
+    excludedSites: ['private.example.com'],
+    skipIncognito: true,
+  }) as { topApps: Array<{ appName: string }> }
+
+  // Controls off → user exclusions do not apply, but invisible OS surfaces
+  // still never leave the machine.
+  assert.deepEqual(filtered.topApps.map((app) => app.appName), ['Cursor'])
+})
+
+test('canonical-id exclusion drops every browser profile variant', () => {
+  const filtered = filterTrackingExcludedEvidence({
+    topApps: [
+      { bundleId: 'com.google.Chrome:Profile 1', canonicalAppId: 'chrome', appName: 'Google Chrome (Profile 1)', totalSeconds: 600 },
+      { bundleId: 'com.google.Chrome:Profile 2', canonicalAppId: 'chrome', appName: 'Google Chrome (Profile 2)', totalSeconds: 300 },
+      { bundleId: 'com.microsoft.VSCode', appName: 'Cursor', totalSeconds: 900 },
+    ],
+  }, {
+    ...controls,
+    excludedApps: ['chrome'],
+    excludedSites: [],
+  }) as { topApps: Array<{ appName: string }> }
+
+  assert.deepEqual(filtered.topApps.map((app) => app.appName), ['Cursor'])
+})

--- a/tests/focusCaptureGate.test.ts
+++ b/tests/focusCaptureGate.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { shouldCaptureFocusEvent } from '../src/main/services/focusCapture.ts'
+import type { TrackingControlsState } from '../src/shared/trackingControls.ts'
+
+const off: TrackingControlsState = {
+  enabled: false, paused: false, excludedApps: [], excludedSites: [], skipIncognito: true,
+}
+const on: TrackingControlsState = {
+  enabled: true, paused: false,
+  excludedApps: ['app.zen-browser.zen'], excludedSites: ['private.example.com'], skipIncognito: true,
+}
+
+test('focus capture records normal app and site events', () => {
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'com.microsoft.VSCode', app_name: 'Cursor', window_title: 'main.ts', url: null }, on), true)
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'com.google.Chrome', app_name: 'Chrome', window_title: null, url: 'https://github.com/x' }, on), true)
+})
+
+test('focus capture drops system-noise events even with controls off', () => {
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'com.apple.loginwindow', app_name: 'loginwindow', window_title: null, url: null }, off), false)
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'com.apple.finder', app_name: 'Finder', window_title: null, url: null }, off), false)
+})
+
+test('focus capture drops events for an excluded app (incl. profile variant)', () => {
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'app.zen-browser.zen:work', app_name: 'Zen (work)', window_title: null, url: null }, on), false)
+  // Same event passes when the feature is off — proves it is the exclusion, not noise.
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'app.zen-browser.zen:work', app_name: 'Zen (work)', window_title: null, url: null }, off), true)
+})
+
+test('focus capture drops events for an excluded site and its subdomains', () => {
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'com.google.Chrome', app_name: 'Chrome', window_title: null, url: 'https://private.example.com/plan' }, on), false)
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'com.google.Chrome', app_name: 'Chrome', window_title: null, url: 'https://team.private.example.com/x' }, on), false)
+})
+
+test('focus capture drops an unparseable url defensively', () => {
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'com.google.Chrome', app_name: 'Chrome', window_title: null, url: 'not a url' }, on), false)
+})
+
+test('focus capture drops incognito windows when enabled', () => {
+  assert.equal(shouldCaptureFocusEvent({ app_bundle_id: 'com.google.Chrome', app_name: 'Chrome', window_title: 'Secret (Incognito)', url: null }, on), false)
+})

--- a/tests/support/verify-dev87.ts
+++ b/tests/support/verify-dev87.ts
@@ -1,0 +1,90 @@
+// DEV-87 live boundary proof — runs the REAL resolver/AI path and the REAL
+// executeTool (MCP) path against the REAL captured database, with an exclusion
+// configured. Not a unit test: it drives the same code the app runs, on real
+// pre-existing data, and prints what would reach the model / an MCP client.
+//
+// Run: ELECTRON_RUN_AS_NODE=1 electron --loader ./tests/support/ts-loader.mjs \
+//        ./tests/support/verify-dev87.ts <dbPath> <date>
+import Database from 'better-sqlite3'
+import { runResolverQueries, serializeFact } from '../../src/main/ai/resolvers'
+import { executeTool } from '../../src/main/services/aiTools'
+import type { TrackingControlsState } from '../../src/shared/trackingControls'
+
+const dbPath = process.argv[2]
+const date = process.argv[3] ?? '2026-06-21'
+const EXCLUDED_APP = 'dia'           // by canonical app id (real top app that day)
+const EXCLUDED_SITE = 'youtube.com'  // real top domain that day
+
+const db = new Database(dbPath, { readonly: true })
+
+const OFF: TrackingControlsState = {
+  enabled: false, paused: false, excludedApps: [], excludedSites: [], skipIncognito: true,
+}
+const ON: TrackingControlsState = {
+  enabled: true, paused: false,
+  excludedApps: [EXCLUDED_APP], excludedSites: [EXCLUDED_SITE], skipIncognito: true,
+}
+
+// A word-bounded search: "dia" must hit the app "Dia" but never "diagram"/"media".
+function mentions(haystack: string, token: string): boolean {
+  return new RegExp(`(^|[^a-z0-9])${token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=$|[^a-z0-9])`, 'i').test(haystack)
+}
+
+function aiFactsText(controls: TrackingControlsState): string {
+  const facts = runResolverQueries([{ resolver: 'getDay', date }], db, controls)
+  return facts.map(serializeFact).join('\n\n')
+}
+
+function line(label: string, ok: boolean, detail: string): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label.padEnd(46)} ${detail}`)
+}
+
+console.log(`\n=== DEV-87 boundary proof — db=${dbPath.split('/').pop()} date=${date} ===`)
+console.log(`Excluding app="${EXCLUDED_APP}" (canonical) and site="${EXCLUDED_SITE}"\n`)
+
+let allPass = true
+function check(label: string, ok: boolean, detail: string): void {
+  if (!ok) allPass = false
+  line(label, ok, detail)
+}
+
+// ── AI tab boundary (resolver → serialized facts → model) ─────────────────────
+const aiOff = aiFactsText(OFF)
+const aiOn = aiFactsText(ON)
+
+check('AI: excluded app present WITHOUT exclusion', mentions(aiOff, 'dia'),
+  `("dia" in baseline facts: ${mentions(aiOff, 'dia')})`)
+check('AI: excluded app ABSENT WITH exclusion', !mentions(aiOn, 'dia'),
+  `("dia" in filtered facts: ${mentions(aiOn, 'dia')})`)
+check('AI: excluded site present WITHOUT exclusion', aiOff.toLowerCase().includes('youtube'),
+  `("youtube" in baseline facts: ${aiOff.toLowerCase().includes('youtube')})`)
+check('AI: excluded site ABSENT WITH exclusion', !aiOn.toLowerCase().includes('youtube'),
+  `("youtube" in filtered facts: ${aiOn.toLowerCase().includes('youtube')})`)
+// Bounded-matching: kept apps survive; nothing benign got corrupted.
+check('AI: kept apps survive the filter', ['zen', 'excel', 'codex'].some((a) => mentions(aiOn, a)),
+  `(other real apps still present)`)
+
+// ── MCP boundary (executeTool — the exact path the MCP server calls) ──────────
+function mcpJson(controls: TrackingControlsState): string {
+  return JSON.stringify(executeTool('getDaySummary', { date }, db, controls)).toLowerCase()
+}
+const mcpOff = mcpJson(OFF)
+const mcpOn = mcpJson(ON)
+
+check('MCP: excluded app present WITHOUT exclusion', mentions(mcpOff, 'dia'),
+  `("dia" in baseline output: ${mentions(mcpOff, 'dia')})`)
+check('MCP: excluded app ABSENT WITH exclusion', !mentions(mcpOn, 'dia'),
+  `("dia" in filtered output: ${mentions(mcpOn, 'dia')})`)
+check('MCP: excluded site present WITHOUT exclusion', mcpOff.includes('youtube'),
+  `("youtube" in baseline output: ${mcpOff.includes('youtube')})`)
+check('MCP: excluded site ABSENT WITH exclusion', !mcpOn.includes('youtube'),
+  `("youtube" in filtered output: ${mcpOn.includes('youtube')})`)
+
+// ── System noise is stripped even with controls OFF ───────────────────────────
+check('AI: system noise (finder/loginwindow) never present',
+  !mentions(aiOff, 'loginwindow') && !mentions(aiOff, 'windowserver'),
+  '(invisible OS identities excluded at the boundary)')
+
+db.close()
+console.log(`\n${allPass ? 'ALL BOUNDARY CHECKS PASS' : 'SOME CHECKS FAILED'}\n`)
+process.exit(allPass ? 0 : 1)

--- a/tests/support/verify-mcp-subprocess.mjs
+++ b/tests/support/verify-mcp-subprocess.mjs
@@ -1,0 +1,66 @@
+// Drives the REAL built MCP server subprocess (dist/mcp-server/index.cjs) over
+// stdio JSON-RPC, exactly as Claude Desktop / Cursor would — with the exclusion
+// env that src/main/services/mcpServer.ts hands it. Proves the excluded app and
+// site are absent from a real MCP tool response on real captured data.
+import { spawn } from 'node:child_process'
+
+const [dbPath, date = '2026-06-21'] = process.argv.slice(2)
+const SERVER = 'dist/mcp-server/index.cjs'
+// Production spawns the bundle under the Electron binary with ELECTRON_RUN_AS_NODE
+// (see mcpServer.ts) so the better-sqlite3 native ABI matches. Mirror that here.
+const ELECTRON = 'node_modules/.bin/electron'
+
+function run(env) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(ELECTRON, [SERVER], {
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: '1', DAYLENS_DB_PATH: dbPath, ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    let out = ''
+    let err = ''
+    proc.stdout.on('data', (c) => { out += c })
+    proc.stderr.on('data', (c) => { err += c })
+    proc.on('error', reject)
+    proc.on('exit', () => {
+      const text = out
+        .split('\n').filter(Boolean)
+        .map((l) => { try { return JSON.parse(l) } catch { return null } })
+        .filter(Boolean)
+        .find((m) => m.id === 2)?.result?.content?.[0]?.text ?? ''
+      if (!text && err) console.error('[stderr]', err.trim())
+      resolve(text.toLowerCase())
+    })
+
+    const send = (obj) => proc.stdin.write(JSON.stringify(obj) + '\n')
+    send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'verify', version: '1' } } })
+    send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'getDaySummary', arguments: { date } } })
+    setTimeout(() => { proc.stdin.end(); proc.kill('SIGTERM') }, 4000)
+  })
+}
+
+function bounded(haystack, token) {
+  return new RegExp(`(^|[^a-z0-9])${token}(?=$|[^a-z0-9])`, 'i').test(haystack)
+}
+
+const off = await run({ DAYLENS_TRACKING_CONTROLS_ENABLED: '0' })
+const on = await run({
+  DAYLENS_TRACKING_CONTROLS_ENABLED: '1',
+  DAYLENS_TRACKING_EXCLUDED_APPS: JSON.stringify(['dia']),
+  DAYLENS_TRACKING_EXCLUDED_SITES: JSON.stringify(['youtube.com']),
+})
+
+console.log(`\n=== REAL MCP subprocess boundary (${SERVER}) date=${date} ===`)
+const checks = [
+  ['MCP subprocess: app "dia" present when controls OFF', bounded(off, 'dia')],
+  ['MCP subprocess: app "dia" ABSENT when excluded', !bounded(on, 'dia')],
+  ['MCP subprocess: site "youtube" present when OFF', on.length > 0 && off.includes('youtube')],
+  ['MCP subprocess: site "youtube" ABSENT when excluded', !on.includes('youtube')],
+  ['MCP subprocess: returned a real payload', on.length > 100],
+]
+let pass = true
+for (const [label, ok] of checks) {
+  if (!ok) pass = false
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}`)
+}
+console.log(`\n${pass ? 'MCP SUBPROCESS BOUNDARY PROVEN' : 'MCP SUBPROCESS CHECK FAILED'}\n`)
+process.exit(pass ? 0 : 1)

--- a/tests/trackingControls.test.ts
+++ b/tests/trackingControls.test.ts
@@ -48,6 +48,25 @@ test('app exclusion matches bundle id or app name, case-insensitively, only when
   assert.equal(isAppExcluded({ ...s, enabled: false }, { bundleId: 'com.tinyspeck.slackmacgap' }), false)
 })
 
+test('app exclusion matches canonical identity and browser profile variants', () => {
+  const s = {
+    ...base,
+    enabled: true,
+    excludedApps: ['chrome', 'app.zen-browser.zen'],
+  }
+  // Excluding the canonical id "chrome" drops a profile-suffixed bundle.
+  assert.equal(decideAppCapture(s, {
+    bundleId: 'com.google.Chrome:Profile 1',
+    canonicalAppId: 'chrome',
+    appName: 'Google Chrome (Profile 1)',
+  }).reason, 'excluded_app')
+  // Excluding the base bundle id drops a profile variant even without canonical.
+  assert.equal(decideAppCapture(s, {
+    bundleId: 'app.zen-browser.zen:work',
+    appName: 'Zen (work)',
+  }).reason, 'excluded_app')
+})
+
 // ── Site exclusion incl. subdomains + www (acceptance #3) ──────────────────────
 
 test('site exclusion matches the host and its subdomains, ignoring www', () => {


### PR DESCRIPTION
## What this fixes (P0 privacy)

Daylens promises *nothing leaves your machine unless you ask*. On current `main` (after DEV-87/88/89/90/92), excluded apps/sites could still reach:

- the **AI tab** (the resolver → facts → model path),
- the **MCP server** (an MCP client could read excluded data), and
- **focus-event capture** (excluded apps/sites were still written to `focus_events`).

Invisible OS surfaces (loginwindow, Finder, Siri, WindowManager…) were also filtered by per-layer lists that had drifted.

This re-applies the DEV-87 exclusion-privacy fix (corrective commit `13a8a5c`), reconciled to current `main` — not a blind cherry-pick. The original commit predated the DEV-90 `plan → resolve → phrase` AI rewrite, so the AI wiring moved from `executeTool` to the new resolver path.

## How it works — one shared policy layer

- **`src/shared/systemNoise.ts`** — one source of truth for invisible OS identities (bundle + name).
- **`src/shared/evidencePrivacy.ts`** — last-line filter before evidence leaves the resolver/MCP layer. Drops excluded apps (by bundle / base-bundle / canonical id / name), excluded sites (host + subdomains), and system noise; redacts excluded values embedded in free text with **bounded matching** so `Arc` never redacts "architecture".
- **`src/shared/trackingControls.ts`** — canonical/profile-aware app exclusion (excluding `chrome` or the base bundle drops every `:Profile` variant).

Wired into `main`'s current structure:
- **AI** — `resolvers.runResolverQueries` filters every fact before it is serialized for the model.
- **MCP** — `executeTool` filters before returning; `mcpServer.ts` hands the current exclusion set to the subprocess via env; `packages/mcp-server` reads it.
- **Capture** — `focusCapture.shouldCaptureFocusEvent` gates every helper event with the same system-noise + app/site exclusion logic as the foreground poll.
- System noise centralized in `tracking.ts` and `queries.ts` onto the shared policy.

## A real leak the original fix never caught

Driving **real captured data** (not just compiling) surfaced a hole the original commit's tests missed: excluding `youtube.com` dropped the structured domain row but left brand mentions — `"Watching YouTube"` block labels and `"… - YouTube"` page titles — naming the site to the AI/MCP. The evidence filter now expands a registrable 2-label host to its brand token (`youtube.com` → `youtube`) while staying bounded (`youtuber` is untouched) and **not** nuking a parent brand for subdomain exclusions (`docs.google.com` does not redact every "Google"). Locked with regression tests.

## Proof (live, on real data — not just green tests)

Against the real captured DB (`2026-06-21`), excluding app `dia` (canonical) + site `youtube.com`:

**Real resolver/AI path + executeTool, real DB** — all pass: excluded app & site present with controls OFF, absent with controls ON; kept apps survive; system noise never present.

**Real MCP subprocess** (`dist/mcp-server/index.cjs` spawned over stdio with the exclusion env, exactly as Claude Desktop would) — all pass: `dia` and `youtube` present OFF, absent ON, real payload returned.

This proves *data captured before the exclusion* is filtered, on all three surfaces. Harnesses checked in at `tests/support/verify-dev87.ts` and `tests/support/verify-mcp-subprocess.mjs`.

## Checks

- `npm run typecheck` ✓  · `npm run lint` ✓ (no new warnings) · `npm test` ✓ **658 pass / 0 fail**
- New tests: `tests/evidencePrivacy.test.ts`, `tests/focusCaptureGate.test.ts`, + additions to `trackingControls`/`captureFoundation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Privacy-critical changes to what data reaches AI/MCP and what gets persisted in focus capture; incorrect filtering could leak excluded activity or over-redact legitimate answers.
> 
> **Overview**
> Closes a **P0 privacy gap** where excluded apps/sites and OS “system noise” could still reach the **AI tab**, **MCP tool responses**, and **`focus_events`**, even when Tracking Controls said they should not leave the machine.
> 
> Introduces shared **`systemNoise`** (one OS-noise policy) and **`evidencePrivacy`** (last-line filter that drops excluded structured rows, strips system noise always, and **redacts** excluded brand tokens in free text with bounded matching—including brand expansion for sites like `youtube.com` so labels/titles do not leak).
> 
> **Wiring:** `runResolverQueries` / `executeTool` apply the filter before serialization or `sanitizeToolResult`; the MCP subprocess gets exclusion lists via **env** from `mcpServer.ts`; **`shouldCaptureFocusEvent`** gates focus helper events like foreground capture; app exclusion matching now covers **canonical id** and **browser profile** bundle variants; `getRange` carries **`bundleId`** on rolled-up apps for bundle-based filtering.
> 
> Adds unit tests plus live verification harnesses for resolver/MCP paths on real DB data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7bd35e285dd67cc0c7c8a5cfdbdfd89afe6f07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced privacy controls now consistently applied across AI tools, resolvers, and data analysis throughout the system.
  * Users can exclude specific apps and websites from being tracked and analyzed.
  * System-level applications are automatically filtered from all data processing.

* **Tests**
  * Added comprehensive tests for privacy filtering, focus event capture, and tracking control boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->