### PR TITLE
DEV-95: Windows capture parity and product proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,18 @@ jobs:
       # the Electron binary never trips on a missing X server during startup.
       - name: Run hermetic test suite
         run: xvfb-run -a npm test
+
+  windows:
+    name: windows-native-rebuild
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - name: Rebuild native modules for Electron
+        run: npx electron-rebuild -f -w better-sqlite3,@paymoapp/active-window,keytar
+      - run: npm run typecheck
+      - run: npm test

--- a/.github/workflows/verify-windows-runtime.yml
+++ b/.github/workflows/verify-windows-runtime.yml
@@ -1,0 +1,81 @@
+name: Verify Windows Runtime
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify-windows-runtime:
+    timeout-minutes: 90
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Rebuild native modules for Electron
+        run: npx electron-rebuild -f -w better-sqlite3,@paymoapp/active-window,keytar
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build Vite bundles and Windows capture helper
+        run: npm run build:all
+
+      - name: Package Windows installer
+        run: npx electron-builder --win nsis --x64 --config electron-builder.config.js --publish never
+
+      - name: Verify packaged native modules
+        run: node scripts/verify-packaged-natives.js
+
+      - name: Smoke-test packaged runtime
+        shell: pwsh
+        run: |
+          $version = node -p "require('./package.json').version"
+          $setup = "dist-release/Daylens-$version-Setup.exe"
+          if (-not (Test-Path $setup)) { throw "Missing installer: $setup" }
+          $installDir = Join-Path $env:RUNNER_TEMP "daylens-smoke"
+          if (Test-Path $installDir) { Remove-Item -Recurse -Force $installDir }
+          New-Item -ItemType Directory -Path $installDir | Out-Null
+          Start-Process -FilePath $setup -ArgumentList '/S', "/D=$installDir" -Wait
+          $appExe = Get-ChildItem -Path $installDir -Filter Daylens.exe -Recurse | Select-Object -First 1
+          if (-not $appExe) { throw 'Daylens.exe not found after install' }
+          $env:DAYLENS_SMOKE_TEST = '1'
+          $env:DAYLENS_SMOKE_REPORT_PATH = Join-Path $env:RUNNER_TEMP 'daylens-windows-smoke.json'
+          $proc = Start-Process -FilePath $appExe.FullName -PassThru -Wait
+          if ($proc.ExitCode -ne 0) { throw "Smoke run exited with code $($proc.ExitCode)" }
+          node scripts/verify-windows-smoke.js --report $env:DAYLENS_SMOKE_REPORT_PATH
+
+      - name: Upload Windows runtime diagnostics
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-runtime-diagnostics
+          if-no-files-found: warn
+          compression-level: 0
+          retention-days: 14
+          path: |
+            dist-release/**
+            ${{ runner.temp }}/daylens-windows-smoke.json
+            builder-debug.yml
+            electron-builder-debug.yml
+            npm-debug.log*

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,33 @@
+# Installing Daylens
+
+Daylens ships installable builds for macOS, Windows, and Linux.
+
+## Windows
+
+1. Download `Daylens-<version>-Setup.exe` from the [GitHub Releases](https://github.com/irachrist1/daylens/releases) page or the in-app updater.
+2. Run the installer. Daylens installs per-user and adds a Start Menu shortcut.
+3. Launch **Daylens** from the Start Menu.
+
+### SmartScreen warning
+
+Unsigned preview builds may show a Windows SmartScreen warning. Choose **More info → Run anyway** for local testing, or install a signed release build when signing secrets are configured in CI.
+
+### Data location
+
+Your local database and settings live under:
+
+`%APPDATA%\Daylens\`
+
+Nothing leaves your machine unless you connect an AI provider and ask Daylens to use it.
+
+## macOS
+
+Download the `.zip` or `.dmg` from Releases, open the app, and grant **Accessibility** (and **Screen Recording** when prompted) so Daylens can read window titles.
+
+## Linux
+
+Use the AppImage, `.deb`, or `.rpm` from Releases. See `CONTRIBUTING.md` for distro dependencies.
+
+## Updating
+
+Packaged builds check for updates on launch when `electron-updater` is enabled. Dev builds (`npm start`) do not auto-update — pull from git instead.

--- a/docs/WINDOWS_SIGNING.md
+++ b/docs/WINDOWS_SIGNING.md
@@ -1,0 +1,30 @@
+# Windows code signing
+
+Production Windows installers should be **Authenticode-signed** so SmartScreen does not block first-time installs.
+
+## CI secrets
+
+Configure these GitHub Actions secrets for `release-windows.yml`:
+
+| Secret | Purpose |
+|--------|---------|
+| `WIN_CERTIFICATE_FILE_PATH` | Path to the `.pfx` on the runner (or use a secure file mount step) |
+| `WIN_CERTIFICATE_PASSWORD` | PFX password |
+| `WIN_CERT_SUBJECT_NAME` | Certificate subject name for `electron-builder` |
+
+`electron-builder.config.js` reads the same environment variables at pack time.
+
+## Local signing
+
+```powershell
+$env:WIN_CERTIFICATE_FILE_PATH = 'C:\path\to\daylens.pfx'
+$env:WIN_CERTIFICATE_PASSWORD = '***'
+$env:WIN_CERT_SUBJECT_NAME = 'Your Publisher Name'
+npm run dist:win
+```
+
+## Verification
+
+`release-windows.yml` runs `Get-AuthenticodeSignature` on the produced `Setup.exe` when secrets are present.
+
+Unsigned builds are fine for internal smoke tests; do not ship them to users without the SmartScreen warning called out in `docs/INSTALL.md`.

--- a/docs/research/windows-capture.md
+++ b/docs/research/windows-capture.md
@@ -1,0 +1,109 @@
+# Windows capture — research and chosen approach
+
+**Status:** Researched · **Date:** 2026-06-22 · **Issue:** DEV-95
+
+Companion to [`docs/findings.md`](../findings.md) and [`docs/research/prior-art.md`](prior-art.md) §1.
+Mac capture is proven via `@paymoapp/active-window` + the Swift helper. This doc records what
+Windows gives us, what we chose, and what comes later.
+
+---
+
+## 1. Baseline (code audit, pre-fix)
+
+| Signal | Windows today | Gap |
+|--------|---------------|-----|
+| Foreground app + window title | `@paymoapp/active-window` every 5s | Works; no high-frequency title stream |
+| Live browser tab URL/title | History inference only (`browserContext.ts`) | No live URL; lag + title-matching errors |
+| Browser discovery | Hardcoded exe list + `windowsBrowsers()` paths | Zen/unknown forks miss unless hardcoded |
+| Capture health | Queries Mac-only `focus_events` sources | Always shows "waiting" on Windows |
+| Permissions UI | Auto-"granted" | Misleading; no helper-running signal |
+| Background builds | WMIC snapshot in diagnostics only | Not in block evidence |
+
+Foreground capture and Chromium/Firefox **history polling** already work. The gaps are live tab
+reads, OS-level browser discovery, platform-aware health, and background-process evidence.
+
+---
+
+## 2. Live tab URL — UI Automation first
+
+**Chosen:** A small **C# native helper** using **UI Automation (UIA)** for Chromium-family
+browsers. Same NDJSON event stream as the Mac Swift helper → `focus_events` with
+`platform='win32'`.
+
+**Why UIA first (not extension):**
+
+- No install step for the user — Daylens ships as one installer.
+- Chromium, Edge, Brave, Arc, Dia, Comet expose the address bar as a UIA `Edit` control in
+  most configurations.
+- Matches the Mac pattern: native helper beside Electron, never guess on failure.
+
+**Firefox / Zen:** Same as Mac — no live URL via OS APIs. Read `places.sqlite` on a poll
+interval; helper emits `confidence: unknown` for tab reads (never invent a URL).
+
+**Phase 2 (documented, not v1):** Browser extension per ActivityWatch / RescueTime — gold
+standard for incognito-aware, exact tab data across every browser. See `prior-art.md` §1.
+
+**UIA risks:** Address-bar automation IDs change between browser versions. Mitigation:
+family-specific selectors + history fallback; capture-health shows when live reads fail.
+
+---
+
+## 3. Browser discovery — StartMenuInternet + URL handlers
+
+**Chosen:** Mirror Mac Launch Services by reading Windows URL-handler registration:
+
+1. **`HKCU\Software\Clients\StartMenuInternet`** — installed browsers (Chrome, Firefox, Edge, …).
+2. **`HKCR\<ProgId>\shell\open\command`** — resolve ProgId → executable path.
+3. **AppData scan** — for each discovered exe, locate `User Data/.../History` (Chromium) or
+   `profiles.ini` → `places.sqlite` (Firefox family, including Zen at `%APPDATA%\zen\Profiles`).
+
+Static paths in `windowsBrowsers()` remain as fallback when registry read fails (corporate
+images, portable browsers).
+
+One registry cache (`REGISTRY_CACHE_MS`) feeds both foreground browser tagging and history
+polling — same single source of truth as Mac `browserRegistry.ts`.
+
+---
+
+## 4. Background process evidence — CIM now, ETW later
+
+**Chosen for v1:** Replace deprecated **WMIC** with **PowerShell `Get-CimInstance Win32_Process`**
+for process name, PID, working set. Track deltas between polls to estimate sustained CPU.
+
+**Later:** ETW provider `Microsoft-Windows-Kernel-Process` for accurate CPU% over time without
+polling every process.
+
+**Guardrails:**
+
+- Filter system noise (`svchost`, `System`, `Registry`, `dwm`, …) — same spirit as Mac
+  `loginwindow` rules.
+- Never surface raw CPU/memory in UI — only fold notable long-running tools into block
+  evidence as intent ("a local build was running").
+- Cap at top N processes per hour.
+
+Mac has no equivalent API today; Windows leads here. A Mac counterpart is a future stub only.
+
+---
+
+## 5. CI and verification
+
+- **PR gate:** `windows-latest` typecheck + native rebuild + hermetic tests.
+- **Runtime gate:** `verify-windows-runtime.yml` — package NSIS, `verify-packaged-natives.js`,
+  launch with `DAYLENS_SMOKE_TEST=1`.
+- **UIA / real browsing:** Manual on a physical Windows machine (CI cannot drive Edge tabs
+  reliably). Surface QA checklist: `docs/windows-surface-qa-checklist.md`.
+
+---
+
+## 6. Implementation packets (ship order)
+
+1. Windows browser registry
+2. UIA capture helper + `windowsFocusCapture.ts`
+3. Platform-aware capture health + Settings panel
+4. Background process evidence (CIM)
+5. Windows CI + smoke mode
+6. Surface QA on real hardware
+7. `INSTALL.md` + `WINDOWS_SIGNING.md`
+
+Parent issue DEV-95 closes when all packets land and the surface matrix is screenshot-verified
+on a real Windows day.

--- a/docs/windows-surface-qa-checklist.md
+++ b/docs/windows-surface-qa-checklist.md
@@ -1,0 +1,52 @@
+# Windows surface QA checklist (DEV-95)
+
+Run on a **physical Windows machine** after capture packets land. Attach screenshots to [DEV-95](https://linear.app/irachrist1/issue/DEV-95).
+
+## Capture
+
+- [ ] Foreground app + window title appear in Timeline within 30s of switching apps
+- [ ] Edge/Chrome tab URL appears in Apps without waiting for history lag (UIA helper)
+- [ ] Zen/Firefox pages appear via history polling; live tab shows honest unknown (never guessed)
+- [ ] Capture health in Settings shows **Healthy** window titles when browsing
+- [ ] Capture health lists discovered browsers
+
+## Timeline (`docs/specs/timeline.md`)
+
+- [ ] Analyze Day yields ~8 believable blocks on a real day
+- [ ] Block height proportional to duration
+- [ ] Rename survives re-analyze
+- [ ] Brief detour absorbed into surrounding block
+
+## Apps (`docs/specs/apps.md`)
+
+- [ ] App names are real (not raw exe noise)
+- [ ] Domains attributed to hosting browser
+- [ ] Delete page/domain works
+
+## AI (`docs/specs/ai.md`)
+
+- [ ] "What did I do today?" returns grounded answer
+- [ ] Chat survives tab switch
+- [ ] Model from Settings is the one that runs
+
+## Settings (`docs/specs/settings.md`)
+
+- [ ] Work memory paragraph edits persist
+- [ ] Label overrides propagate after recompute
+- [ ] Exclusions hide data from AI
+
+## Onboarding (`docs/specs/onboarding.md`)
+
+- [ ] Proof step shows real captured activity (not canned)
+
+## Wraps (`docs/specs/briefs-wraps.md`)
+
+- [ ] When DEV-91 lands: card and write-up totals agree
+
+## Background evidence (Windows advantage)
+
+- [ ] Long `npm run build` while switched away appears in block evidence
+
+## Install
+
+- [ ] NSIS installer on clean VM per `docs/INSTALL.md`

--- a/scripts/build-capture-helper.sh
+++ b/scripts/build-capture-helper.sh
@@ -1,18 +1,30 @@
 #!/usr/bin/env bash
-# Compiles the macOS capture helper to build/capture-helper.
-# Ships to the packaged app via electron-builder's extraResources (build/ -> resources/build).
-# No-op on non-macOS so cross-platform `build:all` stays green.
+# Builds platform capture helpers into build/.
+# macOS: Swift capture-helper
+# Windows: .NET UIA windows-capture-helper.exe
 set -euo pipefail
 
-if [[ "$(uname)" != "Darwin" ]]; then
-  echo "[build-capture-helper] skipping on $(uname); macOS-only"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+mkdir -p "$ROOT/build"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  SRC="$ROOT/src/native/capture-helper/main.swift"
+  OUT="$ROOT/build/capture-helper"
+  swiftc -O -o "$OUT" "$SRC"
+  echo "[build-capture-helper] built $OUT"
   exit 0
 fi
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-SRC="$ROOT/src/native/capture-helper/main.swift"
-OUT="$ROOT/build/capture-helper"
+if [[ "$(uname -s)" == MINGW* ]] || [[ "$(uname -s)" == MSYS* ]] || [[ "${OS:-}" == "Windows_NT" ]]; then
+  dotnet publish "$ROOT/src/native/windows-capture-helper/WindowsCaptureHelper.csproj" \
+    -c Release \
+    -r win-x64 \
+    --self-contained true \
+    -p:PublishSingleFile=true \
+    -o "$ROOT/build"
+  echo "[build-capture-helper] built $ROOT/build/windows-capture-helper.exe"
+  exit 0
+fi
 
-mkdir -p "$ROOT/build"
-swiftc -O -o "$OUT" "$SRC"
-echo "[build-capture-helper] built $OUT"
+echo "[build-capture-helper] skipping on $(uname); helpers are platform-specific"
+exit 0

--- a/scripts/verify-linux-smoke.js
+++ b/scripts/verify-linux-smoke.js
@@ -97,6 +97,14 @@ if (!report.trackingStatus.moduleSource && !report.trackingStatus.loadError) {
   fail('Expected either a tracking backend source or a tracking load error.')
 }
 
+if (!report.linuxTracking || typeof report.linuxTracking !== 'object') {
+  fail('Linux tracking diagnostics were missing from the smoke report.')
+}
+
+if (!['ready', 'limited', 'unsupported'].includes(report.linuxTracking.supportLevel)) {
+  fail(`Expected linuxTracking.supportLevel to be ready/limited/unsupported, got ${report.linuxTracking.supportLevel}`)
+}
+
 console.log('Smoke verification passed:')
 console.log(JSON.stringify({
   packageType: report.linuxDesktop.packageType,
@@ -104,5 +112,7 @@ console.log(JSON.stringify({
   packageOwner: report.linuxDesktop.packageOwner,
   updaterSupported: report.updater.supported,
   trackerBackend: report.trackingStatus.moduleSource,
+  linuxTrackingSupport: report.linuxTracking.supportLevel,
+  discoveredBrowsers: report.browserStatus.discoveredBrowsers.length,
   trayAvailable: report.tray?.available ?? null,
 }, null, 2))

--- a/scripts/verify-windows-smoke.js
+++ b/scripts/verify-windows-smoke.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+function usage() {
+  console.error('Usage: node scripts/verify-windows-smoke.js --report <path>')
+  process.exit(1)
+}
+
+function readArg(flag) {
+  const index = process.argv.indexOf(flag)
+  if (index === -1) return null
+  return process.argv[index + 1] ?? null
+}
+
+function fail(message) {
+  console.error(`Smoke verification failed: ${message}`)
+  process.exit(1)
+}
+
+const reportPathArg = readArg('--report')
+if (!reportPathArg) usage()
+
+const reportPath = path.resolve(reportPathArg)
+if (!fs.existsSync(reportPath)) {
+  fail(`Report file does not exist: ${reportPath}`)
+}
+
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+
+if (report.ok !== true) {
+  fail(`App reported failure at stage "${report.stage ?? 'unknown'}": ${report.error ?? 'unknown error'}`)
+}
+
+if (report.platform !== 'win32') {
+  fail(`Expected win32 platform, got: ${report.platform}`)
+}
+
+if (report.isPackaged !== true) {
+  fail('Expected a packaged app runtime.')
+}
+
+if (!report.trackingStatus || typeof report.trackingStatus !== 'object') {
+  fail('Tracking status was missing from the smoke report.')
+}
+
+if (!report.browserStatus || typeof report.browserStatus !== 'object') {
+  fail('Browser diagnostics were missing from the smoke report.')
+}
+
+if (!Array.isArray(report.browserStatus.discoveredBrowsers)) {
+  fail('Browser discovery diagnostics were malformed.')
+}
+
+if (!report.updater || typeof report.updater !== 'object') {
+  fail('Updater diagnostics were missing from the smoke report.')
+}
+
+console.log('Windows smoke verification passed.')
+process.exit(0)

--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -1833,6 +1833,75 @@ const migrations: Migration[] = [
       `)
     },
   },
+  {
+    version: 35,
+    description: 'Expand focus_events for Windows UIA capture sources and window_changed',
+    up: () => {
+      getDb().exec(`
+        CREATE TABLE focus_events_v35 (
+          id            INTEGER PRIMARY KEY AUTOINCREMENT,
+          ts_ms         INTEGER NOT NULL,
+          mono_ns       INTEGER NOT NULL,
+          event_type    TEXT    NOT NULL CHECK(event_type IN (
+            'app_activated',
+            'app_deactivated',
+            'window_changed',
+            'space_changed',
+            'sleep',
+            'wake',
+            'lock',
+            'unlock',
+            'tab_changed',
+            'tab_sampled'
+          )),
+          app_bundle_id TEXT,
+          app_name      TEXT,
+          pid           INTEGER,
+          window_title  TEXT,
+          url           TEXT,
+          page_title    TEXT,
+          source        TEXT    NOT NULL CHECK(source IN (
+            'nsworkspace_event',
+            'apple_events_tab',
+            'uia_foreground',
+            'uia_tab'
+          )),
+          confidence    TEXT    NOT NULL CHECK(confidence IN ('observed', 'unknown')),
+          platform      TEXT    NOT NULL DEFAULT 'darwin',
+          schema_ver    INTEGER NOT NULL DEFAULT 1 CHECK(schema_ver = 1),
+          CHECK(confidence <> 'unknown' OR (url IS NULL AND page_title IS NULL)),
+          CHECK(source NOT IN ('nsworkspace_event', 'uia_foreground') OR (url IS NULL AND page_title IS NULL)),
+          CHECK(source NOT IN ('apple_events_tab', 'uia_tab') OR confidence <> 'observed' OR url IS NOT NULL),
+          CHECK(source NOT IN ('apple_events_tab', 'uia_tab') OR event_type IN ('tab_changed', 'tab_sampled')),
+          CHECK(source NOT IN ('nsworkspace_event', 'uia_foreground') OR event_type IN (
+            'app_activated',
+            'app_deactivated',
+            'window_changed',
+            'space_changed',
+            'sleep',
+            'wake',
+            'lock',
+            'unlock'
+          ))
+        );
+
+        INSERT INTO focus_events_v35 (
+          id, ts_ms, mono_ns, event_type, app_bundle_id, app_name, pid,
+          window_title, url, page_title, source, confidence, platform, schema_ver
+        )
+        SELECT
+          id, ts_ms, mono_ns, event_type, app_bundle_id, app_name, pid,
+          window_title, url, page_title, source, confidence, platform, schema_ver
+        FROM focus_events;
+
+        DROP TABLE focus_events;
+        ALTER TABLE focus_events_v35 RENAME TO focus_events;
+        CREATE INDEX IF NOT EXISTS idx_focus_events_ts ON focus_events(ts_ms);
+        CREATE INDEX IF NOT EXISTS idx_focus_events_type ON focus_events(event_type);
+        CREATE INDEX IF NOT EXISTS idx_focus_events_platform ON focus_events(platform);
+      `)
+    },
+  },
 ]
 
 function attentionClassForCategory(category: string): 'focus' | 'supporting' | 'ambient' {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,6 +62,8 @@ import { runPendingDerivedStateReset } from './core/projections/metadata'
 import { hasApiKey, initSettings, getSettings, setSettings } from './services/settings'
 import { startTracking, stopTracking, trackingStatus } from './services/tracking'
 import { startFocusCapture, stopFocusCapture } from './services/focusCapture'
+import { startWindowsFocusCapture, stopWindowsFocusCapture } from './services/windowsFocusCapture'
+import { ensureProcessMonitor } from './services/processMonitor'
 import { getBrowserStatus, startBrowserTracking, stopBrowserTracking } from './services/browser'
 import { startSync, stopSync, finalizePreviousDay, syncNowForQuit } from './services/syncUploader'
 import { backfillWindowsHistory } from './services/windowsHistory'
@@ -328,7 +330,11 @@ function startBackgroundServices(): void {
   if (!shouldStartTrackingForSettings(getSettings())) return
 
   startTracking()
-  startFocusCapture()
+  if (process.platform === 'darwin') startFocusCapture()
+  if (process.platform === 'win32') {
+    startWindowsFocusCapture()
+    ensureProcessMonitor()
+  }
   if (!SMOKE_TEST) {
     startSync()
     startDailySummaryNotifier(mainWindow)
@@ -454,6 +460,7 @@ async function shutdownApp(options?: { awaitFinalSync?: boolean; backupBeforeExi
   stopMcpServer()
   stopTracking()
   stopFocusCapture()
+  stopWindowsFocusCapture()
   stopBrowserTracking()
   stopSync()
   stopProcessMonitor()
@@ -545,8 +552,8 @@ function createWindow(): BrowserWindow {
   })
 
   let smokeValidationStarted = false
-  const maybeRunLinuxSmokeValidation = (trigger: SmokeValidationTrigger) => {
-    if (!SMOKE_TEST || process.platform !== 'linux') return
+  const maybeRunSmokeValidation = (trigger: SmokeValidationTrigger) => {
+    if (!SMOKE_TEST || (process.platform !== 'linux' && process.platform !== 'win32')) return
     if (smokeValidationStarted) return
     smokeValidationStarted = true
     void runSmokeValidation(win, trigger)
@@ -554,11 +561,11 @@ function createWindow(): BrowserWindow {
 
   win.once('ready-to-show', () => {
     win.show()
-    maybeRunLinuxSmokeValidation('ready-to-show')
+    maybeRunSmokeValidation('ready-to-show')
   })
-  win.webContents.once('did-finish-load', () => maybeRunLinuxSmokeValidation('did-finish-load'))
-  if (SMOKE_TEST && process.platform === 'linux') {
-    setTimeout(() => maybeRunLinuxSmokeValidation('watchdog'), 20_000)
+  win.webContents.once('did-finish-load', () => maybeRunSmokeValidation('did-finish-load'))
+  if (SMOKE_TEST && (process.platform === 'linux' || process.platform === 'win32')) {
+    setTimeout(() => maybeRunSmokeValidation('watchdog'), 20_000)
   }
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {

--- a/src/main/ipc/db.handlers.ts
+++ b/src/main/ipc/db.handlers.ts
@@ -677,7 +677,7 @@ export function registerDbHandlers(): void {
     let recentSamplesWithTitle = titleRows.with_title ?? 0
     let lastCapturedAt = titleRows.last_captured_at
 
-    if (process.platform === 'win32' && recentSamplesWithTitle === 0) {
+    if ((process.platform === 'win32' || process.platform === 'linux') && recentSamplesWithTitle === 0) {
       const sessionRows = db.prepare(`
         SELECT
           COUNT(*) AS recent_samples,

--- a/src/main/ipc/db.handlers.ts
+++ b/src/main/ipc/db.handlers.ts
@@ -43,6 +43,8 @@ import { runAttributionForRange } from '../services/attribution'
 import { backfillMemoryFromHistory } from '../jobs/eveningConsolidation'
 import { getDb, tableExists } from '../services/database'
 import { getCurrentSession, getLinuxTrackingDiagnostics, trackingStatus } from '../services/tracking'
+import { getBrowserStatus } from '../services/browser'
+import { isWindowsFocusCaptureRunning } from '../services/windowsFocusCapture'
 import { deleteHistoryForApp, deleteHistoryForSite, deleteTrackedActivity } from '../services/trackingHistory'
 import { getProcessMetrics } from '../services/processMonitor'
 import { getBlockDetailPayload, getDistractionCostPayload, getRecapRange, shouldReanalyzeBlockWithAI, writeTimelineBlockReview, mergeTimelineEpisodes } from '../services/workBlocks'
@@ -655,13 +657,14 @@ export function registerDbHandlers(): void {
   ipcMain.handle(IPC.TRACKING.GET_LIVE, () => getCurrentSession())
   ipcMain.handle(IPC.TRACKING.GET_DIAGNOSTICS, () => {
     const since = Date.now() - 15 * 60_000
-    const titleRows = getDb().prepare(`
+    const db = getDb()
+    const titleRows = db.prepare(`
       SELECT
         COUNT(*) AS recent_samples,
         SUM(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN 1 ELSE 0 END) AS with_title,
         MAX(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN ts_ms ELSE NULL END) AS last_captured_at
       FROM focus_events
-      WHERE source = 'nsworkspace_event'
+      WHERE source IN ('nsworkspace_event', 'uia_foreground')
         AND event_type IN ('app_activated', 'window_changed', 'space_changed')
         AND ts_ms >= ?
     `).get(since) as {
@@ -669,7 +672,31 @@ export function registerDbHandlers(): void {
       with_title: number | null
       last_captured_at: number | null
     }
-    const recentSamplesWithTitle = titleRows.with_title ?? 0
+
+    let recentSamples = titleRows.recent_samples
+    let recentSamplesWithTitle = titleRows.with_title ?? 0
+    let lastCapturedAt = titleRows.last_captured_at
+
+    if (process.platform === 'win32' && recentSamplesWithTitle === 0) {
+      const sessionRows = db.prepare(`
+        SELECT
+          COUNT(*) AS recent_samples,
+          SUM(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN 1 ELSE 0 END) AS with_title,
+          MAX(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN start_time ELSE NULL END) AS last_captured_at
+        FROM app_sessions
+        WHERE start_time >= ?
+      `).get(since) as {
+        recent_samples: number
+        with_title: number | null
+        last_captured_at: number | null
+      }
+      recentSamples = Math.max(recentSamples, sessionRows.recent_samples)
+      recentSamplesWithTitle = Math.max(recentSamplesWithTitle, sessionRows.with_title ?? 0)
+      lastCapturedAt = lastCapturedAt ?? sessionRows.last_captured_at
+    }
+
+    const browserStatus = getBrowserStatus()
+    const captureHelperRunning = process.platform === 'win32' ? isWindowsFocusCaptureRunning() : null
 
     return {
       platform: process.platform,
@@ -679,13 +706,18 @@ export function registerDbHandlers(): void {
         windowTitles: {
           status: recentSamplesWithTitle > 0
             ? 'healthy'
-            : titleRows.recent_samples > 0
+            : recentSamples > 0
               ? 'missing'
               : 'waiting',
-          recentSamples: titleRows.recent_samples,
+          recentSamples,
           recentSamplesWithTitle,
-          lastCapturedAt: titleRows.last_captured_at,
+          lastCapturedAt,
         },
+        browsers: {
+          discoveredCount: browserStatus.discoveredBrowsers.length,
+          names: browserStatus.discoveredBrowsers.map((browser) => browser.name),
+        },
+        captureHelperRunning,
       },
       linuxTracking: getLinuxTrackingDiagnostics(),
       linuxDesktop: getLinuxDesktopDiagnostics(),

--- a/src/main/services/backgroundProcessEvidence.ts
+++ b/src/main/services/backgroundProcessEvidence.ts
@@ -54,15 +54,91 @@ function normalizedProcessName(name: string): string {
   return name.replace(/\.exe$/i, '').toLowerCase()
 }
 
+const LINUX_BACKGROUND_NOISE_EXACT = new Set([
+  'systemd',
+  'init',
+  'kthreadd',
+  'ksoftirqd',
+  'migration',
+  'rcu_sched',
+  'rcu_bh',
+  'watchdog',
+  'cpuhp',
+  'kworker',
+  'kdevtmpfs',
+  'kauditd',
+  'khungtaskd',
+  'oom_reaper',
+  'writeback',
+  'kcompactd',
+  'ksmd',
+  'khugepaged',
+  'kintegrityd',
+  'kblockd',
+  'ata_sff',
+  'md',
+  'edac-poller',
+  'devfreq_wq',
+  'watchdogd',
+  'kswapd',
+  'ecryptfs-kthrea',
+  'kthrotld',
+  'acpi_thermal_pm',
+  'scsi_eh',
+  'scsi_tmf',
+  'ipv6_addrconf',
+  'kstrp',
+  'zswap-shrink',
+  'krfcommd',
+  'irq',
+  'dbus-daemon',
+  'pipewire',
+  'wireplumber',
+  'pulseaudio',
+  'xdg-desktop-por',
+  'xdg-document-po',
+  'xdg-permission-',
+  'gjs',
+  'gnome-shell',
+  'mutter',
+  'kwin_wayland',
+  'kwin_x11',
+  'plasmashell',
+  'ksmserver',
+  'systemd-user',
+  'systemd-logind',
+  'systemd-journal',
+  'systemd-udevd',
+  'systemd-resolved',
+  'systemd-network',
+  'sshd',
+  'cron',
+  'at-spi-bus-launcher',
+  'at-spi2-registryd',
+])
+
+function isLinuxBackgroundNoise(name: string): boolean {
+  const normalized = normalizedProcessName(name)
+  if (!normalized) return true
+  if (LINUX_BACKGROUND_NOISE_EXACT.has(normalized)) return true
+  if (normalized.startsWith('kworker')) return true
+  if (normalized.startsWith('irq/')) return true
+  if (normalized.startsWith('xdg-')) return true
+  if (normalized.startsWith('systemd-')) return true
+  return false
+}
+
 export function isBackgroundProcessNoise(name: string): boolean {
   const normalized = normalizedProcessName(name)
-  if (!normalized || BACKGROUND_NOISE_EXACT.has(normalized)) return true
+  if (!normalized) return true
+  if (process.platform === 'linux') return isLinuxBackgroundNoise(name)
+  if (BACKGROUND_NOISE_EXACT.has(normalized)) return true
   if (normalized.startsWith('svchost')) return true
   return false
 }
 
 export function observeProcessSnapshots(snapshots: ProcessSnapshot[], capturedAt = Date.now()): void {
-  if (process.platform !== 'win32') return
+  if (process.platform !== 'win32' && process.platform !== 'linux') return
 
   const seen = new Set<string>()
   for (const snapshot of snapshots) {
@@ -98,7 +174,7 @@ export function getBackgroundProcessEvidence(
   startTime: number,
   endTime: number,
 ): BackgroundProcessEvidence[] {
-  if (process.platform !== 'win32') return []
+  if (process.platform !== 'win32' && process.platform !== 'linux') return []
 
   const results: BackgroundProcessEvidence[] = []
   for (const tracked of activeBackground.values()) {

--- a/src/main/services/backgroundProcessEvidence.ts
+++ b/src/main/services/backgroundProcessEvidence.ts
@@ -1,0 +1,124 @@
+import type { ProcessSnapshot } from '@shared/types'
+
+const MIN_BACKGROUND_DURATION_MS = 5 * 60_000
+const MIN_BACKGROUND_MEMORY_MB = 200
+const MAX_BACKGROUND_PROCESSES = 8
+
+const BACKGROUND_NOISE_EXACT = new Set([
+  'system',
+  'registry',
+  'smss',
+  'csrss',
+  'wininit',
+  'services',
+  'lsass',
+  'svchost',
+  'dwm',
+  'explorer',
+  'runtimebroker',
+  'searchindexer',
+  'searchhost',
+  'shellexperiencehost',
+  'startmenuexperiencehost',
+  'applicationframehost',
+  'textinputhost',
+  'securityhealthservice',
+  'sihost',
+  'taskhostw',
+  'conhost',
+  'dllhost',
+  'audiodg',
+  'spoolsv',
+  'wmiprvse',
+  'fontdrvhost',
+  'ctfmon',
+  'idle',
+])
+
+export interface BackgroundProcessEvidence {
+  name: string
+  totalSeconds: number
+  memoryMbPeak: number
+}
+
+interface TrackedBackgroundProcess {
+  name: string
+  startedAt: number
+  lastSeenAt: number
+  memoryMbPeak: number
+}
+
+const activeBackground = new Map<string, TrackedBackgroundProcess>()
+
+function normalizedProcessName(name: string): string {
+  return name.replace(/\.exe$/i, '').toLowerCase()
+}
+
+export function isBackgroundProcessNoise(name: string): boolean {
+  const normalized = normalizedProcessName(name)
+  if (!normalized || BACKGROUND_NOISE_EXACT.has(normalized)) return true
+  if (normalized.startsWith('svchost')) return true
+  return false
+}
+
+export function observeProcessSnapshots(snapshots: ProcessSnapshot[], capturedAt = Date.now()): void {
+  if (process.platform !== 'win32') return
+
+  const seen = new Set<string>()
+  for (const snapshot of snapshots) {
+    if (isBackgroundProcessNoise(snapshot.name)) continue
+    if (snapshot.memoryMb < MIN_BACKGROUND_MEMORY_MB) continue
+
+    const key = normalizedProcessName(snapshot.name)
+    seen.add(key)
+    const existing = activeBackground.get(key)
+    if (!existing) {
+      activeBackground.set(key, {
+        name: snapshot.name,
+        startedAt: capturedAt,
+        lastSeenAt: capturedAt,
+        memoryMbPeak: snapshot.memoryMb,
+      })
+      continue
+    }
+
+    existing.lastSeenAt = capturedAt
+    existing.memoryMbPeak = Math.max(existing.memoryMbPeak, snapshot.memoryMb)
+  }
+
+  for (const [key, tracked] of activeBackground.entries()) {
+    if (seen.has(key)) continue
+    if (capturedAt - tracked.lastSeenAt > 60_000) {
+      activeBackground.delete(key)
+    }
+  }
+}
+
+export function getBackgroundProcessEvidence(
+  startTime: number,
+  endTime: number,
+): BackgroundProcessEvidence[] {
+  if (process.platform !== 'win32') return []
+
+  const results: BackgroundProcessEvidence[] = []
+  for (const tracked of activeBackground.values()) {
+    const overlapStart = Math.max(startTime, tracked.startedAt)
+    const overlapEnd = Math.min(endTime, tracked.lastSeenAt)
+    if (overlapEnd <= overlapStart) continue
+    const durationMs = overlapEnd - overlapStart
+    if (durationMs < MIN_BACKGROUND_DURATION_MS) continue
+    results.push({
+      name: tracked.name,
+      totalSeconds: Math.round(durationMs / 1_000),
+      memoryMbPeak: tracked.memoryMbPeak,
+    })
+  }
+
+  return results
+    .sort((left, right) => right.totalSeconds - left.totalSeconds)
+    .slice(0, MAX_BACKGROUND_PROCESSES)
+}
+
+export function __resetBackgroundProcessEvidenceForTests(): void {
+  activeBackground.clear()
+}

--- a/src/main/services/browser.ts
+++ b/src/main/services/browser.ts
@@ -24,9 +24,11 @@ import { invalidateProjectionScope } from '../core/projections/invalidation'
 import { localDateString } from '../lib/localDate'
 import { capture, captureRateLimited } from './analytics'
 import {
+  getLinuxBrowserHistoryLocations,
   getMacBrowserHistoryLocations,
   type BrowserFamily,
 } from './browserRegistry'
+import { getWindowsBrowserHistoryLocations } from './windowsBrowserRegistry'
 import { decideAppCapture, decideSiteCapture, trackingControlsStateFromSettings } from '@shared/trackingControls'
 import { getSettings } from './settings'
 
@@ -176,7 +178,20 @@ function parseFirefoxProfilesIni(iniPath: string): string[] {
   return profileDirs
 }
 
-function windowsBrowsers(): BrowserEntry[] {
+function windowsBrowsersFromRegistry(): BrowserEntry[] {
+  return getWindowsBrowserHistoryLocations().map((location) => ({
+    name: location.profileId === 'default'
+      ? location.name
+      : `${location.name} (${location.profileId})`,
+    bundleId: location.profileId === 'default'
+      ? location.bundleId
+      : `${location.bundleId}:${location.profileId}`,
+    historyPath: location.historyPath,
+    type: location.family,
+  }))
+}
+
+function windowsBrowsersStatic(): BrowserEntry[] {
   const local = path.join(os.homedir(), 'AppData', 'Local')
   const roaming = path.join(os.homedir(), 'AppData', 'Roaming')
   const entries: BrowserEntry[] = []
@@ -257,9 +272,29 @@ function windowsBrowsers(): BrowserEntry[] {
   return entries
 }
 
+function windowsBrowsers(): BrowserEntry[] {
+  const registryEntries = windowsBrowsersFromRegistry()
+  if (registryEntries.length > 0) return registryEntries
+  return windowsBrowsersStatic()
+}
+
+function linuxBrowsers(): BrowserEntry[] {
+  return getLinuxBrowserHistoryLocations().map((location) => ({
+    name: location.profileId === 'default'
+      ? location.name
+      : `${location.name} (${location.profileId})`,
+    bundleId: location.profileId === 'default'
+      ? location.bundleId
+      : `${location.bundleId}:${location.profileId}`,
+    historyPath: location.historyPath,
+    type: location.family,
+  }))
+}
+
 export function getBrowserEntries(): BrowserEntry[] {
   if (process.platform === 'darwin') return macBrowsers()
   if (process.platform === 'win32') return windowsBrowsers()
+  if (process.platform === 'linux') return linuxBrowsers()
   return []
 }
 

--- a/src/main/services/browserContext.ts
+++ b/src/main/services/browserContext.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import Database from 'better-sqlite3'
 import type BetterSqlite from 'better-sqlite3'
 import { insertWebsiteVisit } from '../db/queries'
-import { normalizeUrlForStorage, pageKeyForUrl, resolveCanonicalApp, resolveCanonicalBrowser } from '../lib/appIdentity'
+import { normalizeUrlForStorage, pageKeyForUrl, resolveCanonicalBrowser } from '../lib/appIdentity'
 import { invalidateProjectionScope } from '../core/projections/invalidation'
 import { localDateString } from '../lib/localDate'
 import { getBrowserEntries, type BrowserEntry } from './browser'
@@ -16,6 +16,7 @@ import {
   type BrowserApplication,
   type BrowserCandidate,
 } from './browserRegistry'
+import { getDb } from './database'
 
 const MIN_CONTEXT_SEC = 10
 const RECENT_HISTORY_LOOKBACK_MS = 2 * 60_000
@@ -24,20 +25,6 @@ const RECENT_HISTORY_LOOKBACK_MS = 2 * 60_000
 // still cutting the per-5s-poll osascript/history reads during steady reading.
 const TAB_CACHE_TRUST_MS = 30_000
 const CHROME_OFFSET_US = 11_644_473_600_000_000n
-
-const WINDOWS_BROWSER_APP_IDS = new Set([
-  'arc',
-  'brave',
-  'chrome',
-  'chromium',
-  'comet',
-  'dia',
-  'edge',
-  'firefox',
-  'opera',
-  'safari',
-  'vivaldi',
-])
 
 export interface ActiveBrowserWindowSnapshot {
   bundleId: string
@@ -76,31 +63,14 @@ function extractDomain(url: string): string | null {
   }
 }
 
-function macBrowserApplicationFor(snapshot: ActiveBrowserWindowSnapshot): BrowserApplication | null {
-  return resolveBrowserApplication({
+function browserAppIdFor(snapshot: ActiveBrowserWindowSnapshot): string | null {
+  const application = resolveBrowserApplication({
     bundleId: snapshot.bundleId,
     appName: snapshot.appName,
     executablePath: snapshot.executablePath,
   })
-}
-
-function browserAppIdFor(snapshot: ActiveBrowserWindowSnapshot): string | null {
-  if (process.platform === 'darwin') {
-    const application = macBrowserApplicationFor(snapshot)
-    if (!application) return null
-    return resolveCanonicalBrowser(application.bundleId).canonicalBrowserId ?? application.bundleId.toLowerCase()
-  }
-
-  const identity = resolveCanonicalApp(snapshot.bundleId, snapshot.appName)
-  if (identity.canonicalAppId && WINDOWS_BROWSER_APP_IDS.has(identity.canonicalAppId)) {
-    return identity.canonicalAppId
-  }
-
-  const fallback = `${snapshot.bundleId} ${snapshot.appName}`.toLowerCase()
-  for (const browserId of WINDOWS_BROWSER_APP_IDS) {
-    if (fallback.includes(browserId)) return browserId
-  }
-  return null
+  if (!application) return null
+  return resolveCanonicalBrowser(application.bundleId).canonicalBrowserId ?? application.bundleId.toLowerCase()
 }
 
 function sameContext(left: InFlightBrowserContext, right: ActiveBrowserTab, normalizedUrl: string | null): boolean {
@@ -132,8 +102,16 @@ function runOsaScript(script: string): ActiveBrowserTab | null {
   }
 }
 
+function browserApplicationFor(snapshot: ActiveBrowserWindowSnapshot): BrowserApplication | null {
+  return resolveBrowserApplication({
+    bundleId: snapshot.bundleId,
+    appName: snapshot.appName,
+    executablePath: snapshot.executablePath,
+  })
+}
+
 function macActiveTab(snapshot: ActiveBrowserWindowSnapshot): ActiveBrowserTab | null {
-  const application = macBrowserApplicationFor(snapshot)
+  const application = browserApplicationFor(snapshot)
   if (!application || application.family === 'firefox') return null
 
   if (application.family === 'webkit') {
@@ -235,15 +213,44 @@ function recentFirefoxTab(entry: BrowserEntry, now: number, windowTitle: string 
   }
 }
 
+function winActiveTab(snapshot: ActiveBrowserWindowSnapshot): ActiveBrowserTab | null {
+  try {
+    const row = getDb().prepare(`
+      SELECT url, page_title
+      FROM focus_events
+      WHERE source = 'uia_tab'
+        AND confidence = 'observed'
+        AND url IS NOT NULL
+        AND ts_ms >= ?
+        AND (
+          (? IS NOT NULL AND app_bundle_id = ?)
+          OR (? IS NOT NULL AND app_name = ?)
+        )
+      ORDER BY ts_ms DESC, id DESC
+      LIMIT 1
+    `).get(
+      snapshot.capturedAt - TAB_CACHE_TRUST_MS,
+      snapshot.bundleId || null,
+      snapshot.bundleId || null,
+      snapshot.appName || null,
+      snapshot.appName || null,
+    ) as { url: string; page_title: string | null } | undefined
+    if (!row?.url) return null
+    return { url: row.url, title: row.page_title ?? null }
+  } catch {
+    return null
+  }
+}
+
 function recentHistoryTab(snapshot: ActiveBrowserWindowSnapshot): ActiveBrowserTab | null {
   const browserId = browserAppIdFor(snapshot)
   if (!browserId) return null
-  const macApplication = process.platform === 'darwin' ? macBrowserApplicationFor(snapshot) : null
+  const application = browserApplicationFor(snapshot)
 
   const entries = getBrowserEntries()
     .filter((entry) => fs.existsSync(entry.historyPath))
     .filter((entry) => {
-      if (macApplication) return entry.bundleId.split(':', 1)[0] === macApplication.bundleId
+      if (application) return entry.bundleId.split(':', 1)[0] === application.bundleId
       return resolveCanonicalBrowser(entry.bundleId).canonicalBrowserId === browserId
     })
 
@@ -265,6 +272,10 @@ export function readActiveBrowserTab(snapshot: ActiveBrowserWindowSnapshot): Act
   }
 
   if (process.platform === 'win32') {
+    return winActiveTab(snapshot) ?? recentHistoryTab(snapshot)
+  }
+
+  if (process.platform === 'linux') {
     return recentHistoryTab(snapshot)
   }
 
@@ -272,15 +283,7 @@ export function readActiveBrowserTab(snapshot: ActiveBrowserWindowSnapshot): Act
 }
 
 export function isBrowserWindowCandidate(candidate: BrowserCandidate): boolean {
-  if (process.platform === 'darwin') return resolveBrowserApplication(candidate) !== null
-  const snapshot: ActiveBrowserWindowSnapshot = {
-    bundleId: candidate.bundleId ?? '',
-    appName: candidate.appName ?? '',
-    windowTitle: null,
-    capturedAt: Date.now(),
-    executablePath: candidate.executablePath,
-  }
-  return browserAppIdFor(snapshot) !== null
+  return resolveBrowserApplication(candidate) !== null
 }
 
 export class ActiveBrowserContextTracker {

--- a/src/main/services/browserRegistry.ts
+++ b/src/main/services/browserRegistry.ts
@@ -2,6 +2,12 @@ import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import {
+  getLinuxBrowserHistoryLocations,
+  isLinuxBrowserApplication,
+  resolveLinuxBrowserApplication,
+} from './linuxBrowserRegistry'
+import { isWindowsBrowserApplication, resolveWindowsBrowserApplication } from './windowsBrowserRegistry'
 
 export type BrowserFamily = 'chromium' | 'firefox' | 'webkit'
 
@@ -263,6 +269,8 @@ function candidateMatchesApplication(candidate: BrowserCandidate, application: B
 }
 
 export function resolveBrowserApplication(candidate: BrowserCandidate): BrowserApplication | null {
+  if (process.platform === 'win32') return resolveWindowsBrowserApplication(candidate)
+  if (process.platform === 'linux') return resolveLinuxBrowserApplication(candidate)
   if (process.platform !== 'darwin') return null
 
   for (const possiblePath of [candidate.executablePath, candidate.bundleId]) {
@@ -283,6 +291,8 @@ export function resolveBrowserApplication(candidate: BrowserCandidate): BrowserA
 }
 
 export function isBrowserApplication(candidate: BrowserCandidate): boolean {
+  if (process.platform === 'win32') return isWindowsBrowserApplication(candidate)
+  if (process.platform === 'linux') return isLinuxBrowserApplication(candidate)
   return resolveBrowserApplication(candidate) !== null
 }
 
@@ -415,6 +425,8 @@ export function getMacBrowserHistoryLocations(): BrowserHistoryLocation[] {
   }
   return historyCache.locations
 }
+
+export { getLinuxBrowserHistoryLocations }
 
 export function __resetBrowserRegistryForTests(): void {
   registryCache = null

--- a/src/main/services/processMonitor.ts
+++ b/src/main/services/processMonitor.ts
@@ -1,23 +1,43 @@
 import { execFile } from 'node:child_process'
 import type { ProcessSnapshot } from '@shared/types'
+import { observeProcessSnapshots } from './backgroundProcessEvidence'
 
 export type { ProcessSnapshot } from '@shared/types'
 
 const PROCESS_POLL_MS = 30_000
-const WMIC_ARGS = ['process', 'get', 'ProcessId,Name,WorkingSetSize,PageFileUsage', '/format:csv']
 
 let monitorInterval: ReturnType<typeof setInterval> | null = null
 let latestSnapshot: ProcessSnapshot[] = []
 let refreshInFlight = false
 
+export function parseCimProcessOutput(output: string): ProcessSnapshot[] {
+  const now = Date.now()
+  const lines = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+  const snapshots: ProcessSnapshot[] = []
+
+  for (const line of lines) {
+    const parts = line.split('|')
+    if (parts.length < 3) continue
+    const name = parts[0]?.trim()
+    const pid = parseInt(parts[1]?.trim() ?? '0', 10)
+    const workingSetSize = parseInt(parts[2]?.trim() ?? '0', 10)
+    if (!name || pid <= 0 || workingSetSize <= 0) continue
+    snapshots.push({
+      pid,
+      name: name.replace(/\.exe$/i, ''),
+      cpuPercent: 0,
+      memoryMb: Math.round(workingSetSize / 1024 / 1024),
+      capturedAt: now,
+    })
+  }
+
+  return snapshots
+}
+
 export function parseWmicOutput(output: string): ProcessSnapshot[] {
   const now = Date.now()
   const lines = output.split(/\r?\n/).map((line) => line.trim()).filter((line) => line !== '')
 
-  // WMIC /format:csv emits a header row and orders columns alphabetically (not in
-  // the requested order), always prefixed with "Node". Resolve column positions
-  // from the header instead of hardcoding indices, so parsing is correct
-  // regardless of WMIC's ordering.
   const headerIdx = lines.findIndex((line) => line.startsWith('Node,') && /ProcessId/i.test(line))
   if (headerIdx === -1) return []
   const columns = lines[headerIdx].split(',').map((col) => col.trim().toLowerCase())
@@ -45,25 +65,47 @@ export function parseWmicOutput(output: string): ProcessSnapshot[] {
     .filter((process) => process.pid > 0 && process.memoryMb > 0)
 }
 
-// Async refresh so the wmic subprocess never blocks the main thread (the old
-// execSync stalled startup and every poll tick). Result is cached in
-// latestSnapshot for the diagnostics IPC to read.
-function refreshSnapshot(): void {
-  if (process.platform !== 'win32' || refreshInFlight) return
-  refreshInFlight = true
-  execFile('wmic', WMIC_ARGS, { timeout: 5_000, windowsHide: true }, (error, stdout) => {
+function enrichCpuPercent(snapshots: ProcessSnapshot[]): ProcessSnapshot[] {
+  return snapshots
+}
+
+function refreshSnapshotCim(): void {
+  execFile(
+    'powershell',
+    ['-NoProfile', '-Command', 'Get-CimInstance Win32_Process | ForEach-Object { "$($_.Name)|$($_.ProcessId)|$($_.WorkingSetSize)" }'],
+    { timeout: 8_000, windowsHide: true },
+    (error, stdout) => {
+      refreshInFlight = false
+      if (error) return
+      try {
+        latestSnapshot = enrichCpuPercent(parseCimProcessOutput(stdout))
+        observeProcessSnapshots(latestSnapshot)
+      } catch {
+        // keep previous snapshot
+      }
+    },
+  )
+}
+
+function refreshSnapshotWmic(): void {
+  execFile('wmic', ['process', 'get', 'ProcessId,Name,WorkingSetSize', '/format:csv'], { timeout: 5_000, windowsHide: true }, (error, stdout) => {
     refreshInFlight = false
     if (error) return
     try {
       latestSnapshot = parseWmicOutput(stdout)
+      observeProcessSnapshots(latestSnapshot)
     } catch {
-      // leave the previous snapshot in place
+      // keep previous snapshot
     }
   })
 }
 
-// Lazy-start: only spin up the poller when diagnostics actually ask for process
-// metrics (via getProcessMetrics), not on every app launch.
+function refreshSnapshot(): void {
+  if (process.platform !== 'win32' || refreshInFlight) return
+  refreshInFlight = true
+  refreshSnapshotCim()
+}
+
 export function ensureProcessMonitor(): void {
   if (process.platform !== 'win32') {
     latestSnapshot = []
@@ -80,9 +122,6 @@ export function stopProcessMonitor(): void {
   monitorInterval = null
 }
 
-// Called by the diagnostics IPC handler. Starts the monitor on first use and
-// returns whatever the last async poll captured (empty on the very first call,
-// populated on subsequent polls).
 export function getProcessMetrics(): ProcessSnapshot[] {
   ensureProcessMonitor()
   return latestSnapshot
@@ -91,3 +130,6 @@ export function getProcessMetrics(): ProcessSnapshot[] {
 export function getLatestSnapshot(): ProcessSnapshot[] {
   return latestSnapshot
 }
+
+// Test-only export for WMIC fallback verification.
+export { refreshSnapshotWmic }

--- a/src/main/services/processMonitor.ts
+++ b/src/main/services/processMonitor.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import fs from 'node:fs'
 import type { ProcessSnapshot } from '@shared/types'
 import { observeProcessSnapshots } from './backgroundProcessEvidence'
 
@@ -9,6 +10,32 @@ const PROCESS_POLL_MS = 30_000
 let monitorInterval: ReturnType<typeof setInterval> | null = null
 let latestSnapshot: ProcessSnapshot[] = []
 let refreshInFlight = false
+let previousCpuByPid = new Map<number, { cpuTicks: number; capturedAt: number }>()
+
+export function parseProcStatLine(statContent: string, statusContent: string): ProcessSnapshot | null {
+  const close = statContent.lastIndexOf(')')
+  const open = statContent.indexOf('(')
+  if (close <= open) return null
+
+  const pid = parseInt(statContent.slice(0, open).trim(), 10)
+  if (!Number.isFinite(pid) || pid <= 0) return null
+
+  const name = statContent.slice(open + 1, close).trim() || 'unknown'
+  const rest = statContent.slice(close + 2).trim().split(/\s+/)
+  const utime = parseInt(rest[11] ?? '0', 10)
+  const stime = parseInt(rest[12] ?? '0', 10)
+  const rssMatch = statusContent.match(/^VmRSS:\s+(\d+)\s+kB/m)
+  const memoryMb = rssMatch ? Math.round(parseInt(rssMatch[1], 10) / 1024) : 0
+  if (memoryMb <= 0) return null
+
+  return {
+    pid,
+    name,
+    cpuPercent: Math.max(0, utime + stime),
+    memoryMb,
+    capturedAt: Date.now(),
+  }
+}
 
 export function parseCimProcessOutput(output: string): ProcessSnapshot[] {
   const now = Date.now()
@@ -66,7 +93,43 @@ export function parseWmicOutput(output: string): ProcessSnapshot[] {
 }
 
 function enrichCpuPercent(snapshots: ProcessSnapshot[]): ProcessSnapshot[] {
-  return snapshots
+  const now = Date.now()
+  return snapshots.map((snapshot) => {
+    const cpuTicks = snapshot.cpuPercent
+    const previous = previousCpuByPid.get(snapshot.pid)
+    previousCpuByPid.set(snapshot.pid, { cpuTicks, capturedAt: now })
+    if (!previous) return { ...snapshot, cpuPercent: 0 }
+
+    const elapsedSec = Math.max(0.001, (now - previous.capturedAt) / 1_000)
+    const deltaTicks = Math.max(0, cpuTicks - previous.cpuTicks)
+    const cpuPercent = Math.max(0, Math.min(100, (deltaTicks / elapsedSec) * 100 / 100))
+    return { ...snapshot, cpuPercent }
+  })
+}
+
+function refreshSnapshotProc(): void {
+  if (process.platform !== 'linux' || refreshInFlight) return
+  refreshInFlight = true
+  try {
+    const snapshots: ProcessSnapshot[] = []
+    for (const entry of fs.readdirSync('/proc')) {
+      if (!/^\d+$/.test(entry)) continue
+      try {
+        const stat = fs.readFileSync(`/proc/${entry}/stat`, 'utf8')
+        const status = fs.readFileSync(`/proc/${entry}/status`, 'utf8')
+        const snapshot = parseProcStatLine(stat, status)
+        if (snapshot) snapshots.push(snapshot)
+      } catch {
+        // ignore unreadable processes
+      }
+    }
+    latestSnapshot = snapshots
+    observeProcessSnapshots(latestSnapshot)
+  } catch {
+    // keep previous snapshot
+  } finally {
+    refreshInFlight = false
+  }
 }
 
 function refreshSnapshotCim(): void {
@@ -101,13 +164,18 @@ function refreshSnapshotWmic(): void {
 }
 
 function refreshSnapshot(): void {
-  if (process.platform !== 'win32' || refreshInFlight) return
+  if (refreshInFlight) return
+  if (process.platform === 'linux') {
+    refreshSnapshotProc()
+    return
+  }
+  if (process.platform !== 'win32') return
   refreshInFlight = true
   refreshSnapshotCim()
 }
 
 export function ensureProcessMonitor(): void {
-  if (process.platform !== 'win32') {
+  if (process.platform !== 'win32' && process.platform !== 'linux') {
     latestSnapshot = []
     return
   }

--- a/src/main/services/tracking.ts
+++ b/src/main/services/tracking.ts
@@ -691,6 +691,38 @@ function swayActiveWindow(): ActiveWinResult | null {
   }
 }
 
+function gnomeShellActiveWindow(): ActiveWinResult | null {
+  if (!commandAvailable('gdbus')) return null
+  const output = execText('gdbus', [
+    'call',
+    '--session',
+    '--dest',
+    'org.gnome.Shell',
+    '--object-path',
+    '/org/gnome/Shell',
+    '--method',
+    'org.gnome.Shell.Eval',
+    'global.display.focus_window ? global.display.focus_window.get_title() : ""',
+  ])
+  if (!output) return null
+
+  const match = output.match(/\(\s*(?:true|false)\s*,\s*'((?:\\'|[^'])*)'\s*\)/)
+  const title = match?.[1]?.replace(/\\'/g, "'").trim()
+  if (!title) return null
+
+  const application = title.includes(' - ')
+    ? title.split(' - ').pop()?.trim() || title
+    : title
+
+  return {
+    title,
+    application,
+    path: application,
+    pid: 0,
+    icon: '',
+  }
+}
+
 function parseXpropField(output: string, field: string): string {
   const line = output
     .split(/\r?\n/)
@@ -831,6 +863,13 @@ export function linuxFallbackActiveWindow(): { source: Exclude<TrackingModuleSou
     const win = swayActiveWindow()
     if (win) return { source: 'swaymsg', win, trace: ['swaymsg: focused window found'] }
     trace.push(commandAvailable('swaymsg') ? 'swaymsg: no focused node returned' : 'swaymsg: command not found')
+  }
+
+  const gnomeSession = desktop.includes('gnome') && linuxSessionType() === 'wayland'
+  if (gnomeSession) {
+    const win = gnomeShellActiveWindow()
+    if (win) return { source: 'xdotool', win, trace: ['gdbus: GNOME Shell focused window found'] }
+    trace.push(commandAvailable('gdbus') ? 'gdbus: GNOME Shell did not return a focused title' : 'gdbus: command not found')
   }
 
   if (process.env.DISPLAY) {

--- a/src/main/services/tracking.ts
+++ b/src/main/services/tracking.ts
@@ -1565,13 +1565,11 @@ async function poll(): Promise<void> {
     }
 
     const resolvedWin = resolveWindowIdentity(win)
-    const browserApplication = process.platform === 'darwin'
-      ? resolveBrowserApplication({
-          bundleId: resolvedWin.bundleId,
-          appName: resolvedWin.appName,
-          executablePath: resolvedWin.path,
-        })
-      : null
+    const browserApplication = resolveBrowserApplication({
+      bundleId: resolvedWin.bundleId,
+      appName: resolvedWin.appName,
+      executablePath: resolvedWin.path,
+    })
     const bundleId = browserApplication?.bundleId ?? resolvedWin.bundleId
     const appName = browserApplication?.name ?? resolvedWin.appName
     const rawResolvedTitle = resolvedWin.title?.trim() || null

--- a/src/main/services/trackingPermissions.ts
+++ b/src/main/services/trackingPermissions.ts
@@ -8,6 +8,7 @@ import type {
 import { capture, captureException } from './analytics'
 import { getSettings, setSettings } from './settings'
 import { requestTrackingPermission } from './tracking'
+import { isWindowsFocusCaptureRunning } from './windowsFocusCapture'
 
 const MAC_SCREEN_RECORDING_SETTINGS_URL = 'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture'
 const MAC_ACCESSIBILITY_SETTINGS_URL = 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'
@@ -26,6 +27,17 @@ function normalizeMacScreenPermissionStatus(status: string): CapturePermissionSt
 }
 
 export function getTrackingPermissionDetails(): TrackingPermissionDetails {
+  if (process.platform === 'win32') {
+    const helperRunning = isWindowsFocusCaptureRunning()
+    return {
+      accessibility: 'unsupported_or_unknown',
+      screenRecording: 'unsupported_or_unknown',
+      combined: helperRunning ? 'granted' : 'missing',
+      platformNote: 'Windows does not use macOS Accessibility. Daylens relies on its capture helper and foreground polling.',
+      captureHelperRunning: helperRunning,
+    }
+  }
+
   if (process.platform !== 'darwin') {
     return {
       accessibility: 'granted',

--- a/src/main/services/trackingPermissions.ts
+++ b/src/main/services/trackingPermissions.ts
@@ -7,7 +7,7 @@ import type {
 } from '@shared/types'
 import { capture, captureException } from './analytics'
 import { getSettings, setSettings } from './settings'
-import { requestTrackingPermission } from './tracking'
+import { requestTrackingPermission, getLinuxTrackingDiagnostics } from './tracking'
 import { isWindowsFocusCaptureRunning } from './windowsFocusCapture'
 
 const MAC_SCREEN_RECORDING_SETTINGS_URL = 'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture'
@@ -35,6 +35,24 @@ export function getTrackingPermissionDetails(): TrackingPermissionDetails {
       combined: helperRunning ? 'granted' : 'missing',
       platformNote: 'Windows does not use macOS Accessibility. Daylens relies on its capture helper and foreground polling.',
       captureHelperRunning: helperRunning,
+    }
+  }
+
+  if (process.platform === 'linux') {
+    const linuxTracking = getLinuxTrackingDiagnostics()
+    const supportLevel = linuxTracking?.supportLevel ?? 'limited'
+    const combined: TrackingPermissionState =
+      supportLevel === 'ready'
+        ? 'granted'
+        : supportLevel === 'limited'
+          ? 'missing'
+          : 'missing'
+    return {
+      accessibility: 'unsupported_or_unknown',
+      screenRecording: 'unsupported_or_unknown',
+      combined,
+      platformNote: linuxTracking?.supportMessage
+        ?? 'Linux capture depends on your desktop session. Open Capture health in Settings for details.',
     }
   }
 

--- a/src/main/services/windowsBrowserRegistry.ts
+++ b/src/main/services/windowsBrowserRegistry.ts
@@ -1,0 +1,362 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { BrowserApplication, BrowserCandidate, BrowserFamily, BrowserHistoryLocation } from './browserRegistry'
+
+export type { BrowserApplication, BrowserCandidate, BrowserFamily, BrowserHistoryLocation }
+
+const REGISTRY_CACHE_MS = 60_000
+const HISTORY_CACHE_MS = 5 * 60_000
+const MAX_HISTORY_SCAN_DEPTH = 6
+const SKIPPED_SCAN_DIRECTORIES = new Set([
+  'cache',
+  'caches',
+  'code cache',
+  'gpucache',
+  'indexeddb',
+  'local storage',
+  'service worker',
+  'session storage',
+  'storage',
+])
+
+let registryCache: { readAt: number; applications: BrowserApplication[] } | null = null
+let historyCache: { readAt: number; locations: BrowserHistoryLocation[] } | null = null
+
+function unique<T>(items: T[], keyFor: (item: T) => string): T[] {
+  const seen = new Set<string>()
+  return items.filter((item) => {
+    const key = keyFor(item)
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function normalizedPath(value: string): string {
+  try {
+    return path.resolve(value).toLowerCase()
+  } catch {
+    return value.toLowerCase()
+  }
+}
+
+function exeBaseName(exePath: string): string {
+  const normalized = exePath.replace(/\\/g, '/')
+  const parts = normalized.split('/').filter(Boolean)
+  const base = parts[parts.length - 1] ?? exePath
+  return base.toLowerCase()
+}
+
+function bundleIdForExe(exePath: string): string {
+  const base = exeBaseName(exePath)
+  return base.endsWith('.exe') ? base : `${base}.exe`
+}
+
+export function classifyWindowsBrowserFamily(exePath: string, displayName: string): BrowserFamily {
+  const haystack = `${exePath} ${displayName}`.toLowerCase()
+  if (/(firefox|waterfox|librewolf|zen|palemoon|floorp)/.test(haystack)) return 'firefox'
+  if (/(safari|webkit)/.test(haystack)) return 'webkit'
+  return 'chromium'
+}
+
+function parseRegQueryOutput(output: string): Map<string, string> {
+  const values = new Map<string, string>()
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('HKEY_') || trimmed.startsWith('End of')) continue
+    const match = trimmed.match(/^(\S+)\s+REG_\w+\s+(.*)$/)
+    if (!match) continue
+    values.set(match[1].trim(), match[2].trim())
+  }
+  return values
+}
+
+function queryRegistry(key: string): Map<string, string> {
+  if (process.platform !== 'win32') return new Map()
+  try {
+    const output = execFileSync('reg', ['query', key], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000,
+      windowsHide: true,
+    })
+    return parseRegQueryOutput(output)
+  } catch {
+    return new Map()
+  }
+}
+
+function listRegistrySubkeys(key: string): string[] {
+  if (process.platform !== 'win32') return []
+  try {
+    const output = execFileSync('reg', ['query', key], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000,
+      windowsHide: true,
+    })
+    const subkeys: string[] = []
+    for (const line of output.split(/\r?\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('End of')) continue
+      if (trimmed.startsWith('HKEY_')) {
+        const parts = trimmed.split('\\')
+        const last = parts[parts.length - 1]
+        if (last && !last.includes(' ')) subkeys.push(last)
+      }
+    }
+    return unique(subkeys, (value) => value.toLowerCase())
+  } catch {
+    return []
+  }
+}
+
+function parseCommandExe(command: string): string | null {
+  const trimmed = command.trim()
+  if (!trimmed) return null
+  const quoted = trimmed.match(/^"([^"]+)"/)
+  if (quoted) return quoted[1]
+  const first = trimmed.split(/\s+/)[0]
+  return first || null
+}
+
+
+export function parseStartMenuInternetDump(dump: string): BrowserApplication[] {
+  const applications: BrowserApplication[] = []
+  const lines = dump.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+
+  let currentName: string | null = null
+  let expectingCommand = false
+
+  for (const line of lines) {
+    if (line.includes('StartMenuInternet\\') && line.endsWith('\\shell\\open\\command')) {
+      expectingCommand = true
+      continue
+    }
+    if (line.includes('StartMenuInternet\\')) {
+      expectingCommand = false
+      currentName = null
+      continue
+    }
+
+    const defaultMatch = line.match(/^\(default\)\s+REG_\w+\s+(.+)$/i)
+    if (!defaultMatch) continue
+
+    if (expectingCommand) {
+      const exePath = parseCommandExe(defaultMatch[1])
+      if (!exePath) {
+        expectingCommand = false
+        continue
+      }
+      const name = currentName ?? path.basename(exePath, '.exe')
+      applications.push({
+        name,
+        bundleId: bundleIdForExe(exePath),
+        appPath: exePath,
+        family: classifyWindowsBrowserFamily(exePath, name),
+        source: 'launch_services',
+      })
+      expectingCommand = false
+      currentName = null
+      continue
+    }
+
+    currentName = defaultMatch[1].trim()
+  }
+
+  return unique(applications, (app) => app.bundleId.toLowerCase())
+}
+
+export function readStartMenuInternetBrowsers(): BrowserApplication[] {
+  if (process.platform !== 'win32') return []
+
+  const applications: BrowserApplication[] = []
+  const root = 'HKCU\\Software\\Clients\\StartMenuInternet'
+  for (const progId of listRegistrySubkeys(root)) {
+    const name = queryRegistry(`${root}\\${progId}`).get('(Default)') ?? progId
+    const command = queryRegistry(`${root}\\${progId}\\shell\\open\\command`).get('(Default)')
+    if (!command) continue
+    const exePath = parseCommandExe(command)
+    if (!exePath || !fs.existsSync(exePath)) continue
+    applications.push({
+      name,
+      bundleId: bundleIdForExe(exePath),
+      appPath: exePath,
+      family: classifyWindowsBrowserFamily(exePath, name),
+      source: 'launch_services',
+    })
+  }
+
+  return unique(applications, (app) => app.bundleId.toLowerCase())
+}
+
+function scanForHistoryFiles(root: string): string[] {
+  const found: string[] = []
+  const visit = (directory: string, depth: number) => {
+    if (depth > MAX_HISTORY_SCAN_DEPTH) return
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(directory, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(directory, entry.name)
+      if (entry.isFile() && (entry.name === 'History' || entry.name === 'places.sqlite')) {
+        found.push(fullPath)
+        continue
+      }
+      if (!entry.isDirectory() || SKIPPED_SCAN_DIRECTORIES.has(entry.name.toLowerCase())) continue
+      visit(fullPath, depth + 1)
+    }
+  }
+
+  visit(root, 0)
+  return found
+}
+
+function profileIdForHistoryPath(historyPath: string): string {
+  const parent = path.basename(path.dirname(historyPath))
+  if (/^default$/i.test(parent)) return 'default'
+  if (/^profile \d+$/i.test(parent)) return parent
+  return parent || 'default'
+}
+
+function historyPathMatchesFamily(historyPath: string, family: BrowserFamily): boolean {
+  const base = path.basename(historyPath)
+  if (family === 'firefox') return base === 'places.sqlite'
+  return base === 'History'
+}
+
+function appDataRootsForBrowser(application: BrowserApplication, home = os.homedir()): string[] {
+  const local = path.join(home, 'AppData', 'Local')
+  const roaming = path.join(home, 'AppData', 'Roaming')
+  const exeBase = path.basename(application.appPath, '.exe').toLowerCase()
+  const nameToken = application.name.toLowerCase().replace(/[^a-z0-9]+/g, '')
+
+  const roots = new Set<string>()
+  const consider = (candidate: string) => {
+    if (fs.existsSync(candidate)) roots.add(candidate)
+  }
+
+  if (application.family === 'firefox') {
+    consider(path.join(roaming, 'Mozilla', 'Firefox'))
+    consider(path.join(roaming, exeBase))
+    consider(path.join(roaming, 'zen'))
+    consider(path.join(roaming, 'Zen'))
+  } else {
+    consider(path.join(local, application.name))
+    consider(path.join(local, application.name, 'User Data'))
+    consider(path.join(local, exeBase))
+    consider(path.join(local, exeBase, 'User Data'))
+    if (nameToken.includes('chrome')) consider(path.join(local, 'Google', 'Chrome', 'User Data'))
+    if (nameToken.includes('edge')) consider(path.join(local, 'Microsoft', 'Edge', 'User Data'))
+    if (nameToken.includes('brave')) consider(path.join(local, 'BraveSoftware', 'Brave-Browser', 'User Data'))
+    if (nameToken.includes('arc')) {
+      consider(path.join(local, 'Arc', 'User Data'))
+      consider(path.join(local, 'The Browser Company', 'Arc', 'User Data'))
+    }
+    if (nameToken.includes('dia')) {
+      consider(path.join(local, 'Dia', 'User Data'))
+      consider(path.join(local, 'The Browser Company', 'Dia', 'User Data'))
+    }
+    if (nameToken.includes('comet')) {
+      consider(path.join(local, 'Comet', 'User Data'))
+      consider(path.join(local, 'Perplexity', 'Comet', 'User Data'))
+    }
+  }
+
+  const exeDir = path.dirname(application.appPath)
+  consider(path.join(exeDir, 'User Data'))
+
+  return [...roots]
+}
+
+export function discoverWindowsBrowserHistoryLocations(
+  applications = getWindowsBrowserApplications(),
+  home = os.homedir(),
+): BrowserHistoryLocation[] {
+  const locations: BrowserHistoryLocation[] = []
+
+  for (const application of applications) {
+    const historyPaths = unique(
+      appDataRootsForBrowser(application, home).flatMap((root) => scanForHistoryFiles(root)),
+      normalizedPath,
+    )
+    for (const historyPath of historyPaths) {
+      if (!historyPathMatchesFamily(historyPath, application.family)) continue
+      locations.push({
+        ...application,
+        historyPath,
+        profileId: profileIdForHistoryPath(historyPath),
+      })
+    }
+  }
+
+  return unique(locations, (location) => normalizedPath(location.historyPath))
+}
+
+export function refreshWindowsBrowserRegistry(): BrowserApplication[] {
+  if (process.platform !== 'win32') {
+    registryCache = { readAt: Date.now(), applications: [] }
+    historyCache = null
+    return []
+  }
+  const applications = readStartMenuInternetBrowsers()
+  registryCache = { readAt: Date.now(), applications }
+  historyCache = null
+  return applications
+}
+
+export function getWindowsBrowserApplications(): BrowserApplication[] {
+  if (process.platform !== 'win32') return []
+  if (!registryCache || Date.now() - registryCache.readAt >= REGISTRY_CACHE_MS) {
+    return refreshWindowsBrowserRegistry()
+  }
+  return registryCache.applications
+}
+
+export function getWindowsBrowserHistoryLocations(): BrowserHistoryLocation[] {
+  if (process.platform !== 'win32') return []
+  if (!historyCache || Date.now() - historyCache.readAt >= HISTORY_CACHE_MS) {
+    historyCache = {
+      readAt: Date.now(),
+      locations: discoverWindowsBrowserHistoryLocations(),
+    }
+  }
+  return historyCache.locations
+}
+
+function candidateMatchesApplication(candidate: BrowserCandidate, application: BrowserApplication): boolean {
+  const bundleId = candidate.bundleId?.trim().toLowerCase()
+  if (bundleId && bundleId === application.bundleId.toLowerCase()) return true
+  if (bundleId && bundleId === path.basename(application.appPath).toLowerCase()) return true
+
+  const candidatePath = candidate.executablePath?.trim()
+  if (candidatePath && normalizedPath(candidatePath) === normalizedPath(application.appPath)) return true
+
+  const haystack = `${candidate.bundleId ?? ''} ${candidate.appName ?? ''} ${candidate.executablePath ?? ''}`.toLowerCase()
+  const tokens = [
+    application.name,
+    path.basename(application.appPath, '.exe'),
+    application.bundleId.replace(/\.exe$/i, ''),
+  ].map((value) => value.toLowerCase())
+  return tokens.some((token) => token.length >= 3 && haystack.includes(token))
+}
+
+export function resolveWindowsBrowserApplication(candidate: BrowserCandidate): BrowserApplication | null {
+  if (process.platform !== 'win32') return null
+  return getWindowsBrowserApplications().find((application) => candidateMatchesApplication(candidate, application)) ?? null
+}
+
+export function isWindowsBrowserApplication(candidate: BrowserCandidate): boolean {
+  return resolveWindowsBrowserApplication(candidate) !== null
+}
+
+export function __resetWindowsBrowserRegistryForTests(): void {
+  registryCache = null
+  historyCache = null
+}

--- a/src/main/services/windowsFocusCapture.ts
+++ b/src/main/services/windowsFocusCapture.ts
@@ -1,0 +1,319 @@
+// Spawns the Windows UIA capture helper and appends NDJSON events to focus_events.
+// Runs alongside tracking.ts on win32 only.
+
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { app } from 'electron'
+import { shouldCaptureFocusEvent } from './focusCapture'
+import { getDb } from './database'
+import { getSettings } from './settings'
+import { trackingControlsStateFromSettings } from '@shared/trackingControls'
+
+const FOCUS_EVENT_SCHEMA_VERSION = 1
+const FOCUS_EVENT_TYPES = [
+  'app_activated',
+  'app_deactivated',
+  'window_changed',
+  'space_changed',
+  'sleep',
+  'wake',
+  'lock',
+  'unlock',
+  'tab_changed',
+  'tab_sampled',
+] as const
+const FOCUS_EVENT_SOURCES = ['uia_foreground', 'uia_tab'] as const
+const FOCUS_EVENT_CONFIDENCES = ['observed', 'unknown'] as const
+
+type FocusEventType = typeof FOCUS_EVENT_TYPES[number]
+type FocusEventSource = typeof FOCUS_EVENT_SOURCES[number]
+type FocusEventConfidence = typeof FOCUS_EVENT_CONFIDENCES[number]
+
+const FOCUS_EVENT_TYPE_SET = new Set<string>(FOCUS_EVENT_TYPES)
+const FOCUS_EVENT_SOURCE_SET = new Set<string>(FOCUS_EVENT_SOURCES)
+const FOCUS_EVENT_CONFIDENCE_SET = new Set<string>(FOCUS_EVENT_CONFIDENCES)
+const FOREGROUND_EVENT_TYPES = new Set<FocusEventType>([
+  'app_activated',
+  'app_deactivated',
+  'window_changed',
+  'space_changed',
+  'sleep',
+  'wake',
+  'lock',
+  'unlock',
+])
+const TAB_EVENT_TYPES = new Set<FocusEventType>(['tab_changed', 'tab_sampled'])
+
+interface HelperEvent {
+  ts_ms: number
+  mono_ns: number
+  event_type: FocusEventType
+  app_bundle_id?: string | null
+  app_name?: string | null
+  pid?: number | null
+  window_title?: string | null
+  url?: string | null
+  page_title?: string | null
+  source: FocusEventSource
+  confidence: FocusEventConfidence
+  platform?: string | null
+  schema_ver?: number | null
+}
+
+let child: ChildProcessWithoutNullStreams | null = null
+let stopping = false
+let restartTimer: ReturnType<typeof setTimeout> | null = null
+let shutdownKillTimer: ReturnType<typeof setTimeout> | null = null
+let restartDelay = 1000
+let spawnedAt = 0
+const MAX_RESTART_DELAY = 30_000
+const STABLE_UPTIME_MS = 10_000
+const SHUTDOWN_KILL_DELAY_MS = 1500
+
+function helperPath(): string {
+  const fileName = 'windows-capture-helper.exe'
+  return app.isPackaged
+    ? path.join(process.resourcesPath, 'build', fileName)
+    : path.join(__dirname, '..', '..', 'build', fileName)
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isNullableString(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === 'string'
+}
+
+function isNullableNumber(value: unknown): value is number | null | undefined {
+  return value === undefined || value === null || (typeof value === 'number' && Number.isFinite(value))
+}
+
+export function normalizeWindowsHelperEvent(raw: unknown): HelperEvent | null {
+  if (!isObject(raw)) return null
+  const eventType = raw.event_type
+  const source = raw.source
+  const confidence = raw.confidence
+  const schemaVersion = raw.schema_ver ?? FOCUS_EVENT_SCHEMA_VERSION
+  if (typeof raw.ts_ms !== 'number' || !Number.isFinite(raw.ts_ms)) return null
+  if (typeof raw.mono_ns !== 'number' || !Number.isFinite(raw.mono_ns)) return null
+  if (typeof eventType !== 'string' || !FOCUS_EVENT_TYPE_SET.has(eventType)) return null
+  if (typeof source !== 'string' || !FOCUS_EVENT_SOURCE_SET.has(source)) return null
+  if (typeof confidence !== 'string' || !FOCUS_EVENT_CONFIDENCE_SET.has(confidence)) return null
+  if (schemaVersion !== FOCUS_EVENT_SCHEMA_VERSION) return null
+  if (!isNullableString(raw.app_bundle_id)) return null
+  if (!isNullableString(raw.app_name)) return null
+  if (!isNullableNumber(raw.pid)) return null
+  if (!isNullableString(raw.window_title)) return null
+  if (!isNullableString(raw.url)) return null
+  if (!isNullableString(raw.page_title)) return null
+  if (!isNullableString(raw.platform)) return null
+
+  const typedEventType = eventType as FocusEventType
+  const typedSource = source as FocusEventSource
+  const typedConfidence = confidence as FocusEventConfidence
+  const url = raw.url ?? null
+  const pageTitle = raw.page_title ?? null
+
+  if (typedSource === 'uia_foreground' && !FOREGROUND_EVENT_TYPES.has(typedEventType)) return null
+  if (typedSource === 'uia_tab' && !TAB_EVENT_TYPES.has(typedEventType)) return null
+  if (typedConfidence === 'unknown' && (url !== null || pageTitle !== null)) return null
+  if (typedSource === 'uia_tab' && typedConfidence === 'observed' && !url) return null
+  if (typedSource === 'uia_foreground' && (url !== null || pageTitle !== null)) return null
+
+  return {
+    ts_ms: raw.ts_ms,
+    mono_ns: raw.mono_ns,
+    event_type: typedEventType,
+    app_bundle_id: raw.app_bundle_id ?? null,
+    app_name: raw.app_name ?? null,
+    pid: raw.pid ?? null,
+    window_title: raw.window_title ?? null,
+    url,
+    page_title: pageTitle,
+    source: typedSource,
+    confidence: typedConfidence,
+    platform: raw.platform ?? 'win32',
+    schema_ver: FOCUS_EVENT_SCHEMA_VERSION,
+  }
+}
+
+const FOCUS_FLUSH_INTERVAL_MS = 250
+const FOCUS_FLUSH_MAX_BATCH = 100
+let pendingEvents: HelperEvent[] = []
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+function eventParams(ev: HelperEvent): Record<string, unknown> {
+  return {
+    ts_ms: ev.ts_ms,
+    mono_ns: ev.mono_ns,
+    event_type: ev.event_type,
+    app_bundle_id: ev.app_bundle_id ?? null,
+    app_name: ev.app_name ?? null,
+    pid: ev.pid ?? null,
+    window_title: ev.window_title ?? null,
+    url: ev.url ?? null,
+    page_title: ev.page_title ?? null,
+    source: ev.source,
+    confidence: ev.confidence,
+    platform: ev.platform ?? 'win32',
+    schema_ver: ev.schema_ver ?? 1,
+  }
+}
+
+function flushFocusEvents(): void {
+  if (flushTimer) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  if (pendingEvents.length === 0) return
+  const batch = pendingEvents
+  pendingEvents = []
+  try {
+    const db = getDb()
+    const stmt = db.prepare(
+      `INSERT INTO focus_events
+         (ts_ms, mono_ns, event_type, app_bundle_id, app_name, pid, window_title, url, page_title, source, confidence, platform, schema_ver)
+       VALUES (@ts_ms, @mono_ns, @event_type, @app_bundle_id, @app_name, @pid, @window_title, @url, @page_title, @source, @confidence, @platform, @schema_ver)`
+    )
+    const insertAll = db.transaction((events: HelperEvent[]) => {
+      for (const ev of events) stmt.run(eventParams(ev))
+    })
+    insertAll(batch)
+  } catch (err) {
+    console.warn('[windowsFocusCapture] batch insert failed:', err)
+  }
+}
+
+function enqueueEvent(ev: HelperEvent): void {
+  if (!shouldCaptureFocusEvent(ev, trackingControlsStateFromSettings(getSettings()))) return
+  pendingEvents.push(ev)
+  if (pendingEvents.length >= FOCUS_FLUSH_MAX_BATCH) {
+    flushFocusEvents()
+    return
+  }
+  if (!flushTimer) {
+    flushTimer = setTimeout(flushFocusEvents, FOCUS_FLUSH_INTERVAL_MS)
+  }
+}
+
+function handleLine(line: string): void {
+  const trimmed = line.trim()
+  if (!trimmed) return
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return
+  }
+  const ev = normalizeWindowsHelperEvent(parsed)
+  if (!ev) return
+  enqueueEvent(ev)
+}
+
+function scheduleRestart(): void {
+  if (stopping || restartTimer) return
+  restartTimer = setTimeout(() => {
+    restartTimer = null
+    restartDelay = Math.min(restartDelay * 2, MAX_RESTART_DELAY)
+    spawnHelper()
+  }, restartDelay)
+}
+
+function spawnHelper(): void {
+  if (stopping || child) return
+
+  const bin = helperPath()
+  if (!fs.existsSync(bin)) {
+    console.warn(`[windowsFocusCapture] helper not found at ${bin} — run "npm run build:capture-helper" on Windows`)
+    return
+  }
+
+  let proc: ChildProcessWithoutNullStreams
+  try {
+    proc = spawn(bin, [], { stdio: ['pipe', 'pipe', 'pipe'] })
+  } catch (err) {
+    console.warn('[windowsFocusCapture] spawn failed:', err)
+    scheduleRestart()
+    return
+  }
+  child = proc
+  spawnedAt = Date.now()
+
+  let buffer = ''
+  proc.stdout.setEncoding('utf8')
+  proc.stdout.on('data', (chunk: string) => {
+    buffer += chunk
+    let nl = buffer.indexOf('\n')
+    while (nl !== -1) {
+      handleLine(buffer.slice(0, nl))
+      buffer = buffer.slice(nl + 1)
+      nl = buffer.indexOf('\n')
+    }
+  })
+
+  proc.stderr.setEncoding('utf8')
+  proc.stderr.on('data', (chunk: string) => {
+    const msg = chunk.trim()
+    if (msg) console.log('[windowsFocusCapture]', msg)
+  })
+
+  proc.on('error', (err) => {
+    console.warn('[windowsFocusCapture] process error:', err)
+  })
+
+  proc.on('exit', (code, signal) => {
+    if (child === proc) child = null
+    if (shutdownKillTimer) {
+      clearTimeout(shutdownKillTimer)
+      shutdownKillTimer = null
+    }
+    if (stopping) return
+    if (Date.now() - spawnedAt >= STABLE_UPTIME_MS) restartDelay = 1000
+    console.warn(`[windowsFocusCapture] helper exited (code=${code} signal=${signal}); restarting`)
+    scheduleRestart()
+  })
+}
+
+export function startWindowsFocusCapture(): void {
+  if (process.platform !== 'win32') return
+  stopping = false
+  spawnHelper()
+}
+
+export function stopWindowsFocusCapture(): void {
+  if (process.platform !== 'win32') return
+  stopping = true
+  flushFocusEvents()
+  if (restartTimer) {
+    clearTimeout(restartTimer)
+    restartTimer = null
+  }
+  if (shutdownKillTimer) {
+    clearTimeout(shutdownKillTimer)
+    shutdownKillTimer = null
+  }
+  const proc = child
+  if (proc) {
+    try {
+      proc.kill('SIGTERM')
+    } catch {
+      /* noop */
+    }
+    shutdownKillTimer = setTimeout(() => {
+      shutdownKillTimer = null
+      if (child !== proc) return
+      try {
+        proc.kill('SIGKILL')
+      } catch {
+        /* noop */
+      }
+      child = null
+    }, SHUTDOWN_KILL_DELAY_MS)
+  }
+}
+
+export function isWindowsFocusCaptureRunning(): boolean {
+  return child !== null
+}

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -72,6 +72,7 @@ import {
   memoryEnabled,
 } from './workMemory'
 import { isBrowserApplication } from './browserRegistry'
+import { getBackgroundProcessEvidence } from './backgroundProcessEvidence'
 
 /**
  * Sanitize a label that might be a raw file path or bundle path.
@@ -261,7 +262,7 @@ function isBrowserSession(session: Pick<AppSession, 'bundleId' | 'appName' | 'ca
   if (session.category === 'browsing') return true
   const identity = resolveCanonicalApp(session.bundleId, session.appName)
   if (identity.isBrowser || identity.defaultCategory === 'browsing') return true
-  return process.platform === 'darwin' && isBrowserApplication({
+  return (process.platform === 'darwin' || process.platform === 'win32') && isBrowserApplication({
     bundleId: session.bundleId,
     appName: session.appName,
     executablePath: session.bundleId,
@@ -1978,7 +1979,7 @@ function buildWindowTitleEvidence(
     capturedRows = db.prepare(`
       SELECT ts_ms, app_bundle_id, app_name, window_title
       FROM focus_events
-      WHERE source = 'nsworkspace_event'
+      WHERE source IN ('nsworkspace_event', 'uia_foreground')
         AND event_type IN ('app_activated', 'window_changed', 'space_changed')
         AND window_title IS NOT NULL
         AND trim(window_title) <> ''
@@ -2133,6 +2134,23 @@ function buildBlockFromCandidate(
   const storedInsight = isLive ? null : getWorkContextInsightForRange(db, blockStart, blockEnd)
   const confidence = confidenceForCandidate(candidate, coherence)
   const topApps = topAppsFromSessions(candidate.sessions)
+  const backgroundApps = getBackgroundProcessEvidence(blockStart, blockEnd).map((process) => ({
+    bundleId: `${process.name}.exe`,
+    appName: process.name,
+    category: 'development' as AppCategory,
+    totalSeconds: process.totalSeconds,
+    sessionCount: 1,
+    isBrowser: false,
+  }))
+  const mergedTopApps = [...topApps]
+  for (const backgroundApp of backgroundApps) {
+    const existing = mergedTopApps.find((app) => app.appName.toLowerCase() === backgroundApp.appName.toLowerCase())
+    if (existing) {
+      existing.totalSeconds = Math.max(existing.totalSeconds, backgroundApp.totalSeconds)
+      continue
+    }
+    mergedTopApps.push(backgroundApp)
+  }
   const pageCandidates = buildPageCandidates(db, blockStart, blockEnd, context)
   const windowCandidates = buildWindowArtifactCandidates(candidate.sessions)
   const pageRefs = pageCandidates.flatMap((candidate) => candidate.pageRef ? [candidate.pageRef] : [])
@@ -2143,7 +2161,7 @@ function buildBlockFromCandidate(
   const dominantCategory = dominantCategoryForBlock(distribution, topArtifacts)
   const windowTitles = buildWindowTitleEvidence(db, blockStart, blockEnd, candidate.sessions)
   const evidenceSummary = {
-    apps: topApps,
+    apps: mergedTopApps,
     pages: pageRefs,
     documents: documentRefs,
     domains: websites.map((site) => site.domain),
@@ -2168,7 +2186,7 @@ function buildBlockFromCandidate(
     ruleBasedLabel: rawRuleLabel,
     aiLabel: storedInsight?.label ?? null,
     sessions: candidate.sessions,
-    topApps,
+    topApps: mergedTopApps,
     websites,
     keyPages,
     pageRefs,

--- a/src/native/windows-capture-helper/Program.cs
+++ b/src/native/windows-capture-helper/Program.cs
@@ -1,0 +1,288 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Windows.Automation;
+
+namespace Daylens.WindowsCaptureHelper;
+
+internal static class Program
+{
+    private const int SchemaVersion = 1;
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
+    private static readonly HashSet<string> FirefoxFamily = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "firefox", "zen", "waterfox", "librewolf", "palemoon", "floorp",
+    };
+
+    private static int Main()
+    {
+        Console.OutputEncoding = Encoding.UTF8;
+        var cts = new CancellationTokenSource();
+        Console.CancelKeyPress += (_, args) =>
+        {
+            args.Cancel = true;
+            cts.Cancel();
+        };
+
+        var lastForegroundKey = string.Empty;
+        var lastTabKey = string.Empty;
+
+        while (!cts.Token.IsCancellationRequested)
+        {
+            try
+            {
+                PollForeground(ref lastForegroundKey, ref lastTabKey);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[windows-capture-helper] poll error: {ex.Message}");
+            }
+
+            Thread.Sleep(PollInterval);
+        }
+
+        return 0;
+    }
+
+    private static void PollForeground(ref string lastForegroundKey, ref string lastTabKey)
+    {
+        var hwnd = GetForegroundWindow();
+        if (hwnd == IntPtr.Zero) return;
+
+        _ = GetWindowThreadProcessId(hwnd, out var pid);
+        using var process = SafeGetProcess(pid);
+        if (process is null) return;
+
+        var exePath = process.MainModule?.FileName ?? process.ProcessName;
+        var appName = process.ProcessName;
+        var bundleId = Path.GetFileName(exePath).ToLowerInvariant();
+        var windowTitle = ReadWindowTitle(hwnd);
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var mono = Stopwatch.GetTimestamp();
+
+        var foregroundKey = $"{pid}:{hwnd}:{windowTitle}";
+        if (!string.Equals(foregroundKey, lastForegroundKey, StringComparison.Ordinal))
+        {
+            lastForegroundKey = foregroundKey;
+            lastTabKey = string.Empty;
+            Emit(new HelperEvent
+            {
+                TsMs = now,
+                MonoNs = mono,
+                EventType = "window_changed",
+                AppBundleId = bundleId,
+                AppName = appName,
+                Pid = pid,
+                WindowTitle = windowTitle,
+                Source = "uia_foreground",
+                Confidence = "observed",
+                Platform = "win32",
+                SchemaVer = SchemaVersion,
+            });
+        }
+
+        if (!LooksLikeBrowser(bundleId, appName, exePath))
+        {
+            return;
+        }
+
+        if (IsFirefoxFamily(bundleId, appName, exePath))
+        {
+            var tabKey = $"firefox-unknown:{pid}";
+            if (string.Equals(tabKey, lastTabKey, StringComparison.Ordinal)) return;
+            lastTabKey = tabKey;
+            Emit(new HelperEvent
+            {
+                TsMs = now,
+                MonoNs = mono,
+                EventType = "tab_sampled",
+                AppBundleId = bundleId,
+                AppName = appName,
+                Pid = pid,
+                WindowTitle = windowTitle,
+                Source = "uia_tab",
+                Confidence = "unknown",
+                Platform = "win32",
+                SchemaVer = SchemaVersion,
+            });
+            return;
+        }
+
+        if (!TryReadChromiumTab(hwnd, out var url, out var pageTitle))
+        {
+            return;
+        }
+
+        var normalizedTabKey = $"{pid}:{url}";
+        if (string.Equals(normalizedTabKey, lastTabKey, StringComparison.Ordinal)) return;
+        lastTabKey = normalizedTabKey;
+
+        Emit(new HelperEvent
+        {
+            TsMs = now,
+            MonoNs = mono,
+            EventType = "tab_sampled",
+            AppBundleId = bundleId,
+            AppName = appName,
+            Pid = pid,
+            WindowTitle = windowTitle,
+            Url = url,
+            PageTitle = pageTitle,
+            Source = "uia_tab",
+            Confidence = "observed",
+            Platform = "win32",
+            SchemaVer = SchemaVersion,
+        });
+    }
+
+    private static Process? SafeGetProcess(int pid)
+    {
+        try
+        {
+            return Process.GetProcessById(pid);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? ReadWindowTitle(IntPtr hwnd)
+    {
+        const int maxLen = 2048;
+        var builder = new StringBuilder(maxLen);
+        var length = GetWindowText(hwnd, builder, maxLen);
+        if (length <= 0) return null;
+        var title = builder.ToString().Trim();
+        return string.IsNullOrWhiteSpace(title) ? null : title;
+    }
+
+    private static bool LooksLikeBrowser(string bundleId, string appName, string exePath)
+    {
+        var haystack = $"{bundleId} {appName} {exePath}".ToLowerInvariant();
+        return haystack.Contains("chrome")
+            || haystack.Contains("msedge")
+            || haystack.Contains("edge")
+            || haystack.Contains("brave")
+            || haystack.Contains("firefox")
+            || haystack.Contains("zen")
+            || haystack.Contains("arc")
+            || haystack.Contains("dia")
+            || haystack.Contains("comet")
+            || haystack.Contains("opera")
+            || haystack.Contains("vivaldi")
+            || haystack.Contains("browser");
+    }
+
+    private static bool IsFirefoxFamily(string bundleId, string appName, string exePath)
+    {
+        var haystack = $"{bundleId} {appName} {exePath}".ToLowerInvariant();
+        return FirefoxFamily.Any(token => haystack.Contains(token));
+    }
+
+    private static bool TryReadChromiumTab(IntPtr hwnd, out string? url, out string? pageTitle)
+    {
+        url = null;
+        pageTitle = null;
+        try
+        {
+            var root = AutomationElement.FromHandle(hwnd);
+            if (root is null) return false;
+
+            pageTitle = string.IsNullOrWhiteSpace(root.Current.Name) ? null : root.Current.Name.Trim();
+
+            var edits = root.FindAll(
+                TreeScope.Descendants,
+                new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit));
+
+            for (var i = 0; i < edits.Count; i++)
+            {
+                var edit = edits[i];
+                var value = edit.Current.Name;
+                var pattern = edit.GetCurrentPattern(ValuePattern.Pattern) as ValuePattern;
+                var candidate = pattern?.Current.Value ?? value;
+                if (string.IsNullOrWhiteSpace(candidate)) continue;
+                candidate = candidate.Trim();
+                if (!candidate.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                    && !candidate.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                url = candidate;
+                return true;
+            }
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static void Emit(HelperEvent ev)
+    {
+        var json = JsonSerializer.Serialize(ev, JsonOptions);
+        Console.WriteLine(json);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out int processId);
+
+    private sealed class HelperEvent
+    {
+        [JsonPropertyName("ts_ms")]
+        public long TsMs { get; init; }
+
+        [JsonPropertyName("mono_ns")]
+        public long MonoNs { get; init; }
+
+        [JsonPropertyName("event_type")]
+        public string EventType { get; init; } = string.Empty;
+
+        [JsonPropertyName("app_bundle_id")]
+        public string? AppBundleId { get; init; }
+
+        [JsonPropertyName("app_name")]
+        public string? AppName { get; init; }
+
+        [JsonPropertyName("pid")]
+        public int? Pid { get; init; }
+
+        [JsonPropertyName("window_title")]
+        public string? WindowTitle { get; init; }
+
+        [JsonPropertyName("url")]
+        public string? Url { get; init; }
+
+        [JsonPropertyName("page_title")]
+        public string? PageTitle { get; init; }
+
+        [JsonPropertyName("source")]
+        public string Source { get; init; } = string.Empty;
+
+        [JsonPropertyName("confidence")]
+        public string Confidence { get; init; } = string.Empty;
+
+        [JsonPropertyName("platform")]
+        public string Platform { get; init; } = "win32";
+
+        [JsonPropertyName("schema_ver")]
+        public int SchemaVer { get; init; } = SchemaVersion;
+    }
+}

--- a/src/native/windows-capture-helper/WindowsCaptureHelper.csproj
+++ b/src/native/windows-capture-helper/WindowsCaptureHelper.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <AssemblyName>windows-capture-helper</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/src/renderer/views/Onboarding.tsx
+++ b/src/renderer/views/Onboarding.tsx
@@ -8,6 +8,7 @@ import type {
   ProofState,
   TrackingPermissionDetails,
   TrackingPermissionState,
+  LinuxTrackingDiagnostics,
 } from '@shared/types'
 import { nextMacStageAfterGrantedPermission } from '@shared/onboarding'
 import { ipc } from '../lib/ipc'
@@ -119,6 +120,7 @@ export default function Onboarding({
   const [busy, setBusy] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [proof, setProof] = useState<ProofSnapshot>({ liveSession: null, timeline: null, ready: false })
+  const [linuxTracking, setLinuxTracking] = useState<LinuxTrackingDiagnostics | null>(null)
   const [settingsHandoff, setSettingsHandoff] = useState(false)
   const onboardingTrackedRef = useRef(false)
   const proofTrackedRef = useRef(false)
@@ -127,6 +129,7 @@ export default function Onboarding({
   const platform = settings.onboardingState.platform
   const stage = settings.onboardingState.stage
   const isMac = platform === 'macos'
+  const isLinux = platform === 'linux'
   const steps = isMac ? MAC_STEPS : NON_MAC_STEPS
   const activeStepIndex = useMemo(() => {
     const idx = steps.findIndex((s) => s.id.includes(stage))
@@ -262,11 +265,16 @@ export default function Onboarding({
 
     async function loadProof() {
       try {
-        const [timeline, liveSession] = await Promise.all([
+        const [timeline, liveSession, diagnostics] = await Promise.all([
           ipc.db.getTimelineDay(todayString()).catch(() => null),
           ipc.tracking.getLiveSession().catch(() => null),
+          isLinux ? ipc.tracking.getDiagnostics().catch(() => null) : Promise.resolve(null),
         ])
         if (cancelled) return
+
+        if (isLinux && diagnostics?.linuxTracking) {
+          setLinuxTracking(diagnostics.linuxTracking)
+        }
 
         const ready = Boolean(
           liveSession
@@ -304,7 +312,7 @@ export default function Onboarding({
       cancelled = true
       window.clearInterval(interval)
     }
-  }, [stage])
+  }, [stage, isLinux])
 
   useEffect(() => {
     if (!proof.ready || proofTrackedRef.current) return
@@ -563,7 +571,11 @@ export default function Onboarding({
                   <span />
                   <span />
                 </div>
-                <p>Have a great day. Daylens will keep listening for real work signal.</p>
+                {isLinux && linuxTracking && linuxTracking.supportLevel !== 'ready' ? (
+                  <p>{linuxTracking.supportMessage} Open Settings → Capture health after setup for the full picture.</p>
+                ) : (
+                  <p>Have a great day. Daylens will keep listening for real work signal.</p>
+                )}
               </div>
             )}
             <div className="onboarding-actions">

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -571,12 +571,26 @@ function CaptureHealthSection({
       : 'Waiting for data'
   const browserNames = captureHealth.browsers?.names ?? []
   const permissions = captureHealth.permissions
+  const linuxTracking = diagnostics?.linuxTracking
 
   return (
     <SettingsSection title="Capture health">
       <div>
+        {linuxTracking && (
+          <SettingsRow
+            first
+            title="Linux session"
+            description={linuxTracking.supportMessage}
+            control={
+              <StatusPill
+                label={linuxTracking.supportLevel === 'ready' ? 'Ready' : linuxTracking.supportLevel === 'limited' ? 'Limited' : 'Unsupported'}
+                tone={linuxTracking.supportLevel === 'ready' ? 'success' : linuxTracking.supportLevel === 'limited' ? 'warning' : 'neutral'}
+              />
+            }
+          />
+        )}
         <SettingsRow
-          first
+          first={!linuxTracking}
           title="Window titles"
           description="Whether Daylens is capturing what you are working on, not just which app is open."
           control={<StatusPill label={titleLabel} tone={titleStatus === 'healthy' ? 'success' : titleStatus === 'missing' ? 'warning' : 'neutral'} />}

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -555,6 +555,57 @@ function ExclusionEditor({
   )
 }
 
+function CaptureHealthSection({
+  diagnostics,
+}: {
+  diagnostics: TrackingDiagnosticsPayload | null
+}) {
+  const captureHealth = diagnostics?.captureHealth
+  if (!captureHealth) return null
+
+  const titleStatus = captureHealth.windowTitles.status
+  const titleLabel = titleStatus === 'healthy'
+    ? 'Healthy'
+    : titleStatus === 'missing'
+      ? 'Missing titles'
+      : 'Waiting for data'
+  const browserNames = captureHealth.browsers?.names ?? []
+  const permissions = captureHealth.permissions
+
+  return (
+    <SettingsSection title="Capture health">
+      <div>
+        <SettingsRow
+          first
+          title="Window titles"
+          description="Whether Daylens is capturing what you are working on, not just which app is open."
+          control={<StatusPill label={titleLabel} tone={titleStatus === 'healthy' ? 'success' : titleStatus === 'missing' ? 'warning' : 'neutral'} />}
+        />
+        <SettingsRow
+          title="Recent samples"
+          description={`${captureHealth.windowTitles.recentSamplesWithTitle} of ${captureHealth.windowTitles.recentSamples} samples in the last 15 minutes carried a title.`}
+          control={<StatusPill label={`${captureHealth.windowTitles.recentSamplesWithTitle}/${captureHealth.windowTitles.recentSamples}`} />}
+        />
+        <SettingsRow
+          title="Browsers discovered"
+          description={browserNames.length > 0 ? browserNames.join(', ') : 'No browser history locations found yet.'}
+          control={<StatusPill label={String(captureHealth.browsers?.discoveredCount ?? 0)} />}
+        />
+        {permissions.platformNote && (
+          <div style={infoPanelStyle}>
+            <div style={{ fontSize: 12.5, color: 'var(--color-text-secondary)', lineHeight: 1.65 }}>
+              {permissions.platformNote}
+              {typeof captureHealth.captureHelperRunning === 'boolean' && (
+                <> Capture helper: {captureHealth.captureHelperRunning ? 'running' : 'not running'}.</>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </SettingsSection>
+  )
+}
+
 function TrackingControlsSection({
   settings,
   persist,
@@ -1622,6 +1673,8 @@ export default function Settings({ initialSettings = null }: { initialSettings?:
             )}
           </div>
         </SettingsSection>
+
+        <CaptureHealthSection diagnostics={trackingDiagnostics} />
 
         <TrackingControlsSection settings={settings} persist={persist} />
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1059,6 +1059,8 @@ export interface TrackingPermissionDetails {
   accessibility: CapturePermissionStatus
   screenRecording: CapturePermissionStatus
   combined: TrackingPermissionState
+  platformNote?: string | null
+  captureHelperRunning?: boolean | null
 }
 
 export type OnboardingStage =
@@ -1266,6 +1268,11 @@ export interface TrackingDiagnosticsPayload {
       recentSamplesWithTitle: number
       lastCapturedAt: number | null
     }
+    browsers?: {
+      discoveredCount: number
+      names: string[]
+    }
+    captureHelperRunning?: boolean | null
   }
   linuxTracking: LinuxTrackingDiagnostics | null
   linuxDesktop: LinuxDesktopDiagnostics | null

--- a/tests/backgroundProcessEvidence.test.ts
+++ b/tests/backgroundProcessEvidence.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  __resetBackgroundProcessEvidenceForTests,
+  getBackgroundProcessEvidence,
+  isBackgroundProcessNoise,
+  observeProcessSnapshots,
+} from '../src/main/services/backgroundProcessEvidence.ts'
+
+test('background process evidence ignores system noise and short runs', () => {
+  __resetBackgroundProcessEvidenceForTests()
+  const originalPlatform = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+  try {
+    assert.equal(isBackgroundProcessNoise('svchost'), true)
+    assert.equal(isBackgroundProcessNoise('node'), false)
+
+    const start = Date.now()
+    observeProcessSnapshots([
+      { pid: 1, name: 'node', cpuPercent: 0, memoryMb: 512, capturedAt: start },
+    ], start)
+    observeProcessSnapshots([
+      { pid: 1, name: 'node', cpuPercent: 0, memoryMb: 512, capturedAt: start + 2 * 60_000 },
+    ], start + 2 * 60_000)
+
+    const evidence = getBackgroundProcessEvidence(start, start + 2 * 60_000)
+    assert.equal(evidence.length, 0)
+
+    observeProcessSnapshots([
+      { pid: 1, name: 'node', cpuPercent: 0, memoryMb: 512, capturedAt: start + 6 * 60_000 },
+    ], start + 6 * 60_000)
+
+    const longEvidence = getBackgroundProcessEvidence(start, start + 6 * 60_000)
+    assert.equal(longEvidence.length, 1)
+    assert.equal(longEvidence[0]?.name, 'node')
+    assert.ok((longEvidence[0]?.totalSeconds ?? 0) >= 300)
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    __resetBackgroundProcessEvidenceForTests()
+  }
+})

--- a/tests/linuxSmokeMode.test.ts
+++ b/tests/linuxSmokeMode.test.ts
@@ -32,10 +32,10 @@ test('linux smoke mode disables gpu-dependent renderer startup paths', () => {
 
 test('linux smoke readiness signals are registered before the renderer starts loading', () => {
   const source = fs.readFileSync(MAIN_PROCESS_SOURCE, 'utf8')
-  const didFinishLoadListener = source.indexOf("win.webContents.once('did-finish-load', () => maybeRunLinuxSmokeValidation('did-finish-load'))")
-  const watchdog = source.indexOf("setTimeout(() => maybeRunLinuxSmokeValidation('watchdog'), 20_000)")
+  const didFinishLoadListener = source.indexOf("win.webContents.once('did-finish-load', () => maybeRunSmokeValidation('did-finish-load'))")
+  const watchdog = source.indexOf("setTimeout(() => maybeRunSmokeValidation('watchdog'), 20_000)")
   const readyToShow = source.indexOf("win.once('ready-to-show'")
-  const readyToShowSignal = source.indexOf("maybeRunLinuxSmokeValidation('ready-to-show')")
+  const readyToShowSignal = source.indexOf("maybeRunSmokeValidation('ready-to-show')")
   const loadFile = source.indexOf('void win.loadFile(rendererPath)')
   const loadUrl = source.indexOf('win.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL)')
 

--- a/tests/windowsBrowserRegistry.test.ts
+++ b/tests/windowsBrowserRegistry.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  classifyWindowsBrowserFamily,
+  parseStartMenuInternetDump,
+} from '../src/main/services/windowsBrowserRegistry.ts'
+
+test('classifyWindowsBrowserFamily detects firefox forks', () => {
+  assert.equal(classifyWindowsBrowserFamily('C:\\Program Files\\Zen\\zen.exe', 'Zen'), 'firefox')
+  assert.equal(classifyWindowsBrowserFamily('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe', 'Google Chrome'), 'chromium')
+})
+
+test('parseStartMenuInternetDump extracts browser applications', () => {
+  const dump = `
+HKEY_CURRENT_USER\\Software\\Clients\\StartMenuInternet\\ChromeHTML
+    (default)    REG_SZ    Google Chrome
+HKEY_CURRENT_USER\\Software\\Clients\\StartMenuInternet\\ChromeHTML\\shell\\open\\command
+    (default)    REG_SZ    "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" -- "%1"
+HKEY_CURRENT_USER\\Software\\Clients\\StartMenuInternet\\ZenHTML
+    (default)    REG_SZ    Zen
+HKEY_CURRENT_USER\\Software\\Clients\\StartMenuInternet\\ZenHTML\\shell\\open\\command
+    (default)    REG_SZ    "C:\\Program Files\\Zen\\zen.exe" -- "%1"
+`
+
+  const applications = parseStartMenuInternetDump(dump)
+  assert.equal(applications.length, 2)
+  assert.equal(applications[0]?.bundleId, 'chrome.exe')
+  assert.equal(applications[0]?.family, 'chromium')
+  assert.equal(applications[1]?.bundleId, 'zen.exe')
+  assert.equal(applications[1]?.family, 'firefox')
+})

--- a/tests/windowsFocusCapture.test.ts
+++ b/tests/windowsFocusCapture.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { normalizeWindowsHelperEvent } from '../src/main/services/windowsFocusCapture.ts'
+
+test('normalizeWindowsHelperEvent accepts observed chromium tab samples', () => {
+  const event = normalizeWindowsHelperEvent({
+    ts_ms: Date.now(),
+    mono_ns: 123,
+    event_type: 'tab_sampled',
+    app_bundle_id: 'msedge.exe',
+    app_name: 'msedge',
+    pid: 42,
+    window_title: 'GitHub',
+    url: 'https://github.com/',
+    page_title: 'GitHub',
+    source: 'uia_tab',
+    confidence: 'observed',
+    platform: 'win32',
+    schema_ver: 1,
+  })
+
+  assert.ok(event)
+  assert.equal(event?.source, 'uia_tab')
+  assert.equal(event?.url, 'https://github.com/')
+})
+
+test('normalizeWindowsHelperEvent rejects unknown tab events that carry a url', () => {
+  const event = normalizeWindowsHelperEvent({
+    ts_ms: Date.now(),
+    mono_ns: 123,
+    event_type: 'tab_sampled',
+    app_bundle_id: 'zen.exe',
+    app_name: 'zen',
+    pid: 42,
+    window_title: 'Example',
+    url: 'https://example.com/',
+    page_title: 'Example',
+    source: 'uia_tab',
+    confidence: 'unknown',
+    platform: 'win32',
+    schema_ver: 1,
+  })
+
+  assert.equal(event, null)
+})
+
+test('normalizeWindowsHelperEvent accepts foreground window changes without urls', () => {
+  const event = normalizeWindowsHelperEvent({
+    ts_ms: Date.now(),
+    mono_ns: 123,
+    event_type: 'window_changed',
+    app_bundle_id: 'Code.exe',
+    app_name: 'Code',
+    pid: 7,
+    window_title: 'settings.ts — daylens',
+    source: 'uia_foreground',
+    confidence: 'observed',
+    platform: 'win32',
+    schema_ver: 1,
+  })
+
+  assert.ok(event)
+  assert.equal(event?.source, 'uia_foreground')
+  assert.equal(event?.url, null)
+})


### PR DESCRIPTION
## Summary
- Windows browser registry (StartMenuInternet + AppData history) so unknown browsers like Zen work without hardcoding
- UIA native capture helper + `windowsFocusCapture` for live Chromium tab URLs; Firefox/Zen stay on history with never-guess
- Platform-aware capture health (Settings + onboarding proof), background process evidence via CIM, Windows CI smoke
- Docs: `windows-capture.md`, surface QA checklist, `INSTALL.md`, `WINDOWS_SIGNING.md`

## Test plan
- [ ] `npm run typecheck` and `npm test` green
- [ ] Windows CI: `verify-windows-runtime` packages NSIS and smoke-tests boot
- [ ] On a real Windows machine: walk `docs/windows-surface-qa-checklist.md` and attach screenshots to DEV-95

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows support for capturing active browser tabs and window titles.
  * Enhanced Linux browser discovery and process monitoring capabilities.
  * Added "Capture health" diagnostics in Settings showing capture status and discovered browsers.

* **Documentation**
  * Added installation guide for Windows, macOS, and Linux.
  * Added Windows code-signing documentation for releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->