### PR TITLE
One shared source of corrected activity facts (DEV-168)

### DIFF
--- a/.cursor/rules/model-routing.mdc
+++ b/.cursor/rules/model-routing.mdc
@@ -1,25 +1,9 @@
 ---
-description: Role-based model routing for Daylens agents
+description: Sub-agent model for Daylens
 alwaysApply: true
 ---
 
 # Model Routing
 
-Use the cheapest model that can meet the bar, but cost is only a tie-breaker.
-For shipped work: intelligence > taste > cost. If output is weak, rerun or redo
-with a stronger model without asking.
-
-- Mechanical edits, file mapping, boilerplate, formatting, and clear tests:
-  use `fast-worker` or a cheap fast lane.
-- Architecture, root cause, ambiguous bugs, algorithms, and correctness calls:
-  use `deep-reasoner`.
-- User-facing UI, copy, API design, or product taste: use Opus/Fable-class
-  reasoning; do not let a mechanical worker invent the look or voice.
-- GPT-5.5 is the Codex lane, not a native Cursor subagent here. Use `gpt-peer`
-  only as a thin wrapper that runs `codex exec --model gpt-5.5 --effort xhigh`.
-- Review-only GPT passes must use `codex exec -s read-only` with a
-  self-contained prompt.
-- High-stakes decisions get two blind passes; resolve disagreement with specs,
-  real data, tests, or a founder question, not vibes.
-
-Never use Haiku for this repo.
+When launching Cursor sub-agents (the Task tool), use Grok 4.5
+(`cursor-grok-4.5-high-fast`).

--- a/scripts/real-day/run.ts
+++ b/scripts/real-day/run.ts
@@ -325,6 +325,12 @@ async function evaluate(args: Args): Promise<RealDayObservation> {
       { resolveDayEnrichment },
       { getWorkMemoryProfile, chatMemoryPromptBlock },
       { executeTool },
+      { queryCorrectedActivityFactsForDay },
+      {
+        compareCanonicalAndLegacyDay,
+        formatCanonicalLegacyParitySideBySide,
+        writeLocalCanonicalLegacyParityReport,
+      },
     ] = await Promise.all([
       import('../../src/main/core/query/projections'),
       import('../../src/main/services/workBlocks'),
@@ -334,12 +340,25 @@ async function evaluate(args: Args): Promise<RealDayObservation> {
       import('../../src/main/services/enrichmentResolve'),
       import('../../src/main/services/workMemoryProfile'),
       import('../../src/main/services/aiTools'),
+      import('../../src/main/core/query/activityFactsQuery'),
+      import('../../src/main/core/query/canonicalLegacyParity'),
     ])
     const [fromMs, toMs] = dayBounds(manifest.date)
     const projection = getTimelineDayProjection(db, manifest.date, null, { materialize: false })
     const direct = getTimelineDayPayload(db, manifest.date, null, { materialize: false })
     const apps = getCorrectedAppSummariesForRange(db, fromMs, toMs)
     const capturedSessions = getCorrectedSessionsForRange(db, fromMs, toMs)
+    const sharedFacts = queryCorrectedActivityFactsForDay(db, manifest.date, { asOfMs: toMs })
+    const parity = compareCanonicalAndLegacyDay(db, manifest.date, { asOfMs: toMs })
+    const parityPath = writeLocalCanonicalLegacyParityReport(
+      parity,
+      path.join(fixtureDir, 'local-parity'),
+    )
+    console.log(formatCanonicalLegacyParitySideBySide(parity))
+    console.log(
+      `Shared query: ${formatDuration(sharedFacts.totalSeconds)} tracked / ${formatDuration(sharedFacts.focusSeconds)} focused (${sharedFacts.evidenceSource}, ${sharedFacts.sessions.length} sessions) — side by side with today's production path: Timeline ${formatDuration(Math.round(projection.totalSeconds))}, Apps ${formatDuration(apps.reduce((sum, item) => sum + Math.round(item.totalSeconds), 0))}`,
+    )
+    console.log(`Local parity report (not analytics): ${parityPath}`)
     const projectionEpisodes = projection.blocks.map(episode)
     const directEpisodes = direct.blocks.map(episode)
     const appItems = apps.map((item) => ({

--- a/src/main/core/evidence/legacyAdapter.ts
+++ b/src/main/core/evidence/legacyAdapter.ts
@@ -1,0 +1,75 @@
+// Compatibility reads for legacy capture tables during the migration.
+// These rows are never rewritten into fake focus_events — they stay
+// app_sessions / website_visits and are exposed as typed compatibility inputs.
+
+import type Database from 'better-sqlite3'
+import type { AppSession, WebsiteSummary } from '@shared/types'
+import {
+  getSessionsForRange,
+  getWebsiteSummariesForRange,
+  getWebsiteVisitsForRange,
+  type WebsiteVisitRecord,
+} from '../../db/queries'
+
+export interface LegacyAppSessionInput {
+  kind: 'legacy_app_session'
+  session: AppSession
+}
+
+export interface LegacyWebsiteVisitInput {
+  kind: 'legacy_website_visit'
+  visit: WebsiteVisitRecord
+}
+
+export interface LegacyWebsiteSummaryInput {
+  kind: 'legacy_website_summary'
+  summary: WebsiteSummary
+}
+
+export type LegacyCompatibilityInput =
+  | LegacyAppSessionInput
+  | LegacyWebsiteVisitInput
+  | LegacyWebsiteSummaryInput
+
+/** Legacy app_sessions as compatibility inputs for the shared query boundary. */
+export function listLegacyAppSessionInputs(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+): LegacyAppSessionInput[] {
+  return getSessionsForRange(db, fromMs, toMs, { minimumDurationSeconds: 10 }).map((session) => ({
+    kind: 'legacy_app_session' as const,
+    session: {
+      ...session,
+      captureSource: session.captureSource ?? 'app_sessions',
+    },
+  }))
+}
+
+export function listLegacyWebsiteVisitInputs(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+): LegacyWebsiteVisitInput[] {
+  return getWebsiteVisitsForRange(db, fromMs, toMs).map((visit) => ({
+    kind: 'legacy_website_visit' as const,
+    visit,
+  }))
+}
+
+export function listLegacyWebsiteSummaryInputs(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+): LegacyWebsiteSummaryInput[] {
+  return getWebsiteSummariesForRange(db, fromMs, toMs).map((summary) => ({
+    kind: 'legacy_website_summary' as const,
+    summary,
+  }))
+}
+
+export function legacyAppSessionsAsAppSessions(
+  inputs: readonly LegacyAppSessionInput[],
+): AppSession[] {
+  return inputs.map((input) => input.session)
+}

--- a/src/main/core/projections/chunk2.ts
+++ b/src/main/core/projections/chunk2.ts
@@ -23,7 +23,7 @@ export const PROJECTION_VERSION = 1
 const IDLE_GAP_MS = 15 * 60 * 1000   // 15 min boundary between blocks
 const MIN_SESSION_MS = 1000          // drop sub-second flicker
 
-interface DerivedSessionRow {
+export interface DerivedSessionRow {
   start_ts_ms: number
   end_ts_ms: number
   active_seconds: number
@@ -110,7 +110,15 @@ interface OpenSession {
   confidence: 'observed' | 'uncertain'
 }
 
-function foldSessions(events: StoredFocusEvent[], dayEnd: number): DerivedSessionRow[] {
+/** Pure session fold over focus_events. Live and historical reads share this. */
+export function projectSessionsFromFocusEvents(
+  events: readonly StoredFocusEvent[],
+  rangeEndMs: number,
+): DerivedSessionRow[] {
+  return foldSessions(events, rangeEndMs)
+}
+
+function foldSessions(events: readonly StoredFocusEvent[], dayEnd: number): DerivedSessionRow[] {
   const out: DerivedSessionRow[] = []
   let open: OpenSession | null = null
 

--- a/src/main/core/query/activityFactsQuery.ts
+++ b/src/main/core/query/activityFactsQuery.ts
@@ -1,0 +1,261 @@
+// One query boundary for corrected activity facts (capture migration slices 6–7).
+// Live and historical reads share the same projection + correction path.
+// Consumers are not moved onto this boundary here — that is separate work.
+
+import type Database from 'better-sqlite3'
+import type { AppCategory, AppSession } from '@shared/types'
+import { isSystemNoiseApp } from '@shared/systemNoise'
+import { ownedDayBounds } from '../../lib/dayOwnership'
+import { localDateString } from '../../lib/localDate'
+import { isAppFocused } from '../../lib/focusScore'
+import { resolveCanonicalApp } from '../../lib/appIdentity'
+import { getSettings } from '../../services/settings'
+import { applyTimelineCorrectionsToSessions } from '../../services/activityFacts'
+import {
+  countFocusEventsInRange,
+  listFocusEventsInRange,
+  type StoredFocusEvent,
+} from '../../db/focusEventRepository'
+import {
+  PROJECTION_VERSION,
+  projectSessionsFromFocusEvents,
+  type DerivedSessionRow,
+} from '../projections/chunk2'
+import {
+  legacyAppSessionsAsAppSessions,
+  listLegacyAppSessionInputs,
+} from '../evidence/legacyAdapter'
+
+export const ACTIVITY_FACTS_QUERY_VERSION = 1
+
+const APP_CATEGORIES: ReadonlySet<string> = new Set([
+  'development',
+  'communication',
+  'research',
+  'writing',
+  'aiTools',
+  'design',
+  'browsing',
+  'meetings',
+  'entertainment',
+  'email',
+  'productivity',
+  'social',
+  'system',
+  'uncategorized',
+])
+
+export type ActivityGapKind =
+  | 'idle'
+  | 'locked'
+  | 'asleep'
+  | 'paused'
+  | 'capture_unavailable'
+  | 'unknown'
+
+export interface ActivityGapFact {
+  startMs: number
+  endMs: number
+  kind: ActivityGapKind
+}
+
+export interface CorrectedActivityDayFacts {
+  date: string
+  projectionVersion: number
+  queryVersion: number
+  evidenceSource: 'canonical' | 'legacy' | 'mixed'
+  sessions: AppSession[]
+  totalSeconds: number
+  focusSeconds: number
+  gaps: ActivityGapFact[]
+  focusEventCount: number
+  legacySessionCount: number
+}
+
+export interface QueryCorrectedActivityFactsOptions {
+  /** Wall-clock override for “today” / live clipping. */
+  nowMs?: number
+  /**
+   * Exclusive end of the evidence window inside the day.
+   * Historical complete-day reads pass the day end; live reads pass “now”.
+   * Same evidence + same asOfMs ⇒ identical facts.
+   */
+  asOfMs?: number
+}
+
+function toAppCategory(category: string | null | undefined): AppCategory {
+  return category && APP_CATEGORIES.has(category) ? (category as AppCategory) : 'uncategorized'
+}
+
+function derivedRowToAppSession(
+  row: DerivedSessionRow,
+  index: number,
+  focusApps: string[] | undefined,
+): AppSession {
+  const bundleId = row.app_bundle_id ?? row.app_name ?? 'unknown'
+  const appName = row.app_name ?? row.app_bundle_id ?? 'Unknown app'
+  const category = toAppCategory(row.category)
+  const identity = resolveCanonicalApp(bundleId, appName)
+  return {
+    id: -(index + 1),
+    bundleId,
+    appName: identity.displayName || appName,
+    startTime: row.start_ts_ms,
+    endTime: row.end_ts_ms,
+    durationSeconds: row.active_seconds,
+    category,
+    isFocused: isAppFocused(category, bundleId, identity.displayName || appName, focusApps),
+    windowTitle: row.window_title,
+    rawAppName: appName,
+    canonicalAppId: identity.canonicalAppId ?? bundleId,
+    appInstanceId: bundleId,
+    captureSource: 'focus_events',
+    endedReason: null,
+    captureVersion: PROJECTION_VERSION,
+  }
+}
+
+function projectGapsFromFocusEvents(
+  events: readonly StoredFocusEvent[],
+  rangeEndMs: number,
+): ActivityGapFact[] {
+  const gaps: ActivityGapFact[] = []
+  let open: { startMs: number; kind: ActivityGapKind } | null = null
+
+  const close = (endMs: number) => {
+    if (!open) return
+    if (endMs > open.startMs) gaps.push({ startMs: open.startMs, endMs, kind: open.kind })
+    open = null
+  }
+
+  for (const event of events) {
+    switch (event.event_type) {
+      case 'idle_started':
+        close(event.ts_ms)
+        open = { startMs: event.ts_ms, kind: 'idle' }
+        break
+      case 'idle_ended':
+        if (open?.kind === 'idle') close(event.ts_ms)
+        else open = null
+        break
+      case 'lock':
+        close(event.ts_ms)
+        open = { startMs: event.ts_ms, kind: 'locked' }
+        break
+      case 'unlock':
+        if (open?.kind === 'locked') close(event.ts_ms)
+        else open = null
+        break
+      case 'sleep':
+        close(event.ts_ms)
+        open = { startMs: event.ts_ms, kind: 'asleep' }
+        break
+      case 'wake':
+        if (open?.kind === 'asleep') close(event.ts_ms)
+        else open = null
+        break
+      case 'capture_paused':
+        close(event.ts_ms)
+        open = { startMs: event.ts_ms, kind: 'paused' }
+        break
+      case 'capture_resumed':
+        if (open?.kind === 'paused') close(event.ts_ms)
+        else open = null
+        break
+      case 'capture_failed':
+        close(event.ts_ms)
+        open = { startMs: event.ts_ms, kind: 'capture_unavailable' }
+        break
+      case 'capture_recovered':
+        if (open?.kind === 'capture_unavailable') close(event.ts_ms)
+        else open = null
+        break
+      default:
+        break
+    }
+  }
+  close(rangeEndMs)
+  return gaps
+}
+
+function totalsFromSessions(sessions: readonly AppSession[]): {
+  totalSeconds: number
+  focusSeconds: number
+} {
+  const totalSeconds = sessions.reduce((sum, session) => sum + session.durationSeconds, 0)
+  const rawFocus = sessions
+    .filter((session) => session.isFocused)
+    .reduce((sum, session) => sum + session.durationSeconds, 0)
+  // Focused duration never exceeds tracked duration for the same scope.
+  return { totalSeconds, focusSeconds: Math.min(rawFocus, totalSeconds) }
+}
+
+/**
+ * Shared corrected activity-fact query for one local day.
+ * Deterministic: same evidence + same corrections + same projection/query
+ * versions + same asOfMs ⇒ same facts, whether the caller is live or rebuilt.
+ */
+export function queryCorrectedActivityFactsForDay(
+  db: Database.Database,
+  date: string,
+  options: QueryCorrectedActivityFactsOptions = {},
+): CorrectedActivityDayFacts {
+  const nowMs = options.nowMs ?? Date.now()
+  const [fromMs, dayEndMs] = ownedDayBounds(db, date)
+  const asOfMs = Math.min(dayEndMs, Math.max(fromMs, options.asOfMs ?? nowMs))
+  const focusApps = getSettings().focusApps
+
+  const focusEventCount = countFocusEventsInRange(db, fromMs, asOfMs)
+  const events = listFocusEventsInRange(db, fromMs, asOfMs)
+  const projected = projectSessionsFromFocusEvents(events, asOfMs)
+  const canonicalSessions = projected
+    .filter((row) => !isSystemNoiseApp({ bundleId: row.app_bundle_id, appName: row.app_name }))
+    .map((row, index) => derivedRowToAppSession(row, index, focusApps))
+
+  const legacyInputs = listLegacyAppSessionInputs(db, fromMs, asOfMs)
+  const legacySessions = legacyAppSessionsAsAppSessions(legacyInputs)
+  const legacySessionCount = legacySessions.length
+
+  let evidenceSource: CorrectedActivityDayFacts['evidenceSource']
+  let rawSessions: AppSession[]
+  if (canonicalSessions.length > 0 && legacySessionCount > 0) {
+    evidenceSource = 'mixed'
+    rawSessions = canonicalSessions
+  } else if (canonicalSessions.length > 0) {
+    evidenceSource = 'canonical'
+    rawSessions = canonicalSessions
+  } else {
+    evidenceSource = 'legacy'
+    rawSessions = legacySessions
+  }
+
+  const sessions = applyTimelineCorrectionsToSessions(db, rawSessions, fromMs, asOfMs)
+  const { totalSeconds, focusSeconds } = totalsFromSessions(sessions)
+  const gaps = projectGapsFromFocusEvents(events, asOfMs)
+
+  return {
+    date,
+    projectionVersion: PROJECTION_VERSION,
+    queryVersion: ACTIVITY_FACTS_QUERY_VERSION,
+    evidenceSource,
+    sessions,
+    totalSeconds,
+    focusSeconds,
+    gaps,
+    focusEventCount,
+    legacySessionCount,
+  }
+}
+
+/** Convenience: facts for “today” clipped to now, using the shared query. */
+export function queryCorrectedActivityFactsForToday(
+  db: Database.Database,
+  options: Omit<QueryCorrectedActivityFactsOptions, 'asOfMs'> = {},
+): CorrectedActivityDayFacts {
+  const nowMs = options.nowMs ?? Date.now()
+  return queryCorrectedActivityFactsForDay(db, localDateString(new Date(nowMs)), {
+    ...options,
+    nowMs,
+    asOfMs: nowMs,
+  })
+}

--- a/src/main/core/query/canonicalLegacyParity.ts
+++ b/src/main/core/query/canonicalLegacyParity.ts
@@ -1,0 +1,118 @@
+// Local-only comparison of canonical shared-query facts vs legacy app_sessions.
+// Differences are recorded on disk for migration measurement — never sent to analytics.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import type Database from 'better-sqlite3'
+import { ownedDayBounds } from '../../lib/dayOwnership'
+import { legacyAppSessionsAsAppSessions, listLegacyAppSessionInputs } from '../evidence/legacyAdapter'
+import {
+  queryCorrectedActivityFactsForDay,
+  type CorrectedActivityDayFacts,
+} from './activityFactsQuery'
+
+export interface CanonicalLegacyDayParity {
+  date: string
+  comparedAt: string
+  canonical: {
+    evidenceSource: CorrectedActivityDayFacts['evidenceSource']
+    sessionCount: number
+    totalSeconds: number
+    focusSeconds: number
+    gapCount: number
+    focusEventCount: number
+  }
+  legacy: {
+    sessionCount: number
+    totalSeconds: number
+    focusSeconds: number
+  }
+  delta: {
+    sessionCount: number
+    totalSeconds: number
+    focusSeconds: number
+  }
+  notes: string[]
+}
+
+export function compareCanonicalAndLegacyDay(
+  db: Database.Database,
+  date: string,
+  options: { nowMs?: number; asOfMs?: number } = {},
+): CanonicalLegacyDayParity {
+  const [fromMs, dayEndMs] = ownedDayBounds(db, date)
+  const asOfMs = options.asOfMs ?? dayEndMs
+  const canonical = queryCorrectedActivityFactsForDay(db, date, {
+    nowMs: options.nowMs,
+    asOfMs,
+  })
+  const legacySessions = legacyAppSessionsAsAppSessions(
+    listLegacyAppSessionInputs(db, fromMs, asOfMs),
+  )
+  const legacyTotal = legacySessions.reduce((sum, session) => sum + session.durationSeconds, 0)
+  const legacyFocusRaw = legacySessions
+    .filter((session) => session.isFocused)
+    .reduce((sum, session) => sum + session.durationSeconds, 0)
+  const legacyFocus = Math.min(legacyFocusRaw, legacyTotal)
+
+  const notes: string[] = []
+  if (canonical.evidenceSource === 'legacy') {
+    notes.push('No canonical focus_events in range; shared query fell back to legacy sessions.')
+  } else if (canonical.evidenceSource === 'mixed') {
+    notes.push('Both focus_events and legacy app_sessions present; shared query used canonical projection.')
+  }
+  if (canonical.focusSeconds > canonical.totalSeconds) {
+    notes.push('Invariant broken: canonical focusSeconds exceeded totalSeconds.')
+  }
+  if (Math.abs(canonical.totalSeconds - legacyTotal) > 0) {
+    notes.push(
+      `Tracked duration differs by ${canonical.totalSeconds - legacyTotal}s (canonical − legacy).`,
+    )
+  }
+
+  return {
+    date,
+    comparedAt: new Date(options.nowMs ?? Date.now()).toISOString(),
+    canonical: {
+      evidenceSource: canonical.evidenceSource,
+      sessionCount: canonical.sessions.length,
+      totalSeconds: canonical.totalSeconds,
+      focusSeconds: canonical.focusSeconds,
+      gapCount: canonical.gaps.length,
+      focusEventCount: canonical.focusEventCount,
+    },
+    legacy: {
+      sessionCount: legacySessions.length,
+      totalSeconds: legacyTotal,
+      focusSeconds: legacyFocus,
+    },
+    delta: {
+      sessionCount: canonical.sessions.length - legacySessions.length,
+      totalSeconds: canonical.totalSeconds - legacyTotal,
+      focusSeconds: canonical.focusSeconds - legacyFocus,
+    },
+    notes,
+  }
+}
+
+/** Write a parity report to a local directory. Never phones home. */
+export function writeLocalCanonicalLegacyParityReport(
+  report: CanonicalLegacyDayParity,
+  directory: string,
+): string {
+  fs.mkdirSync(directory, { recursive: true })
+  const filePath = path.join(directory, `${report.date}-canonical-vs-legacy.json`)
+  fs.writeFileSync(filePath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+  return filePath
+}
+
+export function formatCanonicalLegacyParitySideBySide(report: CanonicalLegacyDayParity): string {
+  const lines = [
+    `Canonical vs legacy — ${report.date}`,
+    `  canonical: ${report.canonical.totalSeconds}s tracked, ${report.canonical.focusSeconds}s focused, ${report.canonical.sessionCount} sessions (${report.canonical.evidenceSource}, ${report.canonical.focusEventCount} focus_events)`,
+    `  legacy:    ${report.legacy.totalSeconds}s tracked, ${report.legacy.focusSeconds}s focused, ${report.legacy.sessionCount} sessions`,
+    `  delta:     ${report.delta.totalSeconds}s tracked, ${report.delta.focusSeconds}s focused, ${report.delta.sessionCount} sessions`,
+  ]
+  for (const note of report.notes) lines.push(`  note: ${note}`)
+  return lines.join('\n')
+}

--- a/tests/activityFactsQuery.test.ts
+++ b/tests/activityFactsQuery.test.ts
@@ -1,0 +1,205 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type Database from 'better-sqlite3'
+import { createProductionTestDatabase } from './support/testDatabase.ts'
+import { insertFocusEvents } from '../src/main/db/focusEventRepository.ts'
+import {
+  FOCUS_EVENT_SCHEMA_VERSION,
+  POLL_FOCUS_EVENT_SOURCE,
+  type FocusEventInsert,
+} from '../src/main/core/evidence/focusEvent.ts'
+import { queryCorrectedActivityFactsForDay } from '../src/main/core/query/activityFactsQuery.ts'
+import {
+  compareCanonicalAndLegacyDay,
+  formatCanonicalLegacyParitySideBySide,
+  writeLocalCanonicalLegacyParityReport,
+} from '../src/main/core/query/canonicalLegacyParity.ts'
+import { projectDay } from '../src/main/core/projections/chunk2.ts'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const DATE = '2026-04-22'
+const DAY_END = new Date(2026, 3, 23, 0, 0, 0, 0).getTime()
+
+function ms(hour: number, minute = 0): number {
+  return new Date(2026, 3, 22, hour, minute, 0, 0).getTime()
+}
+
+function focusEvent(
+  tsMs: number,
+  eventType: FocusEventInsert['event_type'],
+  overrides: Partial<FocusEventInsert> = {},
+): FocusEventInsert {
+  return {
+    ts_ms: tsMs,
+    mono_ns: tsMs * 1_000_000,
+    event_type: eventType,
+    app_bundle_id: overrides.app_bundle_id ?? 'com.mitchellh.ghostty',
+    app_name: overrides.app_name ?? 'Ghostty',
+    pid: overrides.pid ?? 1001,
+    window_title: overrides.window_title ?? 'Editor',
+    url: null,
+    page_title: null,
+    source: POLL_FOCUS_EVENT_SOURCE,
+    confidence: 'observed',
+    platform: 'darwin',
+    schema_ver: FOCUS_EVENT_SCHEMA_VERSION,
+    ...overrides,
+  }
+}
+
+function seedCanonicalMorning(db: Database.Database): void {
+  insertFocusEvents(db, [
+    focusEvent(ms(9, 0), 'app_activated'),
+    focusEvent(ms(9, 30), 'app_deactivated'),
+    focusEvent(ms(9, 30), 'app_activated', {
+      app_bundle_id: 'com.apple.Safari',
+      app_name: 'Safari',
+      window_title: 'Docs',
+    }),
+    focusEvent(ms(10, 0), 'app_deactivated', {
+      app_bundle_id: 'com.apple.Safari',
+      app_name: 'Safari',
+    }),
+    focusEvent(ms(10, 0), 'idle_started', {
+      app_bundle_id: null,
+      app_name: null,
+      pid: null,
+      window_title: null,
+      source: 'capture_supervisor',
+    }),
+    focusEvent(ms(10, 20), 'idle_ended', {
+      app_bundle_id: null,
+      app_name: null,
+      pid: null,
+      window_title: null,
+      source: 'capture_supervisor',
+    }),
+  ])
+}
+
+function seedLegacyMirror(db: Database.Database): void {
+  db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec,
+      category, is_focused, window_title, raw_app_name, canonical_app_id, capture_source, capture_version
+    ) VALUES
+      ('com.mitchellh.ghostty', 'Ghostty', ?, ?, 1800, 'development', 1, 'Editor', 'Ghostty', 'ghostty', 'test', 1),
+      ('com.apple.Safari', 'Safari', ?, ?, 1800, 'browsing', 0, 'Docs', 'Safari', 'safari', 'test', 1)
+  `).run(ms(9, 0), ms(9, 30), ms(9, 30), ms(10, 0))
+}
+
+test('live and historical reads of the same day return identical sessions, totals, and gaps', () => {
+  const db = createProductionTestDatabase()
+  seedCanonicalMorning(db)
+  const asOfMs = DAY_END
+  const liveShaped = queryCorrectedActivityFactsForDay(db, DATE, { nowMs: asOfMs, asOfMs })
+  const historicalShaped = queryCorrectedActivityFactsForDay(db, DATE, {
+    nowMs: asOfMs + 86_400_000,
+    asOfMs,
+  })
+  assert.equal(liveShaped.evidenceSource, 'canonical')
+  assert.deepEqual(
+    liveShaped.sessions.map((s) => ({
+      bundleId: s.bundleId,
+      startTime: s.startTime,
+      endTime: s.endTime,
+      durationSeconds: s.durationSeconds,
+    })),
+    historicalShaped.sessions.map((s) => ({
+      bundleId: s.bundleId,
+      startTime: s.startTime,
+      endTime: s.endTime,
+      durationSeconds: s.durationSeconds,
+    })),
+  )
+  assert.equal(liveShaped.totalSeconds, historicalShaped.totalSeconds)
+  assert.equal(liveShaped.focusSeconds, historicalShaped.focusSeconds)
+  assert.deepEqual(liveShaped.gaps, historicalShaped.gaps)
+  assert.ok(liveShaped.gaps.some((gap) => gap.kind === 'idle'))
+})
+
+test('corrections survive rebuild through the shared query', () => {
+  const db = createProductionTestDatabase()
+  seedCanonicalMorning(db)
+  const before = queryCorrectedActivityFactsForDay(db, DATE, { asOfMs: DAY_END, nowMs: DAY_END })
+  assert.ok(before.totalSeconds > 0)
+
+  const now = Date.now()
+  db.prepare(`
+    INSERT INTO timeline_block_reviews (
+      id, date, block_id, evidence_key, review_state, original_block_json, correction_json, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, 'ignored', ?, '{}', ?, ?)
+  `).run(
+    'review-test-block',
+    DATE,
+    'test-block',
+    'test-block',
+    JSON.stringify({ startTime: ms(9, 0), endTime: ms(9, 30) }),
+    now,
+    now,
+  )
+
+  const afterCorrection = queryCorrectedActivityFactsForDay(db, DATE, {
+    asOfMs: DAY_END,
+    nowMs: DAY_END,
+  })
+  assert.ok(afterCorrection.totalSeconds < before.totalSeconds)
+
+  projectDay(db, DATE, { finalize: true, now: new Date(DAY_END + 3_600_000) })
+  const afterRebuild = queryCorrectedActivityFactsForDay(db, DATE, {
+    asOfMs: DAY_END,
+    nowMs: DAY_END + 3_600_000,
+  })
+  assert.equal(afterRebuild.totalSeconds, afterCorrection.totalSeconds)
+  assert.deepEqual(
+    afterRebuild.sessions.map((s) => [s.startTime, s.endTime, s.durationSeconds]),
+    afterCorrection.sessions.map((s) => [s.startTime, s.endTime, s.durationSeconds]),
+  )
+})
+
+test('focused duration never exceeds tracked duration for the same scope', () => {
+  const db = createProductionTestDatabase()
+  seedCanonicalMorning(db)
+  const facts = queryCorrectedActivityFactsForDay(db, DATE, { asOfMs: DAY_END, nowMs: DAY_END })
+  assert.ok(facts.focusSeconds <= facts.totalSeconds)
+})
+
+test('canonical-vs-legacy differences are recorded locally and never invent focus events from legacy rows', () => {
+  const db = createProductionTestDatabase()
+  seedCanonicalMorning(db)
+  seedLegacyMirror(db)
+  const report = compareCanonicalAndLegacyDay(db, DATE, { asOfMs: DAY_END, nowMs: DAY_END })
+  assert.equal(report.canonical.focusEventCount > 0, true)
+  assert.equal(report.legacy.sessionCount, 2)
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'daylens-parity-'))
+  const filePath = writeLocalCanonicalLegacyParityReport(report, dir)
+  assert.equal(fs.existsSync(filePath), true)
+  const written = JSON.parse(fs.readFileSync(filePath, 'utf8')) as typeof report
+  assert.equal(written.date, DATE)
+  const sideBySide = formatCanonicalLegacyParitySideBySide(report)
+  assert.match(sideBySide, /canonical:/)
+  assert.match(sideBySide, /legacy:/)
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+test('shared query falls back to legacy compatibility inputs when focus_events are absent', () => {
+  const db = createProductionTestDatabase()
+  seedLegacyMirror(db)
+  const facts = queryCorrectedActivityFactsForDay(db, DATE, { asOfMs: DAY_END, nowMs: DAY_END })
+  assert.equal(facts.evidenceSource, 'legacy')
+  assert.equal(facts.sessions.length, 2)
+  assert.equal(facts.totalSeconds, 3600)
+  assert.ok(facts.focusSeconds <= facts.totalSeconds)
+})
+
+test('same evidence + corrections + projection version is byte-stable across repeated queries', () => {
+  const db = createProductionTestDatabase()
+  seedCanonicalMorning(db)
+  const a = queryCorrectedActivityFactsForDay(db, DATE, { asOfMs: DAY_END, nowMs: DAY_END })
+  const b = queryCorrectedActivityFactsForDay(db, DATE, { asOfMs: DAY_END, nowMs: DAY_END })
+  assert.equal(JSON.stringify(a), JSON.stringify(b))
+  assert.equal(a.projectionVersion, b.projectionVersion)
+  assert.equal(a.queryVersion, b.queryVersion)
+})


### PR DESCRIPTION
Closes #164

## Summary
- Add `queryCorrectedActivityFactsForDay`: one live/historical projection from `focus_events`, correction overlay, focus clamped to tracked duration
- Expose `app_sessions` / website visits via a legacy compatibility adapter (never rewritten into fake events)
- Record canonical-vs-legacy differences locally; `verify:real-day` prints side-by-side with today's Timeline/Apps path
- Out of scope (unchanged): migrating Timeline/Apps/AI callers onto the query; segmentation/labels

## Test plan
- [x] `npm run typecheck`
- [x] `npx eslint` on touched files
- [x] `npm test` (only known `wrapPreflight` midnight flake)
- [x] `npm run verify:synthetic-day`
- [x] `npm run timeline:eval -- --strict`
- [x] `npm run verify:real-day -- --date 2026-07-16` — shared query 4h 58m side by side with Timeline 4h 58m / Apps 7h 35m; local parity JSON written


Made with [Cursor](https://cursor.com)