### PR TITLE
Browser pages are privacy-verified before they enter memory (DEV-164)

### DIFF
--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -2342,6 +2342,22 @@ const migrations: Migration[] = [
       `)
     },
   },
+  {
+    version: 48,
+    description:
+      'Drop website_visits_pending (unverified page content at rest) and add durable browser history source cursors',
+    up: () => {
+      const db = getDb()
+      db.exec(`
+        DROP TABLE IF EXISTS website_visits_pending;
+        CREATE TABLE IF NOT EXISTS browser_history_cursors (
+          browser_bundle_id TEXT PRIMARY KEY,
+          cursor_us         TEXT    NOT NULL,
+          updated_at        INTEGER NOT NULL
+        );
+      `)
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations.at(-1)?.version ?? 0

--- a/src/main/db/queries.ts
+++ b/src/main/db/queries.ts
@@ -21,7 +21,14 @@ import type {
 } from '@shared/types'
 import { isCategoryFocused } from '../lib/focusScore'
 import { localDateString, localDayBounds, shiftLocalDateString } from '../lib/localDate'
-import { resolveCanonicalApp, type CanonicalAppIdentity } from '../lib/appIdentity'
+import {
+  normalizeUrlForStorage,
+  pageKeyForUrl,
+  resolveCanonicalApp,
+  resolveCanonicalBrowser,
+  sanitizeUrlForPersistence,
+  type CanonicalAppIdentity,
+} from '../lib/appIdentity'
 import { resolveBrowserApplication } from '../services/browserRegistry'
 import { learnFromBlockOverride } from '../services/workMemory'
 import { isSystemNoiseApp } from '@shared/systemNoise'
@@ -2120,6 +2127,17 @@ export function insertWebsiteVisit(
   db: Database.Database,
   visit: WebsiteVisitInsert,
 ): boolean {
+  const url = sanitizeUrlForPersistence(visit.url)
+  if (!url) return false
+  const normalizedUrl = visit.normalizedUrl ?? normalizeUrlForStorage(visit.url)
+  const pageKey = visit.pageKey ?? pageKeyForUrl(visit.url)
+  const durationSec = clipWebsiteVisitDurationToBrowserForeground(db, {
+    visitTime: visit.visitTime,
+    durationSec: visit.durationSec,
+    browserBundleId: visit.browserBundleId,
+    canonicalBrowserId: visit.canonicalBrowserId,
+  })
+
   const result = db.prepare(`
     INSERT OR IGNORE INTO website_visits
       (
@@ -2140,97 +2158,105 @@ export function insertWebsiteVisit(
   `).run(
     visit.domain,
     visit.pageTitle,
-    visit.url,
+    url,
     visit.visitTime,
     visit.visitTimeUs,
-    visit.durationSec,
+    durationSec,
     visit.browserBundleId,
     visit.canonicalBrowserId,
     visit.browserProfileId,
-    visit.normalizedUrl,
-    visit.pageKey,
+    normalizedUrl,
+    pageKey,
     visit.source,
   )
   return result.changes > 0
 }
 
-// Live tab reads from browsers that cannot report their window mode land here
-// instead of website_visits. The history poll promotes rows the browser's own
-// history corroborates and deletes the rest — private windows never write
-// browser history, so uncorroborated rows are private-window visits.
+/** Clip page duration to overlapping foreground browser time when any exists. */
+export function clipWebsiteVisitDurationToBrowserForeground(
+  db: Database.Database,
+  visit: {
+    visitTime: number
+    durationSec: number
+    browserBundleId: string
+    canonicalBrowserId: string | null
+  },
+): number {
+  if (visit.durationSec <= 0) return 0
+  const visitEnd = visit.visitTime + visit.durationSec * 1000
+  const visitCanonical =
+    visit.canonicalBrowserId ?? resolveCanonicalBrowser(visit.browserBundleId).canonicalBrowserId
+  const visitBundleBase = visit.browserBundleId.split(':', 1)[0]?.toLowerCase() ?? ''
 
-export interface PendingWebsiteVisit extends WebsiteVisitInsert {
-  id: number
-  observedAt: number
+  let rows: Array<{
+    start_time: number
+    end_time: number | null
+    duration_sec: number
+    bundle_id: string | null
+    canonical_app_id: string | null
+  }>
+  try {
+    rows = db.prepare(`
+      SELECT start_time, end_time, duration_sec, bundle_id, canonical_app_id
+      FROM app_sessions
+      WHERE start_time < ?
+        AND COALESCE(end_time, start_time + duration_sec * 1000) > ?
+    `).all(visitEnd, visit.visitTime) as typeof rows
+  } catch {
+    return visit.durationSec
+  }
+
+  let overlapMs = 0
+  for (const row of rows) {
+    const bundle = (row.bundle_id ?? '').toLowerCase()
+    const bundleBase = bundle.split(':', 1)[0] ?? ''
+    const canonical = (row.canonical_app_id ?? '').toLowerCase()
+    const sameBrowser =
+      (visitCanonical != null && canonical !== '' && canonical === visitCanonical.toLowerCase())
+      || (bundleBase !== '' && bundleBase === visitBundleBase)
+      || bundle === visit.browserBundleId.toLowerCase()
+    if (!sameBrowser) continue
+
+    const sessionEnd = row.end_time ?? row.start_time + row.duration_sec * 1000
+    const overlapStart = Math.max(visit.visitTime, row.start_time)
+    const overlapEnd = Math.min(visitEnd, sessionEnd)
+    if (overlapEnd > overlapStart) overlapMs += overlapEnd - overlapStart
+  }
+
+  // No foreground overlap: keep the source duration for retrieval; active-time
+  // reconciliation still refuses to credit it against browser ownership.
+  if (overlapMs <= 0) return visit.durationSec
+  return Math.max(1, Math.round(overlapMs / 1000))
 }
 
-export function insertPendingWebsiteVisit(
+export function getBrowserHistoryCursor(
   db: Database.Database,
-  visit: WebsiteVisitInsert,
-  observedAt = Date.now(),
+  browserBundleId: string,
+): bigint | null {
+  const row = db.prepare(`
+    SELECT cursor_us FROM browser_history_cursors WHERE browser_bundle_id = ?
+  `).get(browserBundleId) as { cursor_us: string } | undefined
+  if (!row?.cursor_us) return null
+  try {
+    return BigInt(row.cursor_us)
+  } catch {
+    return null
+  }
+}
+
+export function setBrowserHistoryCursor(
+  db: Database.Database,
+  browserBundleId: string,
+  cursorUs: bigint,
+  updatedAt = Date.now(),
 ): void {
   db.prepare(`
-    INSERT INTO website_visits_pending
-      (domain, page_title, url, normalized_url, page_key, visit_time,
-       visit_time_us, duration_sec, browser_bundle_id, canonical_browser_id,
-       browser_profile_id, observed_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(
-    visit.domain,
-    visit.pageTitle,
-    visit.url,
-    visit.normalizedUrl,
-    visit.pageKey,
-    visit.visitTime,
-    visit.visitTimeUs,
-    visit.durationSec,
-    visit.browserBundleId,
-    visit.canonicalBrowserId,
-    visit.browserProfileId,
-    observedAt,
-  )
-}
-
-export function listPendingWebsiteVisits(
-  db: Database.Database,
-  canonicalBrowserId: string | null,
-  limit = 200,
-): PendingWebsiteVisit[] {
-  const rows = db.prepare(`
-    SELECT id, domain, page_title, url, normalized_url, page_key, visit_time,
-           visit_time_us, duration_sec, browser_bundle_id, canonical_browser_id,
-           browser_profile_id, observed_at
-    FROM website_visits_pending
-    WHERE canonical_browser_id IS ?
-    ORDER BY observed_at ASC
-    LIMIT ?
-  `).all(canonicalBrowserId, limit) as Array<Record<string, unknown>>
-  return rows.map((row) => ({
-    id: Number(row.id),
-    domain: String(row.domain),
-    pageTitle: (row.page_title as string | null) ?? null,
-    url: String(row.url),
-    normalizedUrl: (row.normalized_url as string | null) ?? null,
-    pageKey: (row.page_key as string | null) ?? null,
-    visitTime: Number(row.visit_time),
-    visitTimeUs: BigInt(row.visit_time_us as number | bigint),
-    durationSec: Number(row.duration_sec),
-    browserBundleId: String(row.browser_bundle_id),
-    canonicalBrowserId: (row.canonical_browser_id as string | null) ?? null,
-    browserProfileId: (row.browser_profile_id as string | null) ?? null,
-    source: 'active_browser_context',
-    observedAt: Number(row.observed_at),
-  }))
-}
-
-export function deletePendingWebsiteVisits(db: Database.Database, ids: number[]): void {
-  if (ids.length === 0) return
-  const placeholders = ids.map(() => '?').join(',')
-  db.prepare(`DELETE FROM website_visits_pending WHERE id IN (${placeholders})`).run(...ids)
-}
-
-export function deleteExpiredPendingWebsiteVisits(db: Database.Database, olderThanMs: number): number {
-  return db.prepare('DELETE FROM website_visits_pending WHERE observed_at < ?').run(olderThanMs).changes
+    INSERT INTO browser_history_cursors (browser_bundle_id, cursor_us, updated_at)
+    VALUES (?, ?, ?)
+    ON CONFLICT(browser_bundle_id) DO UPDATE SET
+      cursor_us = excluded.cursor_us,
+      updated_at = excluded.updated_at
+  `).run(browserBundleId, cursorUs.toString(), updatedAt)
 }
 
 

--- a/src/main/lib/appIdentity.ts
+++ b/src/main/lib/appIdentity.ts
@@ -168,16 +168,23 @@ export function resolveCanonicalBrowser(browserBundleId: string | null | undefin
   }
 }
 
-export function normalizeUrlForStorage(rawUrl: string | null | undefined): string | null {
-  if (!rawUrl) return null
+// Query keys that must never be persisted. Tracking params are stripped for
+// identity; secrets are stripped before any URL lands in storage.
+const TRACKING_QUERY_KEY_RE = /^(utm_|fbclid$|gclid$|mc_cid$|mc_eid$)/i
+const SENSITIVE_QUERY_KEY_RE =
+  /^(?:access_token|id_token|refresh_token|auth_token|token|session(?:id|_id)?|sid|code|state|password|passwd|pwd|secret|client_secret|api[_-]?key|apikey|jwt|auth|authorization|oauth[_-]?token)$/i
 
+function rewriteUrlSearch(
+  rawUrl: string,
+  shouldDrop: (key: string) => boolean,
+): string | null {
   try {
     const url = new URL(rawUrl)
     url.hash = ''
 
     const filteredParams = new URLSearchParams()
     for (const [key, value] of url.searchParams.entries()) {
-      if (/^(utm_|fbclid$|gclid$|mc_cid$|mc_eid$)/i.test(key)) continue
+      if (shouldDrop(key)) continue
       filteredParams.append(key, value)
     }
     url.search = filteredParams.toString()
@@ -187,6 +194,21 @@ export function normalizeUrlForStorage(rawUrl: string | null | undefined): strin
   } catch {
     return null
   }
+}
+
+/** Reopenable URL: fragments and sensitive query values removed; safe params kept. */
+export function sanitizeUrlForPersistence(rawUrl: string | null | undefined): string | null {
+  if (!rawUrl) return null
+  return rewriteUrlSearch(rawUrl, (key) => SENSITIVE_QUERY_KEY_RE.test(key))
+}
+
+/** Stable identity URL: also drops common tracking parameters. */
+export function normalizeUrlForStorage(rawUrl: string | null | undefined): string | null {
+  if (!rawUrl) return null
+  return rewriteUrlSearch(
+    rawUrl,
+    (key) => SENSITIVE_QUERY_KEY_RE.test(key) || TRACKING_QUERY_KEY_RE.test(key),
+  )
 }
 
 export function pageKeyForUrl(rawUrl: string | null | undefined): string | null {

--- a/src/main/services/browser.ts
+++ b/src/main/services/browser.ts
@@ -21,12 +21,11 @@ import { ANALYTICS_EVENT, classifyFailureKind } from '@shared/analytics'
 import type { SafariHistoryAccessStatus } from '@shared/types'
 import { getDb } from './database'
 import {
+  getBrowserHistoryCursor,
   insertWebsiteVisit,
-  listPendingWebsiteVisits,
-  deletePendingWebsiteVisits,
-  deleteExpiredPendingWebsiteVisits,
+  setBrowserHistoryCursor,
 } from '../db/queries'
-import { normalizeUrlForStorage, pageKeyForUrl, resolveCanonicalBrowser } from '../lib/appIdentity'
+import { normalizeUrlForStorage, pageKeyForUrl, resolveCanonicalBrowser, sanitizeUrlForPersistence } from '../lib/appIdentity'
 import { invalidateProjectionScope } from '../core/projections/invalidation'
 import { localDateString } from '../lib/localDate'
 import { capture, captureRateLimited } from './analytics'
@@ -540,38 +539,42 @@ async function copyHistorySnapshot(historyPath: string, tmpDb: string, tmpWal: s
 
 // ─── Chromium poll ─────────────────────────────────────────────────────────────
 
-// Quarantined live visits (browserContext could not read the window mode)
-// are resolved against the browser's own history while its copy is open:
-// corroborated rows are promoted to website_visits, the rest deleted —
-// private windows never write browser history. The grace period gives the
-// browser time to flush its own history write; expiry bounds how long an
-// uncorroborable row can wait.
-const PENDING_VISIT_GRACE_MS = 90_000
-const PENDING_VISIT_MAX_AGE_MS = 86_400_000
+function loadBrowserCursor(db: ReturnType<typeof getDb>, bundleId: string): bigint | null {
+  return browserCursors.get(bundleId) ?? getBrowserHistoryCursor(db, bundleId)
+}
 
-function reconcilePendingLiveVisits(
+function persistBrowserCursor(
   db: ReturnType<typeof getDb>,
-  browserBundleId: string,
-  urlExistsInHistory: (url: string) => boolean,
+  bundleId: string,
+  cursor: bigint,
 ): void {
-  const canonicalBrowserId = resolveCanonicalBrowser(browserBundleId).canonicalBrowserId
-  const now = Date.now()
-  const resolved: number[] = []
-  for (const visit of listPendingWebsiteVisits(db, canonicalBrowserId)) {
-    if (now - visit.observedAt < PENDING_VISIT_GRACE_MS) continue
-    if (urlExistsInHistory(visit.url)) {
-      const inserted = insertWebsiteVisit(db, visit)
-      if (inserted) {
-        const date = localDateString(new Date(visit.visitTime))
-        invalidateProjectionScope('timeline', 'active_browser_context_recorded', { date })
-        invalidateProjectionScope('apps', 'active_browser_context_recorded', { canonicalAppId: visit.canonicalBrowserId })
-        invalidateProjectionScope('insights', 'active_browser_context_recorded', { date })
-      }
-    }
-    resolved.push(visit.id)
-  }
-  deletePendingWebsiteVisits(db, resolved)
-  deleteExpiredPendingWebsiteVisits(db, now - PENDING_VISIT_MAX_AGE_MS)
+  browserCursors.set(bundleId, cursor)
+  setBrowserHistoryCursor(db, bundleId, cursor)
+}
+
+function historyVisitInsert(
+  db: ReturnType<typeof getDb>,
+  browser: BrowserEntry,
+  processed: ProcessedHistoryRow,
+  source: string,
+): boolean {
+  const persistedUrl = sanitizeUrlForPersistence(processed.url)
+  if (!persistedUrl) return false
+  const browserIdentity = resolveCanonicalBrowser(browser.bundleId)
+  return insertWebsiteVisit(db, {
+    domain: processed.domain,
+    pageTitle: processed.pageTitle,
+    url: persistedUrl,
+    normalizedUrl: normalizeUrlForStorage(processed.url),
+    pageKey: pageKeyForUrl(processed.url),
+    visitTime: processed.visitTime,
+    visitTimeUs: processed.visitTimeUs,
+    durationSec: processed.durationSec,
+    browserBundleId: browser.bundleId,
+    canonicalBrowserId: browserIdentity.canonicalBrowserId,
+    browserProfileId: browserIdentity.browserProfileId,
+    source,
+  })
 }
 
 async function pollChromium(
@@ -586,7 +589,7 @@ async function pollChromium(
   let inserted = 0
   let error: string | null = null
 
-  const lastCursorUs = browserCursors.get(browser.bundleId) ?? null
+  const lastCursorUs = loadBrowserCursor(db, browser.bundleId)
   // If no cursor yet, start from 24h ago
   const fromUs: bigint = lastCursorUs ?? msToChromeUs(Date.now() - 86_400_000)
   const controls = trackingControlsStateFromSettings(getSettings())
@@ -621,22 +624,7 @@ async function pollChromium(
 
       for (const processed of processChromiumRows(rowsToProcess)) {
         if (!decideSiteCapture(controls, { domain: processed.domain }).capture) continue
-        const browserIdentity = resolveCanonicalBrowser(browser.bundleId)
-        const didInsert = insertWebsiteVisit(db, {
-          domain:          processed.domain,
-          pageTitle:       processed.pageTitle,
-          url:             processed.url,
-          normalizedUrl:   normalizeUrlForStorage(processed.url),
-          pageKey:         pageKeyForUrl(processed.url),
-          visitTime:       processed.visitTime,
-          visitTimeUs:     processed.visitTimeUs,
-          durationSec:     processed.durationSec,
-          browserBundleId: browser.bundleId,
-          canonicalBrowserId: browserIdentity.canonicalBrowserId,
-          browserProfileId: browserIdentity.browserProfileId,
-          source:          'chrome_history',
-        })
-        if (didInsert) inserted++
+        if (historyVisitInsert(db, browser, processed, 'chrome_history')) inserted++
       }
 
       const lastRowUs = rows[rows.length - 1].visit_time
@@ -659,11 +647,8 @@ async function pollChromium(
       }
     }
 
-    // Persist the cursor so next poll continues from where we left off
-    browserCursors.set(browser.bundleId, cursor)
-
-    const urlLookup = histDb.prepare('SELECT 1 FROM urls WHERE url = ? LIMIT 1')
-    reconcilePendingLiveVisits(db, browser.bundleId, (url) => urlLookup.get(url) != null)
+    // Persist the cursor only after a successful read/write pass.
+    persistBrowserCursor(db, browser.bundleId, cursor)
 
     histDb.close()
   } catch (err) {
@@ -699,7 +684,7 @@ async function pollFirefox(
   let error: string | null = null
 
   // Firefox visit_date is Unix µs — not Chrome epoch µs
-  const lastCursorUs = browserCursors.get(browser.bundleId) ?? null
+  const lastCursorUs = loadBrowserCursor(db, browser.bundleId)
   const fromUs: bigint = lastCursorUs ?? (BigInt(Date.now() - 86_400_000) * 1000n)
   const controls = trackingControlsStateFromSettings(getSettings())
 
@@ -731,22 +716,7 @@ async function pollFirefox(
 
       for (const processed of processFirefoxRows(rowsToProcess)) {
         if (!decideSiteCapture(controls, { domain: processed.domain }).capture) continue
-        const browserIdentity = resolveCanonicalBrowser(browser.bundleId)
-        const didInsert = insertWebsiteVisit(db, {
-          domain:          processed.domain,
-          pageTitle:       processed.pageTitle,
-          url:             processed.url,
-          normalizedUrl:   normalizeUrlForStorage(processed.url),
-          pageKey:         pageKeyForUrl(processed.url),
-          visitTime:       processed.visitTime,
-          visitTimeUs:     processed.visitTimeUs,
-          durationSec:     processed.durationSec,
-          browserBundleId: browser.bundleId,
-          canonicalBrowserId: browserIdentity.canonicalBrowserId,
-          browserProfileId: browserIdentity.browserProfileId,
-          source:          'firefox_history',
-        })
-        if (didInsert) inserted++
+        if (historyVisitInsert(db, browser, processed, 'firefox_history')) inserted++
       }
 
       const lastRowUs = rows[rows.length - 1].visit_date
@@ -761,7 +731,7 @@ async function pollFirefox(
       }
     }
 
-    browserCursors.set(browser.bundleId, cursor)
+    persistBrowserCursor(db, browser.bundleId, cursor)
     histDb.close()
   } catch (err) {
     error = String(err)
@@ -792,7 +762,7 @@ async function pollWebKit(
   let inserted = 0
   let error: string | null = null
 
-  const lastCursorUs = browserCursors.get(browser.bundleId) ?? null
+  const lastCursorUs = loadBrowserCursor(db, browser.bundleId)
   const fromMs = lastCursorUs ? Number(lastCursorUs / 1_000n) : Date.now() - 86_400_000
   const fromWebKitSeconds = fromMs / 1_000 - WEBKIT_EPOCH_OFFSET_SEC
 
@@ -814,36 +784,18 @@ async function pollWebKit(
       LIMIT 5000
     `).all(fromWebKitSeconds) as WebKitHistoryRow[]
 
-    const urlLookup = histDb.prepare('SELECT 1 FROM history_items WHERE url = ? LIMIT 1')
-    reconcilePendingLiveVisits(db, browser.bundleId, (url) => urlLookup.get(url) != null)
-
     histDb.close()
 
     const controls = trackingControlsStateFromSettings(getSettings())
     for (const processed of processWebKitRows(rows)) {
       if (!decideSiteCapture(controls, { domain: processed.domain }).capture) continue
-      const browserIdentity = resolveCanonicalBrowser(browser.bundleId)
-      const didInsert = insertWebsiteVisit(db, {
-        domain: processed.domain,
-        pageTitle: processed.pageTitle,
-        url: processed.url,
-        normalizedUrl: normalizeUrlForStorage(processed.url),
-        pageKey: pageKeyForUrl(processed.url),
-        visitTime: processed.visitTime,
-        visitTimeUs: processed.visitTimeUs,
-        durationSec: processed.durationSec,
-        browserBundleId: browser.bundleId,
-        canonicalBrowserId: browserIdentity.canonicalBrowserId,
-        browserProfileId: browserIdentity.browserProfileId,
-        source: 'webkit_history',
-      })
-      if (didInsert) inserted++
+      if (historyVisitInsert(db, browser, processed, 'webkit_history')) inserted++
     }
 
     const last = rows[rows.length - 1]
     if (last) {
       const lastMs = Math.round((last.visit_time + WEBKIT_EPOCH_OFFSET_SEC) * 1_000)
-      browserCursors.set(browser.bundleId, BigInt(lastMs) * 1_000n)
+      persistBrowserCursor(db, browser.bundleId, BigInt(lastMs) * 1_000n)
     }
   } catch (err) {
     error = String(err)

--- a/src/main/services/browserContext.ts
+++ b/src/main/services/browserContext.ts
@@ -4,8 +4,8 @@ import os from 'node:os'
 import path from 'node:path'
 import Database from 'better-sqlite3'
 import type BetterSqlite from 'better-sqlite3'
-import { insertWebsiteVisit, insertPendingWebsiteVisit } from '../db/queries'
-import { normalizeUrlForStorage, pageKeyForUrl, resolveCanonicalBrowser } from '../lib/appIdentity'
+import { insertWebsiteVisit } from '../db/queries'
+import { normalizeUrlForStorage, pageKeyForUrl, resolveCanonicalBrowser, sanitizeUrlForPersistence } from '../lib/appIdentity'
 import { invalidateProjectionScope } from '../core/projections/invalidation'
 import { localDateString } from '../lib/localDate'
 import { getBrowserEntries, type BrowserEntry } from './browser'
@@ -42,9 +42,9 @@ export interface ActiveBrowserTab {
   // tracked — no website visit, no app session — regardless of settings.
   isPrivate?: boolean
   // False when the browser could not report its window mode (Chromium forks
-  // that dropped the property, WebKit). Visits from such reads are quarantined
-  // until the browser's own history corroborates them — private windows never
-  // write history, so uncorroborated visits are deleted, never stored.
+  // that dropped the property, WebKit). Page title/URL are not persisted from
+  // these reads — only browser identity and timing (via app sessions) remain
+  // until the browser's own non-private history corroborates the page.
   modeKnown?: boolean
 }
 
@@ -272,7 +272,8 @@ function recentChromiumTab(entry: BrowserEntry, now: number, windowTitle: string
     db.close()
 
     const row = rows.find((candidate) => titleMatchesWindow(candidate.title, windowTitle)) ?? rows[0]
-    return row ? { url: row.url, title: row.title ?? null } : null
+    // History is non-private by definition — treat as mode-verified.
+    return row ? { url: row.url, title: row.title ?? null, modeKnown: true } : null
   } catch {
     return null
   } finally {
@@ -297,7 +298,7 @@ function recentFirefoxTab(entry: BrowserEntry, now: number, windowTitle: string 
     db.close()
 
     const row = rows.find((candidate) => titleMatchesWindow(candidate.title, windowTitle)) ?? rows[0]
-    return row ? { url: row.url, title: row.title ?? null } : null
+    return row ? { url: row.url, title: row.title ?? null, modeKnown: true } : null
   } catch {
     return null
   } finally {
@@ -524,6 +525,20 @@ export class ActiveBrowserContextTracker {
       }
     }
 
+    // Unverifiable window mode: keep browser app timing (tracking sessions)
+    // but never accumulate page title/URL for persistence. History ingestion
+    // is the only path that may later attach page detail.
+    if (tab.modeKnown === false) {
+      this.flush(db, snapshot.capturedAt)
+      this.pending = null
+      this.inFlight = null
+      this.lastWindowTitle = snapshot.windowTitle ?? null
+      return {
+        isPrivate: false,
+        passivePresence: passivePresenceForDomain(domain, snapshot),
+      }
+    }
+
     this.lastWindowTitle = snapshot.windowTitle ?? null
 
     const normalizedUrl = normalizeUrlForStorage(tab.url)
@@ -539,6 +554,9 @@ export class ActiveBrowserContextTracker {
     this.inFlight = null
     this.pending = null
     if (!context) return false
+
+    // Defense in depth: unverifiable reads must never reach website_visits.
+    if (context.tab.modeKnown === false) return false
 
     const domain = extractDomain(context.tab.url)
     if (!domain) return false
@@ -558,11 +576,13 @@ export class ActiveBrowserContextTracker {
     if (durationSec < MIN_CONTEXT_SEC) return false
 
     const browserIdentity = resolveCanonicalBrowser(context.snapshot.bundleId)
+    const persistedUrl = sanitizeUrlForPersistence(context.tab.url)
+    if (!persistedUrl) return false
     const visit = {
       domain,
       pageTitle: context.tab.title,
-      url: context.tab.url,
-      normalizedUrl: context.normalizedUrl,
+      url: persistedUrl,
+      normalizedUrl: context.normalizedUrl ?? normalizeUrlForStorage(context.tab.url),
       pageKey: pageKeyForUrl(context.tab.url),
       visitTime: context.startedAt,
       visitTimeUs: BigInt(context.startedAt) * 1000n,
@@ -571,14 +591,6 @@ export class ActiveBrowserContextTracker {
       canonicalBrowserId: browserIdentity.canonicalBrowserId,
       browserProfileId: browserIdentity.browserProfileId,
       source: 'active_browser_context',
-    }
-
-    // A read without a window-mode signal cannot prove the window was not
-    // private: quarantine the visit until the browser's own history
-    // corroborates it (see reconcilePendingLiveVisits in browser.ts).
-    if (context.tab.modeKnown === false) {
-      insertPendingWebsiteVisit(db, visit)
-      return false
     }
 
     const inserted = insertWebsiteVisit(db, visit)

--- a/src/main/services/trackingHistory.ts
+++ b/src/main/services/trackingHistory.ts
@@ -208,12 +208,6 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
       // Derived projection tables are optional on older installs.
     }
 
-    try {
-      deletedRows += db.prepare(`DELETE FROM website_visits_pending ${where}`).run(...params).changes
-    } catch {
-      // Pending-visit table arrives with migration v45.
-    }
-
     // A browser window title is the page title, so the site's name can sit in
     // ANY text column of ANY table: titles, urls, block labels, chat tool
     // traces, narrative JSON, work-memory observations. A hand-maintained

--- a/tests/browserEvidencePrivacy.test.ts
+++ b/tests/browserEvidencePrivacy.test.ts
@@ -1,0 +1,250 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createProductionTestDatabase } from './support/testDatabase.ts'
+import {
+  ActiveBrowserContextTracker,
+  type ActiveBrowserWindowSnapshot,
+} from '../src/main/services/browserContext.ts'
+import {
+  clipWebsiteVisitDurationToBrowserForeground,
+  getBrowserHistoryCursor,
+  insertWebsiteVisit,
+  setBrowserHistoryCursor,
+} from '../src/main/db/queries.ts'
+import {
+  normalizeUrlForStorage,
+  sanitizeUrlForPersistence,
+} from '../src/main/lib/appIdentity.ts'
+
+const BASE = 1_800_000_000_000
+
+function snapshot(overrides: Partial<ActiveBrowserWindowSnapshot> = {}): ActiveBrowserWindowSnapshot {
+  return {
+    bundleId: 'com.google.Chrome',
+    appName: 'Google Chrome',
+    windowTitle: 'Example',
+    capturedAt: BASE,
+    ...overrides,
+  }
+}
+
+test('unverifiable window mode persists no page title or URL', () => {
+  const db = createProductionTestDatabase()
+  try {
+    const tracker = new ActiveBrowserContextTracker(
+      () => ({
+        url: 'https://secret.example/private-tab?token=abc123secret',
+        title: 'Private tab title',
+        modeKnown: false,
+      }),
+      () => true,
+    )
+
+    tracker.sample(db, snapshot())
+    tracker.sample(db, snapshot({ capturedAt: BASE + 30_000 }))
+    assert.equal(tracker.flush(db, BASE + 60_000), false)
+
+    assert.equal(
+      (db.prepare('SELECT COUNT(*) AS n FROM website_visits').get() as { n: number }).n,
+      0,
+    )
+    const leaked = db
+      .prepare(
+        `
+      SELECT name FROM sqlite_master
+      WHERE type = 'table' AND sql LIKE '%Private tab title%'
+    `,
+      )
+      .all()
+    assert.deepEqual(leaked, [])
+    assert.doesNotMatch(
+      JSON.stringify(
+        db.prepare('SELECT * FROM website_visits').all(),
+      ),
+      /secret\.example|Private tab|abc123secret/i,
+    )
+  } finally {
+    db.close()
+  }
+})
+
+test('confirmed private windows leave zero page rows anywhere', () => {
+  const db = createProductionTestDatabase()
+  try {
+    const tracker = new ActiveBrowserContextTracker(
+      () => ({ url: '', title: null, isPrivate: true, modeKnown: true }),
+      () => true,
+    )
+    tracker.sample(db, snapshot({ windowTitle: 'Incognito' }))
+    tracker.flush(db, BASE + 60_000)
+
+    assert.equal(
+      (db.prepare('SELECT COUNT(*) AS n FROM website_visits').get() as { n: number }).n,
+      0,
+    )
+    assert.equal(
+      (
+        db
+          .prepare(
+            "SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'table' AND name = 'website_visits_pending'",
+          )
+          .get() as { n: number }
+      ).n,
+      0,
+    )
+  } finally {
+    db.close()
+  }
+})
+
+test('sensitive query values and fragments are stripped before persistence', () => {
+  const raw =
+    'https://app.example/callback?code=oauth_code_value&state=xyz&keep=1&access_token=tok_abc#fragment-secret'
+  assert.equal(
+    sanitizeUrlForPersistence(raw),
+    'https://app.example/callback?keep=1',
+  )
+  assert.equal(
+    normalizeUrlForStorage('https://app.example/page?utm_source=x&session_id=s1&v=ok'),
+    'https://app.example/page?v=ok',
+  )
+
+  const db = createProductionTestDatabase()
+  try {
+    const inserted = insertWebsiteVisit(db, {
+      domain: 'app.example',
+      pageTitle: 'Callback',
+      url: raw,
+      normalizedUrl: normalizeUrlForStorage(raw),
+      pageKey: 'app.example/callback',
+      visitTime: BASE,
+      visitTimeUs: BigInt(BASE) * 1000n,
+      durationSec: 30,
+      browserBundleId: 'com.google.Chrome',
+      canonicalBrowserId: 'chrome',
+      browserProfileId: 'default',
+      source: 'chrome_history',
+    })
+    assert.equal(inserted, true)
+    const row = db.prepare('SELECT url, normalized_url FROM website_visits').get() as {
+      url: string
+      normalized_url: string
+    }
+    assert.equal(row.url, 'https://app.example/callback?keep=1')
+    assert.doesNotMatch(row.url, /code=|state=|access_token=|fragment/i)
+    assert.doesNotMatch(row.normalized_url, /code=|state=|access_token=/i)
+  } finally {
+    db.close()
+  }
+})
+
+test('page duration is clipped to the owning browser foreground interval', () => {
+  const db = createProductionTestDatabase()
+  try {
+    db.prepare(`
+      INSERT INTO app_sessions (
+        bundle_id, app_name, start_time, end_time, duration_sec, category, is_focused,
+        window_title, raw_app_name, canonical_app_id, app_instance_id, capture_source, capture_version
+      ) VALUES (?, ?, ?, ?, ?, 'browsing', 1, ?, ?, ?, ?, 'test', 2)
+    `).run(
+      'com.google.Chrome',
+      'Google Chrome',
+      BASE,
+      BASE + 20_000,
+      20,
+      'Google Chrome',
+      'Google Chrome',
+      'chrome',
+      'com.google.Chrome',
+    )
+
+    const clipped = clipWebsiteVisitDurationToBrowserForeground(db, {
+      visitTime: BASE,
+      durationSec: 120,
+      browserBundleId: 'com.google.Chrome',
+      canonicalBrowserId: 'chrome',
+    })
+    assert.equal(clipped, 20)
+
+    insertWebsiteVisit(db, {
+      domain: 'example.com',
+      pageTitle: 'Example',
+      url: 'https://example.com/',
+      normalizedUrl: 'https://example.com/',
+      pageKey: 'example.com',
+      visitTime: BASE,
+      visitTimeUs: BigInt(BASE) * 1000n,
+      durationSec: 120,
+      browserBundleId: 'com.google.Chrome',
+      canonicalBrowserId: 'chrome',
+      browserProfileId: 'default',
+      source: 'chrome_history',
+    })
+    const row = db.prepare('SELECT duration_sec FROM website_visits').get() as { duration_sec: number }
+    assert.equal(row.duration_sec, 20)
+  } finally {
+    db.close()
+  }
+})
+
+test('browser history source cursors are durable and idempotent', () => {
+  const db = createProductionTestDatabase()
+  try {
+    assert.equal(getBrowserHistoryCursor(db, 'com.google.Chrome'), null)
+    setBrowserHistoryCursor(db, 'com.google.Chrome', 123456789n)
+    assert.equal(getBrowserHistoryCursor(db, 'com.google.Chrome'), 123456789n)
+    setBrowserHistoryCursor(db, 'com.google.Chrome', 999n)
+    assert.equal(getBrowserHistoryCursor(db, 'com.google.Chrome'), 999n)
+
+    const visit = {
+      domain: 'example.com',
+      pageTitle: 'Example',
+      url: 'https://example.com/',
+      normalizedUrl: 'https://example.com/',
+      pageKey: 'example.com',
+      visitTime: BASE,
+      visitTimeUs: 42n,
+      durationSec: 15,
+      browserBundleId: 'com.google.Chrome',
+      canonicalBrowserId: 'chrome',
+      browserProfileId: 'default',
+      source: 'chrome_history',
+    }
+    assert.equal(insertWebsiteVisit(db, visit), true)
+    assert.equal(insertWebsiteVisit(db, visit), false)
+    assert.equal(
+      (db.prepare('SELECT COUNT(*) AS n FROM website_visits').get() as { n: number }).n,
+      1,
+    )
+  } finally {
+    db.close()
+  }
+})
+
+test('mode-verified live context still persists page evidence', () => {
+  const db = createProductionTestDatabase()
+  try {
+    const tracker = new ActiveBrowserContextTracker(
+      () => ({
+        url: 'https://github.com/daylens/daylens?token=should-strip',
+        title: 'daylens',
+        modeKnown: true,
+      }),
+      () => true,
+    )
+    tracker.sample(db, snapshot())
+    tracker.sample(db, snapshot({ capturedAt: BASE + 20_000 }))
+    assert.equal(tracker.flush(db, BASE + 30_000), true)
+    const row = db.prepare('SELECT domain, url, page_title FROM website_visits').get() as {
+      domain: string
+      url: string
+      page_title: string
+    }
+    assert.equal(row.domain, 'github.com')
+    assert.equal(row.page_title, 'daylens')
+    assert.equal(row.url, 'https://github.com/daylens/daylens')
+    assert.doesNotMatch(row.url, /token=/)
+  } finally {
+    db.close()
+  }
+})

--- a/tests/captureConsentGate.test.ts
+++ b/tests/captureConsentGate.test.ts
@@ -121,7 +121,7 @@ const WIN = {
 
 const BASE = new Date(2026, 6, 3, 10, 0, 0, 0).getTime()
 
-const EVIDENCE_TABLES = ['app_sessions', 'focus_events', 'website_visits', 'website_visits_pending', 'activity_state_events']
+const EVIDENCE_TABLES = ['app_sessions', 'focus_events', 'website_visits', 'activity_state_events']
 
 function evidenceRowCounts(db: Database.Database): Record<string, number> {
   const counts: Record<string, number> = {}

--- a/tests/incognitoNeverTracked.test.ts
+++ b/tests/incognitoNeverTracked.test.ts
@@ -118,7 +118,22 @@ test('poll: a private window creates no app session and cuts the one before it',
     assert.equal(sessions.length, 1, 'only the pre-private session persists')
     assert.equal(sessions[0].ended_reason, 'incognito')
     assert.equal(sessions[0].end_time, BASE + 60_000)
-    assert.equal((db.prepare('SELECT COUNT(*) AS n FROM website_visits_pending').get() as { n: number }).n, 0)
+    const visits = db.prepare('SELECT domain, url, page_title FROM website_visits').all() as
+      Array<{ domain: string; url: string; page_title: string | null }>
+    assert.equal(visits.length, 1, 'only the pre-private page may remain')
+    assert.equal(visits[0].domain, 'canva.com')
+    assert.doesNotMatch(JSON.stringify(visits), /Private|incognito/i)
+    assert.equal(
+      (
+        db
+          .prepare(
+            "SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'table' AND name = 'website_visits_pending'",
+          )
+          .get() as { n: number }
+      ).n,
+      0,
+      'website_visits_pending must not exist',
+    )
     // The canonical store carries exactly the normal session's activation and
     // deactivation — the private window contributed nothing, not even a title.
     const focusRows = db.prepare('SELECT event_type, window_title FROM focus_events ORDER BY id').all() as
@@ -163,7 +178,6 @@ test('private Netflix activity produces neither a domain nor an app session', as
     assert.equal(getCurrentSession(), null)
     assert.equal((db.prepare('SELECT COUNT(*) AS n FROM app_sessions').get() as { n: number }).n, 0)
     assert.equal((db.prepare('SELECT COUNT(*) AS n FROM website_visits').get() as { n: number }).n, 0)
-    assert.equal((db.prepare('SELECT COUNT(*) AS n FROM website_visits_pending').get() as { n: number }).n, 0)
     assert.equal((db.prepare('SELECT COUNT(*) AS n FROM focus_events').get() as { n: number }).n, 0)
   } finally {
     __setTrackingFsmTestHarness(null)

--- a/tests/privacyPropagation.test.ts
+++ b/tests/privacyPropagation.test.ts
@@ -199,12 +199,19 @@ test('private and excluded observations cannot reach storage or downstream produ
     )
     assert.doesNotMatch(JSON.stringify(storedSessions), /Zen|Private|Dia/i)
 
-    {
-      const row = db.prepare('SELECT COUNT(*) AS count FROM website_visits_pending').get() as { count: number }
-      assert.equal(row.count, 0, 'website_visits_pending must contain no blocked evidence')
-    }
-    // The canonical store now mirrors allowed foreground observations, so it
-    // is not empty — the invariant is that nothing blocked reaches it.
+    assert.equal(
+      (
+        db
+          .prepare(
+            "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name = 'website_visits_pending'",
+          )
+          .get() as { count: number }
+      ).count,
+      0,
+      'website_visits_pending must not exist after privacy-verified browser evidence',
+    )
+    // The canonical store mirrors allowed foreground observations — nothing
+    // blocked may reach it.
     const focusRows = db.prepare('SELECT event_type, app_name, window_title, url, page_title FROM focus_events').all()
     assert.doesNotMatch(JSON.stringify(focusRows), /Zen|private\.example|Private quarterly|Dia/i)
     const visits = db.prepare('SELECT domain, page_title, url FROM website_visits').all()
@@ -246,7 +253,7 @@ test('private and excluded observations cannot reach storage or downstream produ
   }
 })
 
-test('an excluded site with unknown browser mode never enters pending evidence', () => {
+test('an excluded site with unknown browser mode never enters page evidence', () => {
   const db = createProductionTestDatabase()
   __setSettings({
     trackingControlsEnabled: true,
@@ -269,14 +276,6 @@ test('an excluded site with unknown browser mode never enters pending evidence',
     })
     assert.equal(result.captureBlockReason, 'excluded_site')
     tracker.flush(db, BASE + 60_000)
-    assert.equal(
-      (
-        db.prepare('SELECT COUNT(*) AS count FROM website_visits_pending').get() as {
-          count: number
-        }
-      ).count,
-      0,
-    )
     assert.equal(
       (db.prepare('SELECT COUNT(*) AS count FROM website_visits').get() as { count: number }).count,
       0,

--- a/tests/syntheticDay.test.ts
+++ b/tests/syntheticDay.test.ts
@@ -168,13 +168,6 @@ test('synthetic day agrees from source boundaries through every local fact surfa
           )
           .get() as { n: number }
       ).n,
-      pending: (
-        db
-          .prepare(
-            "SELECT COUNT(*) AS n FROM website_visits_pending WHERE domain = 'excluded.example'",
-          )
-          .get() as { n: number }
-      ).n,
       visits: (
         db
           .prepare("SELECT COUNT(*) AS n FROM website_visits WHERE domain = 'excluded.example'")
@@ -195,7 +188,7 @@ test('synthetic day agrees from source boundaries through every local fact surfa
           .get() as { n: number }
       ).n,
     }
-    assert.deepEqual(forbiddenCounts, { sessions: 0, pending: 0, visits: 0, focus: 0, derived: 0 })
+    assert.deepEqual(forbiddenCounts, { sessions: 0, visits: 0, focus: 0, derived: 0 })
 
     const search = searchAll(db, 'Acme', {
       startDate: fixture.date,

--- a/tests/testDatabaseBootstrap.test.ts
+++ b/tests/testDatabaseBootstrap.test.ts
@@ -12,7 +12,7 @@ test('production test database applies every migration and startup schema repair
     assert.equal(version.version, LATEST_SCHEMA_VERSION)
 
     const requiredTables = [
-      'website_visits_pending',
+      'browser_history_cursors',
       'focus_events',
       'derived_sessions',
       'derived_blocks',


### PR DESCRIPTION
Closes #160
Closes DEV-164

## Summary
- Confirmed private windows and unverifiable browser modes no longer persist page titles/URLs; page detail arrives only via non-private history corroboration
- Stored URLs strip fragments and sensitive query values (tokens, session ids, auth codes) at the persistence boundary
- History ingestion uses durable source cursors, clips page duration to the owning browser foreground interval, and `website_visits_pending` is removed by a forward-only migration

## Test plan
- [x] `npm run typecheck`
- [x] `npx eslint` on touched files
- [x] `npm test` (known unrelated flake: `wrapPreflight.test.ts` staleCapture near local midnight)
- [x] `npm run verify:synthetic-day`
- [x] Privacy-boundary suite: `browserEvidencePrivacy`, `privacyPropagation`, `incognitoNeverTracked`
- [x] Mac verification: Comet (`mode=normal` Chromium), Dia (`mode=unknown` fallback), Safari (unverifiable) — live OAuth callback URL secrets stripped; unverifiable live context left zero page rows; history corroboration stored sanitized URL only


Made with [Cursor](https://cursor.com)