### PR TITLE
docs(agents): add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,3 +122,22 @@ scored baseline, not a pass/fail gate.
 Plain English. No role honorifics ("as requested, sir"), no agent-speak ("I shall now
 proceed to..."), no walls of text. Write like the specs are written — short, specific,
 grounded. Say what changed and what to test. That's it.
+
+## Cursor Cloud specific instructions
+
+This is an Electron desktop app. Standard commands live in `package.json` / `CONTRIBUTING.md`
+(`npm run typecheck`, `npm run lint`, `npm test`, `npm start`). The VM snapshot already has the
+native-module system libraries (`libsecret-1-dev`, `xvfb`, `dbus-x11`, etc.) and node deps
+installed; the startup update script runs `npm install`, whose `postinstall` rebuilds the native
+modules (`better-sqlite3`, `@paymoapp/active-window`, `keytar`) against Electron. If a run ever
+hits a native-module ABI error, re-run `npm install` to rebuild.
+
+- **Running the app:** it needs a display. A desktop is on `DISPLAY=:1`, and the container needs
+  the sandbox off, so launch with `DISPLAY=:1 ELECTRON_DISABLE_SANDBOX=1 npm start`.
+- **Expected non-fatal noise:** `Failed to connect to the bus` (dbus), `Exiting GPU process`,
+  `failed to register global shortcut`, and `keytar`/`settings hasApiKey` "transport disabled"
+  errors are all normal headless-VM output — the app still runs. There is no OS keyring, so API
+  keys can't be stored; the app starts fine without one.
+- **Tests:** `npm test` is hermetic (no API keys, no network) and runs each file in its own
+  Electron-as-node process. It does not need a display. The paid AI suites listed above still
+  require human approval and real keys.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

Set up the Daylens development environment in the cloud VM and documented durable, non-obvious run/test caveats for future agents under `## Cursor Cloud specific instructions` in `AGENTS.md`.

No application code changed — this is environment setup plus a docs note.

## Environment setup performed

- Installed native-module system libs (`libsecret-1-dev`, `libnotify-dev`, `libx11-dev`, `libxss-dev`, `libxtst-dev`, `xvfb`, `xauth`, `dbus-x11`, `x11-utils`).
- `npm install` (runs `postinstall` `electron-rebuild` for `better-sqlite3`, `@paymoapp/active-window`, `keytar`).
- Update script registered: `npm install`.

## Verification

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — 0 errors (10 pre-existing warnings)
- ✅ `npm test` — 102 files, 655 pass, 0 fail, 1 skip
- ✅ `DISPLAY=:1 ELECTRON_DISABLE_SANDBOX=1 npm start` — app launched, DB migrated to v34, tracking started, completed onboarding and navigated Timeline / Apps / Settings

[daylens_app_walkthrough.mp4](https://cursor.com/agents/bc-cde3e4c3-4ceb-4778-bdfd-9961fb301f88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdaylens_app_walkthrough.mp4)

[Timeline view](https://cursor.com/agents/bc-cde3e4c3-4ceb-4778-bdfd-9961fb301f88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdaylens_timeline.webp)
[Settings view](https://cursor.com/agents/bc-cde3e4c3-4ceb-4778-bdfd-9961fb301f88/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdaylens_settings.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cde3e4c3-4ceb-4778-bdfd-9961fb301f88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cde3e4c3-4ceb-4778-bdfd-9961fb301f88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

