### PR TITLE
Finish consent boundary protections (DEV-165)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -127,7 +127,7 @@ import { fireTestDailyNotification } from './services/notificationHarness'
 import { consumePendingNavigationRoute } from './services/dailySummaryNavigation'
 import { registerCommandPaletteShortcut, unregisterCommandPaletteShortcut } from './services/commandPalette'
 import { registerDistractionAlerterHandlers, resetDistractionStateOnResume, setDistractionAlertWindow, startDistractionAlerter } from './services/distractionAlerter'
-import { startExternalSignalCollection } from './services/externalSignals'
+import { startExternalSignalCollection, stopExternalSignalCollection } from './services/externalSignals'
 import { getLinuxDesktopDiagnostics, syncLinuxLaunchOnLogin } from './services/linuxDesktop'
 import { performUninstallCleanup } from './services/uninstallCleanup'
 import { detectCLITools } from './jobs/aiService'
@@ -499,6 +499,7 @@ function startCaptureServices(): void {
   if (process.platform === 'darwin') startFocusCapture()
   if (process.platform === 'win32') startWindowsFocusCapture()
   if (!SMOKE_TEST && (process.platform === 'win32' || process.platform === 'linux')) ensureProcessMonitor()
+  if (!SMOKE_TEST) startExternalSignalCollection()
 
   if (!SMOKE_TEST) {
     if (captureAdapterStartupTimer) clearTimeout(captureAdapterStartupTimer)
@@ -523,6 +524,7 @@ function stopCaptureServices(): void {
   stopWindowsFocusCapture()
   stopBrowserTracking()
   stopProcessMonitor()
+  stopExternalSignalCollection()
 }
 
 function startBackgroundServices(): void {
@@ -537,7 +539,6 @@ function startBackgroundServices(): void {
       startDailySummaryNotifier(mainWindow)
       setDistractionAlertWindow(mainWindow)
       startDistractionAlerter()
-      startExternalSignalCollection()
     }
     backgroundServicesStarted = true
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -212,6 +212,7 @@ let mainWindow: BrowserWindow | null = null
 let isQuitting = false
 let deferredIntegrationStartup: ReturnType<typeof setTimeout> | null = null
 let backgroundServicesStarted = false
+let captureAdapterStartupTimer: ReturnType<typeof setTimeout> | null = null
 // Set to latest version string when a newer release is detected
 export const updateAvailable: string | null = null
 
@@ -492,55 +493,71 @@ function ensureTray(): void {
   }
 }
 
-function startBackgroundServices(): void {
-  if (backgroundServicesStarted) return
-  if (REAL_DAY_HARNESS) {
-    backgroundServicesStarted = true
-    return
-  }
+function startCaptureServices(): void {
   if (!SMOKE_TEST && !shouldStartTrackingForSettings(getSettings())) return
-
   startTracking()
   if (process.platform === 'darwin') startFocusCapture()
   if (process.platform === 'win32') startWindowsFocusCapture()
-  // Background-process evidence (long-running apps that never come to the
-  // foreground) feeds block naming on both Windows and Linux. macOS uses
-  // focus events instead, so the monitor is a no-op there.
   if (!SMOKE_TEST && (process.platform === 'win32' || process.platform === 'linux')) ensureProcessMonitor()
-  if (!SMOKE_TEST) {
-    startSync()
-    startDailySummaryNotifier(mainWindow)
-    setDistractionAlertWindow(mainWindow)
-    startDistractionAlerter()
-    // Optional Wrapped connectors (git, calendar, focus apps) — best-effort
-    // background collection into external_signals; silent when unavailable.
-    startExternalSignalCollection()
-  }
-  backgroundServicesStarted = true
 
   if (!SMOKE_TEST) {
-    setTimeout(() => {
+    if (captureAdapterStartupTimer) clearTimeout(captureAdapterStartupTimer)
+    captureAdapterStartupTimer = setTimeout(() => {
+      captureAdapterStartupTimer = null
+      if (!shouldStartTrackingForSettings(getSettings())) return
       startBrowserTracking()
       setImmediate(() => {
         try { backfillWindowsHistory() } catch (err) { console.warn('[init] win history:', err) }
       })
     }, 5_000)
   }
+}
 
-  setTimeout(() => {
-    capture(ANALYTICS_EVENT.TRACKING_ENGINE_HEALTH, {
-      module_source: trackingStatus.moduleSource,
-      status: trackingStatus.moduleSource ? 'ok' : 'error',
-      surface: 'tracking',
-      ...(trackingStatus.loadError ? { failure_kind: classifyFailureKind(trackingStatus.loadError) } : {}),
-    })
-  }, 5_000)
-
-  if (!SMOKE_TEST) {
-    setTimeout(() => {
-      setTimeout(() => finalizePreviousDay(), 0)
-    }, 10_000)
+function stopCaptureServices(): void {
+  if (captureAdapterStartupTimer) {
+    clearTimeout(captureAdapterStartupTimer)
+    captureAdapterStartupTimer = null
   }
+  stopTracking()
+  stopFocusCapture()
+  stopWindowsFocusCapture()
+  stopBrowserTracking()
+  stopProcessMonitor()
+}
+
+function startBackgroundServices(): void {
+  if (REAL_DAY_HARNESS) {
+    backgroundServicesStarted = true
+    return
+  }
+
+  if (!backgroundServicesStarted) {
+    if (!SMOKE_TEST) {
+      startSync()
+      startDailySummaryNotifier(mainWindow)
+      setDistractionAlertWindow(mainWindow)
+      startDistractionAlerter()
+      startExternalSignalCollection()
+    }
+    backgroundServicesStarted = true
+
+    setTimeout(() => {
+      capture(ANALYTICS_EVENT.TRACKING_ENGINE_HEALTH, {
+        module_source: trackingStatus.moduleSource,
+        status: trackingStatus.moduleSource ? 'ok' : 'error',
+        surface: 'tracking',
+        ...(trackingStatus.loadError ? { failure_kind: classifyFailureKind(trackingStatus.loadError) } : {}),
+      })
+    }, 5_000)
+
+    if (!SMOKE_TEST) {
+      setTimeout(() => {
+        setTimeout(() => finalizePreviousDay(), 0)
+      }, 10_000)
+    }
+  }
+
+  startCaptureServices()
 }
 
 async function backupUserDataForUpdate(): Promise<void> {
@@ -697,12 +714,8 @@ async function shutdownApp(options?: { awaitFinalSync?: boolean; backupBeforeExi
     deferredIntegrationStartup = null
   }
   stopMcpServer()
-  stopTracking()
-  stopFocusCapture()
-  stopWindowsFocusCapture()
-  stopBrowserTracking()
+  stopCaptureServices()
   stopSync()
-  stopProcessMonitor()
   stopAIUsageRetentionSchedule()
   unregisterCommandPaletteShortcut()
 
@@ -1011,13 +1024,6 @@ ipcMain.handle(IPC.APP.RESET_AND_UNINSTALL, async (event): Promise<{ started: bo
 })
 
 ipcMain.handle(IPC.APP.COMPLETE_ONBOARDING, async () => {
-  // Completing onboarding through any flow (including legacy paths that never
-  // hit the explicit consent call) is a consent act — record it rather than
-  // leaving a completed install gated off. Explicit decisions are never
-  // overwritten here.
-  if (getSettings().captureConsent.status === 'unset') {
-    await setSettings({ captureConsent: grantedCaptureConsent(Date.now()) })
-  }
   ensureTray()
   startBackgroundServices()
 })
@@ -1034,21 +1040,8 @@ ipcMain.handle(IPC.APP.SET_CAPTURE_CONSENT, async (_e, granted: unknown) => {
   })
   if (decision) {
     startBackgroundServices()
-    // Re-grant after services already started once (decline→grant, policy
-    // re-consent): startBackgroundServices is a one-shot, so restart the
-    // capture adapters directly — each start is idempotent.
-    if (backgroundServicesStarted && !SMOKE_TEST && !REAL_DAY_HARNESS && shouldStartTrackingForSettings(getSettings())) {
-      startTracking()
-      if (process.platform === 'darwin') startFocusCapture()
-      if (process.platform === 'win32') startWindowsFocusCapture()
-      startBrowserTracking()
-    }
   } else {
-    stopTracking()
-    stopFocusCapture()
-    stopWindowsFocusCapture()
-    stopBrowserTracking()
-    stopProcessMonitor()
+    stopCaptureServices()
   }
   return getSettings().captureConsent
 })

--- a/src/main/services/browser.ts
+++ b/src/main/services/browser.ts
@@ -37,6 +37,7 @@ import {
 import { getWindowsBrowserHistoryLocations } from './windowsBrowserRegistry'
 import { decideAppCapture, decideSiteCapture, trackingControlsStateFromSettings } from '@shared/trackingControls'
 import { getSettings } from './settings'
+import { currentCaptureConsentDecidedAt } from '@shared/captureConsent'
 
 // ─── Chrome timestamp arithmetic ─────────────────────────────────────────────
 // Chrome stores timestamps as microseconds since 1601-01-01 00:00:00 UTC.
@@ -44,6 +45,10 @@ import { getSettings } from './settings'
 // arithmetic is required to avoid precision loss.
 
 const CHROME_OFFSET_US = 11_644_473_600_000_000n  // µs between 1601 and Unix epoch
+
+function consentFloorMs(): number {
+  return currentCaptureConsentDecidedAt(getSettings().captureConsent) ?? Date.now()
+}
 
 function msToChromeUs(ms: number): bigint {
   return BigInt(ms) * 1000n + CHROME_OFFSET_US
@@ -590,8 +595,10 @@ async function pollChromium(
   let error: string | null = null
 
   const lastCursorUs = loadBrowserCursor(db, browser.bundleId)
-  // If no cursor yet, start from 24h ago
-  const fromUs: bigint = lastCursorUs ?? msToChromeUs(Date.now() - 86_400_000)
+  // A cursor from an earlier consent can never cross a newer consent boundary.
+  const fromUs = [lastCursorUs, msToChromeUs(consentFloorMs())]
+    .filter((value): value is bigint => value !== null)
+    .reduce((latest, value) => value > latest ? value : latest)
   const controls = trackingControlsStateFromSettings(getSettings())
 
   try {
@@ -685,7 +692,8 @@ async function pollFirefox(
 
   // Firefox visit_date is Unix µs — not Chrome epoch µs
   const lastCursorUs = loadBrowserCursor(db, browser.bundleId)
-  const fromUs: bigint = lastCursorUs ?? (BigInt(Date.now() - 86_400_000) * 1000n)
+  const consentUs = BigInt(consentFloorMs()) * 1_000n
+  const fromUs = lastCursorUs && lastCursorUs > consentUs ? lastCursorUs : consentUs
   const controls = trackingControlsStateFromSettings(getSettings())
 
   try {
@@ -763,7 +771,8 @@ async function pollWebKit(
   let error: string | null = null
 
   const lastCursorUs = loadBrowserCursor(db, browser.bundleId)
-  const fromMs = lastCursorUs ? Number(lastCursorUs / 1_000n) : Date.now() - 86_400_000
+  const cursorMs = lastCursorUs ? Number(lastCursorUs / 1_000n) : 0
+  const fromMs = Math.max(cursorMs, consentFloorMs())
   const fromWebKitSeconds = fromMs / 1_000 - WEBKIT_EPOCH_OFFSET_SEC
 
   try {

--- a/src/main/services/externalSignals.ts
+++ b/src/main/services/externalSignals.ts
@@ -193,21 +193,26 @@ export async function collectExternalSignals(
 }
 
 let scheduled: ReturnType<typeof setInterval> | null = null
+let initialScheduled: ReturnType<typeof setTimeout> | null = null
 
 /** Background cadence: first pass a couple of minutes after launch (today and
  *  yesterday), then a refresh every 6 hours. Cheap: connectors early-exit when
  *  the stored signal is fresh. */
 export function startExternalSignalCollection(): void {
-  if (scheduled) return
+  if (scheduled || initialScheduled) return
   const run = () => {
     const today = localDateString()
     const yesterday = shiftLocalDateString(localDateString(), -1)
     void collectExternalSignals(yesterday).then(() => collectExternalSignals(today))
   }
-  setTimeout(run, 2 * 60 * 1000)
+  initialScheduled = setTimeout(() => {
+    initialScheduled = null
+    run()
+  }, 2 * 60 * 1000)
   scheduled = setInterval(run, 6 * 60 * 60 * 1000)
 }
 
 export function stopExternalSignalCollection(): void {
+  if (initialScheduled) { clearTimeout(initialScheduled); initialScheduled = null }
   if (scheduled) { clearInterval(scheduled); scheduled = null }
 }

--- a/src/main/services/onboarding.ts
+++ b/src/main/services/onboarding.ts
@@ -1,6 +1,6 @@
 import type { AppSettings, OnboardingStage, ProofState } from '@shared/types'
 import { nextMacStageAfterGrantedPermission } from '@shared/onboarding'
-import { grantedCaptureConsent, type CaptureConsentState } from '@shared/captureConsent'
+import { grantedCaptureConsent, isCaptureConsentCurrent, type CaptureConsentState } from '@shared/captureConsent'
 import { getTrackingPermissionState } from './trackingPermissions'
 import { getSettingsAsync, setSettings } from './settings'
 
@@ -25,6 +25,14 @@ export async function reconcileOnboardingState(): Promise<AppSettings> {
   // act, so record it rather than silently stopping their capture on update.
   // Never overwrite an explicit decision — only 'unset' is reconciled.
   let captureConsent: CaptureConsentState = settings.captureConsent
+  const requiresCaptureReconsent = captureConsent.status === 'granted'
+    && !isCaptureConsentCurrent(captureConsent)
+  if (requiresCaptureReconsent) {
+    onboardingState.stage = 'why'
+    onboardingState.completedAt = null
+    onboardingState.proofState = 'idle'
+    changed = true
+  }
   if (
     captureConsent.status === 'unset'
     && (settings.onboardingComplete || !PRE_CONSENT_STAGES.has(onboardingState.stage))
@@ -33,7 +41,7 @@ export async function reconcileOnboardingState(): Promise<AppSettings> {
     changed = true
   }
 
-  if (settings.onboardingComplete && onboardingState.stage !== 'complete') {
+  if (settings.onboardingComplete && onboardingState.stage !== 'complete' && !requiresCaptureReconsent) {
     onboardingState.stage = 'complete'
     onboardingState.completedAt = onboardingState.completedAt ?? Date.now()
     onboardingState.proofState = 'ready'
@@ -41,7 +49,7 @@ export async function reconcileOnboardingState(): Promise<AppSettings> {
     changed = true
   }
 
-  if (process.platform === 'darwin' && onboardingState.stage !== 'complete') {
+  if (process.platform === 'darwin' && onboardingState.stage !== 'complete' && !requiresCaptureReconsent) {
     const permissionState = getTrackingPermissionState()
     if (onboardingState.trackingPermissionState !== permissionState) {
       onboardingState.trackingPermissionState = permissionState

--- a/src/main/services/windowsHistory.ts
+++ b/src/main/services/windowsHistory.ts
@@ -1,8 +1,7 @@
 // Windows app usage history backfill.
 //
-// Reads the Windows Timeline ActivityCache.db (ActivitiesCache.db) to seed
-// the last 24 hours of app sessions on first launch — the same way the browser
-// service reads Chrome history retroactively.
+// Reads the Windows Timeline ActivityCache.db (ActivitiesCache.db) to import
+// app sessions recorded after the current capture consent.
 //
 // ActivityCache.db is at:
 //   %LOCALAPPDATA%\ConnectedDevicesPlatform\<account-folder>\ActivitiesCache.db
@@ -19,6 +18,8 @@ import Database from 'better-sqlite3'
 import { getDb } from './database'
 import { insertAppSession } from '../db/queries'
 import { classifyResult } from './tracking'
+import { currentCaptureConsentDecidedAt } from '@shared/captureConsent'
+import { getSettings } from './settings'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -144,8 +145,9 @@ export function backfillWindowsHistory(): void {
   }
 
   const windowFloorSec = Math.floor((Date.now() - BACKFILL_WINDOW_MS) / 1_000)
+  const consentFloorSec = Math.floor((currentCaptureConsentDecidedAt(getSettings().captureConsent) ?? Date.now()) / 1_000)
   const cursorSec = readBackfillCursorSec()
-  const fromSec  = Math.max(windowFloorSec, cursorSec)
+  const fromSec  = Math.max(windowFloorSec, consentFloorSec, cursorSec)
   const mainDb   = getDb()
   let   totalImported = 0
   let   maxStartSec = cursorSec

--- a/src/renderer/views/Onboarding.tsx
+++ b/src/renderer/views/Onboarding.tsx
@@ -1208,10 +1208,7 @@ export default function Onboarding({
     }
   }
 
-  // Leaving the capture explainer toward permission/proof is the consent act:
-  // record it before advancing so capture (and the proof step's live data) is
-  // allowed to start. The redesigned consent screen (separate issue) will own
-  // this decision; the recorded state and gate are already in force.
+  // Finishing the capture explainer records consent before live proof begins.
   async function consentAndLeaveWhy() {
     try {
       await ipc.app.setCaptureConsent(true)
@@ -1233,7 +1230,9 @@ export default function Onboarding({
   }
 
   function skipWhy() {
-    void consentAndLeaveWhy()
+    void persistOnboarding(isMac ? 'permission' : 'proof', {
+      proofState: isMac ? 'idle' : 'collecting',
+    })
   }
 
   async function continueFromProof() {

--- a/src/renderer/views/Onboarding.tsx
+++ b/src/renderer/views/Onboarding.tsx
@@ -1229,10 +1229,13 @@ export default function Onboarding({
     void consentAndLeaveWhy()
   }
 
-  function skipWhy() {
-    void persistOnboarding(isMac ? 'permission' : 'proof', {
-      proofState: isMac ? 'idle' : 'collecting',
-    })
+  async function skipWhy() {
+    try {
+      await ipc.app.setCaptureConsent(false)
+      await persistOnboarding('tour', { proofState: 'idle' })
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : String(error))
+    }
   }
 
   async function continueFromProof() {
@@ -1476,7 +1479,7 @@ export default function Onboarding({
             centered
             contentKey={`why-${beat.scene}`}
             primary={{ label: last ? "Makes sense, let's go" : 'Continue', onClick: () => advanceWhy() }}
-            skip={{ label: 'Skip', onClick: () => skipWhy() }}
+            skip={{ label: 'Skip', onClick: () => void skipWhy() }}
           >
             <WhyScene scene={beat.scene} name={greetName} />
             <div className="ob-why-dots" aria-hidden="true">

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -28,6 +28,7 @@ import { formatUsdAmount } from '@shared/formatUsd'
 import { CHANGELOG, LATEST_CHANGELOG, formatChangelogDate, changelogIssueLabel, type ChangelogEntry } from '@shared/changelog'
 import { ALL_ACTIVITY_CATEGORY_OPTIONS } from '@shared/activityCategories'
 import { claudeDesktopConfigDisplayPath } from '@shared/platformPaths'
+import { currentCaptureConsentDecidedAt } from '@shared/captureConsent'
 
 const CATEGORY_OPTIONS: Array<{ value: AppCategory; label: string }> = ALL_ACTIVITY_CATEGORY_OPTIONS
 
@@ -989,15 +990,18 @@ function CaptureHealthContent({
 function TrackingControlsContent({
   settings,
   persist,
+  grantCaptureConsent,
 }: {
   settings: AppSettings
   persist: (partial: Partial<AppSettings>) => Promise<boolean>
+  grantCaptureConsent: () => Promise<void>
 }) {
   const [busy, setBusy] = useState(false)
   const [privacyError, setPrivacyError] = useState<string | null>(null)
   const enabled = settings.trackingControlsEnabled ?? false
   const excludedApps = settings.trackingExcludedApps ?? []
   const excludedSites = settings.trackingExcludedSites ?? []
+  const consentCurrent = currentCaptureConsentDecidedAt(settings.captureConsent) !== null
 
   const normalizeSite = (raw: string) => raw.trim().toLowerCase()
     .replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '')
@@ -1038,8 +1042,32 @@ function TrackingControlsContent({
 
   return (
     <>
+      {!consentCurrent && (
+        <SettingsRow
+          first
+          title="Activity capture is off"
+          description="Allow Daylens to record foreground apps, window titles, active browser pages, and machine state on this computer. Private windows, screenshots, audio, keystrokes, message bodies, and file contents are never captured."
+          control={(
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => {
+                setBusy(true)
+                setPrivacyError(null)
+                void grantCaptureConsent()
+                  .catch((error) => setPrivacyError(error instanceof Error ? error.message : String(error)))
+                  .finally(() => setBusy(false))
+              }}
+              style={{ ...inlineButtonStyle, opacity: busy ? 0.6 : 1, cursor: busy ? 'default' : 'pointer' }}
+            >
+              Allow capture
+            </button>
+          )}
+        />
+      )}
+      {privacyError && <div style={{ color: '#f87171', fontSize: 12.5, lineHeight: 1.5, padding: '8px 0' }}>{privacyError}</div>}
       <SettingsRow
-        first
+        first={consentCurrent}
         title="Pause tracking"
         description="Temporarily stop recording all activity. Stays paused until you turn it back on, even after a restart."
         control={<Toggle checked={settings.trackingPaused ?? false} onChange={(value) => void persist({ trackingPaused: value })} />}
@@ -1051,7 +1079,6 @@ function TrackingControlsContent({
       />
       {enabled && (
         <>
-          {privacyError && <div style={{ color: '#f87171', fontSize: 12.5, lineHeight: 1.5, padding: '8px 0' }}>{privacyError}</div>}
           <SettingsRow
             title="Skip private / incognito windows"
             description="When on, Daylens records nothing from a browser's incognito or private window — no URL, page title, or session."
@@ -2299,6 +2326,11 @@ export default function Settings({ initialSettings = null }: { initialSettings?:
       }
       return false
     }
+  }
+
+  async function grantCaptureConsent(): Promise<void> {
+    const captureConsent = await ipc.app.setCaptureConsent(true)
+    setSettings((current) => current ? { ...current, captureConsent } : current)
   }
 
   // Appearance changes (activity colors, leisure dimming) take effect the
@@ -3677,7 +3709,11 @@ export default function Settings({ initialSettings = null }: { initialSettings?:
           <div style={{ display: 'grid', gap: 24 }}>
             <div>
               <GroupLabel>Preferences</GroupLabel>
-              <TrackingControlsContent settings={settings} persist={persist} />
+              <TrackingControlsContent
+                settings={settings}
+                persist={persist}
+                grantCaptureConsent={grantCaptureConsent}
+              />
             </div>
             <div>
               <GroupLabel>Your data</GroupLabel>

--- a/src/shared/captureConsent.ts
+++ b/src/shared/captureConsent.ts
@@ -44,6 +44,11 @@ export function isCaptureConsentCurrent(
   return consent.status === 'granted' && consent.policyVersion === currentPolicyVersion
 }
 
+export function currentCaptureConsentDecidedAt(raw: unknown): number | null {
+  const consent = normalizeCaptureConsent(raw)
+  return isCaptureConsentCurrent(consent) ? consent.decidedAt : null
+}
+
 // Settings cross the electron-store / IPC boundary, so treat the stored shape
 // as untrusted: anything malformed collapses to unset (capture off).
 export function normalizeCaptureConsent(raw: unknown): CaptureConsentState {

--- a/tests/captureConsentGate.test.ts
+++ b/tests/captureConsentGate.test.ts
@@ -264,6 +264,31 @@ test('a stale grant reopens onboarding at the consent explainer', async () => {
   __resetSettings()
 })
 
+test('skipping capture declines consent and bypasses the proof gate', () => {
+  const onboardingSource = fs.readFileSync(
+    new URL('../src/renderer/views/Onboarding.tsx', import.meta.url),
+    'utf8',
+  )
+  assert.match(
+    onboardingSource,
+    /async function skipWhy\(\)[\s\S]*?setCaptureConsent\(false\)[\s\S]*?persistOnboarding\('tour', \{ proofState: 'idle' \}\)/,
+  )
+})
+
+test('external activity signals start and stop with consent-gated capture services', () => {
+  const mainSource = fs.readFileSync(new URL('../src/main/index.ts', import.meta.url), 'utf8')
+  const captureStart = mainSource.slice(
+    mainSource.indexOf('function startCaptureServices'),
+    mainSource.indexOf('function stopCaptureServices'),
+  )
+  const captureStop = mainSource.slice(
+    mainSource.indexOf('function stopCaptureServices'),
+    mainSource.indexOf('function startBackgroundServices'),
+  )
+  assert.match(captureStart, /startExternalSignalCollection\(\)/)
+  assert.match(captureStop, /stopExternalSignalCollection\(\)/)
+})
+
 test('runtime wiring keeps non-capture services alive and history behind consent', () => {
   const indexSource = fs.readFileSync('src/main/index.ts', 'utf8')
   const onboardingSource = fs.readFileSync('src/renderer/views/Onboarding.tsx', 'utf8')
@@ -275,9 +300,9 @@ test('runtime wiring keeps non-capture services alive and history behind consent
   assert.match(indexSource, /function stopCaptureServices\(\)[\s\S]*clearTimeout\(captureAdapterStartupTimer\)/)
   assert.match(indexSource, /function startBackgroundServices\(\)[\s\S]*startSync\(\)[\s\S]*startCaptureServices\(\)/)
 
-  const skipWhy = onboardingSource.split('function skipWhy()')[1]?.split('async function continueFromProof')[0] ?? ''
-  assert.ok(skipWhy.includes('persistOnboarding'))
-  assert.ok(!skipWhy.includes('setCaptureConsent'))
+  const skipWhy = onboardingSource.split('async function skipWhy()')[1]?.split('async function continueFromProof')[0] ?? ''
+  assert.ok(skipWhy.includes('setCaptureConsent(false)'))
+  assert.ok(skipWhy.includes("persistOnboarding('tour'"))
 
   assert.match(browserSource, /Math\.max\(cursorMs, consentFloorMs\(\)\)/)
   assert.match(windowsHistorySource, /Math\.max\(windowFloorSec, consentFloorSec, cursorSec\)/)

--- a/tests/captureConsentGate.test.ts
+++ b/tests/captureConsentGate.test.ts
@@ -5,6 +5,7 @@
 
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
 import type Database from 'better-sqlite3'
 import { createProductionTestDatabase } from './support/testDatabase.ts'
 import { clearTestDb, setTestDb } from './support/database-stub.mjs'
@@ -13,6 +14,7 @@ import {
   CAPTURE_POLICY_VERSION,
   DEFAULT_CAPTURE_CONSENT,
   grantedCaptureConsent,
+  currentCaptureConsentDecidedAt,
   isCaptureConsentCurrent,
   normalizeCaptureConsent,
 } from '../src/shared/captureConsent.ts'
@@ -52,6 +54,8 @@ test('consent is current only when granted for the policy version in force', () 
   assert.equal(isCaptureConsentCurrent(DECLINED), false)
   // A material policy change (version bump) closes the gate until re-consent.
   assert.equal(isCaptureConsentCurrent(STALE_GRANT), false)
+  assert.equal(currentCaptureConsentDecidedAt(GRANTED), 1)
+  assert.equal(currentCaptureConsentDecidedAt(STALE_GRANT), null)
 })
 
 test('every capture decision refuses without consent, before any other rule', () => {
@@ -242,4 +246,39 @@ test('an explicit decline is never overwritten by reconciliation', async () => {
 
   assert.equal(settings.captureConsent.status, 'declined')
   __resetSettings()
+})
+
+test('a stale grant reopens onboarding at the consent explainer', async () => {
+  __resetSettings()
+  __setSettings({
+    onboardingComplete: true,
+    onboardingState: { stage: 'complete', trackingPermissionState: 'granted' },
+    captureConsent: STALE_GRANT,
+  })
+
+  const settings = await reconcileOnboardingState()
+
+  assert.equal(settings.onboardingComplete, false)
+  assert.equal(settings.onboardingState.stage, 'why')
+  assert.deepEqual(settings.captureConsent, STALE_GRANT)
+  __resetSettings()
+})
+
+test('runtime wiring keeps non-capture services alive and history behind consent', () => {
+  const indexSource = fs.readFileSync('src/main/index.ts', 'utf8')
+  const onboardingSource = fs.readFileSync('src/renderer/views/Onboarding.tsx', 'utf8')
+  const browserSource = fs.readFileSync('src/main/services/browser.ts', 'utf8')
+  const windowsHistorySource = fs.readFileSync('src/main/services/windowsHistory.ts', 'utf8')
+
+  assert.match(indexSource, /function startCaptureServices\(\)[\s\S]*ensureProcessMonitor\(\)/)
+  assert.match(indexSource, /captureAdapterStartupTimer = setTimeout\([\s\S]*shouldStartTrackingForSettings\(getSettings\(\)\)[\s\S]*startBrowserTracking\(\)/)
+  assert.match(indexSource, /function stopCaptureServices\(\)[\s\S]*clearTimeout\(captureAdapterStartupTimer\)/)
+  assert.match(indexSource, /function startBackgroundServices\(\)[\s\S]*startSync\(\)[\s\S]*startCaptureServices\(\)/)
+
+  const skipWhy = onboardingSource.split('function skipWhy()')[1]?.split('async function continueFromProof')[0] ?? ''
+  assert.ok(skipWhy.includes('persistOnboarding'))
+  assert.ok(!skipWhy.includes('setCaptureConsent'))
+
+  assert.match(browserSource, /Math\.max\(cursorMs, consentFloorMs\(\)\)/)
+  assert.match(windowsHistorySource, /Math\.max\(windowFloorSec, consentFloorSec, cursorSec\)/)
 })


### PR DESCRIPTION
Restores the consent-boundary fixes that were reviewed but did not make it into the merged DEV-165 branch. Capture services now stop and restart correctly, delayed browser startup is cancelled on revocation, browser and Windows history imports cannot cross the latest consent boundary, and onboarding no longer grants consent when skipped. Includes focused regression tests.