### PR TITLE
Purge site titles from browser history (DEV-214)

### DIFF
--- a/src/main/services/trackingHistory.ts
+++ b/src/main/services/trackingHistory.ts
@@ -163,6 +163,52 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
   const urlPatterns = [`%://${domain}/%`, `%://%.${domain}/%`, `%://${domain}`, `%://%.${domain}`]
 
   const purge = db.transaction(() => {
+    db.exec(`
+      CREATE TEMP TABLE IF NOT EXISTS purge_site_pages (
+        title TEXT NOT NULL,
+        bundle_id TEXT NOT NULL,
+        PRIMARY KEY (title, bundle_id)
+      );
+      DELETE FROM purge_site_pages;
+    `)
+    const collectPages = (
+      table: string,
+      condition: string,
+      conditionParams: unknown[],
+      browserExpression: string,
+    ): void => {
+      for (const column of ['page_title', 'window_title']) {
+        try {
+          db.prepare(`
+            INSERT OR IGNORE INTO purge_site_pages (title, bundle_id)
+            SELECT lower(trim(${column})), lower(${browserExpression})
+            FROM ${table}
+            WHERE (${condition})
+              AND ${column} IS NOT NULL AND trim(${column}) <> ''
+              AND ${browserExpression} IS NOT NULL AND trim(${browserExpression}) <> ''
+          `).run(...conditionParams)
+        } catch {
+          // Optional legacy tables do not all carry both title columns.
+        }
+      }
+    }
+
+    const domainCondition = 'lower(domain) = ? OR lower(domain) LIKE ?'
+    const rawBrowser = `CASE
+      WHEN instr(browser_bundle_id, ':') > 0
+        THEN substr(browser_bundle_id, 1, instr(browser_bundle_id, ':') - 1)
+      ELSE browser_bundle_id
+    END`
+    collectPages('website_visits', domainCondition, params, rawBrowser)
+    collectPages('website_visits', domainCondition, params, 'canonical_browser_id')
+    collectPages('derived_sessions', domainCondition, params, 'app_bundle_id')
+    collectPages(
+      'focus_events',
+      '(lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ?)',
+      urlPatterns,
+      'app_bundle_id',
+    )
+
     const rows = db.prepare(`SELECT visit_time FROM website_visits ${where}`).all(...params) as { visit_time: number }[]
     for (const date of distinctLocalDates(rows.map((row) => row.visit_time))) affected.add(date)
     deletedRows += db.prepare(`DELETE FROM website_visits ${where}`).run(...params).changes
@@ -204,6 +250,60 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
         DELETE FROM derived_sessions
         WHERE lower(domain) = ? OR lower(domain) LIKE ?
       `).run(...params).changes
+    } catch {
+      // Derived projection tables are optional on older installs.
+    }
+
+    const appTitleRows = db.prepare(`
+      UPDATE app_sessions
+      SET window_title = NULL
+      WHERE window_title IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM purge_site_pages
+          WHERE title = lower(trim(app_sessions.window_title))
+            AND bundle_id IN (
+              lower(app_sessions.bundle_id),
+              lower(coalesce(app_sessions.canonical_app_id, ''))
+            )
+        )
+      RETURNING start_time
+    `).all() as { start_time: number }[]
+    for (const date of distinctLocalDates(appTitleRows.map((row) => row.start_time))) affected.add(date)
+    deletedRows += appTitleRows.length
+
+    const focusTitleRows = db.prepare(`
+      UPDATE focus_events
+      SET window_title = NULL, page_title = NULL
+      WHERE EXISTS (
+          SELECT 1 FROM purge_site_pages
+          WHERE bundle_id = lower(focus_events.app_bundle_id)
+            AND (
+              title = lower(trim(focus_events.window_title))
+              OR title = lower(trim(focus_events.page_title))
+            )
+        )
+      RETURNING ts_ms
+    `).all() as { ts_ms: number }[]
+    for (const date of distinctLocalDates(focusTitleRows.map((row) => row.ts_ms))) affected.add(date)
+    deletedRows += focusTitleRows.length
+
+    try {
+      const derivedTitleRows = db.prepare(`
+        UPDATE derived_sessions
+        SET window_title = NULL, page_title = NULL
+        WHERE is_browser = 1
+          AND EXISTS (
+            SELECT 1 FROM purge_site_pages
+            WHERE bundle_id = lower(derived_sessions.app_bundle_id)
+              AND (
+                title = lower(trim(derived_sessions.window_title))
+                OR title = lower(trim(derived_sessions.page_title))
+              )
+          )
+        RETURNING date
+      `).all() as { date: string }[]
+      for (const row of derivedTitleRows) affected.add(row.date)
+      deletedRows += derivedTitleRows.length
     } catch {
       // Derived projection tables are optional on older installs.
     }
@@ -283,6 +383,8 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
         }
       }
     }
+
+    db.exec('DELETE FROM purge_site_pages')
   })
   purge()
   if (deletedRows > 0) clearGeneratedActivitySummaries(db)

--- a/src/main/services/trackingHistory.ts
+++ b/src/main/services/trackingHistory.ts
@@ -169,13 +169,31 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
         canonical_id TEXT NOT NULL
       );
       CREATE TEMP TABLE IF NOT EXISTS purge_site_pages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        canonical_browser_id TEXT NOT NULL,
+        raw_browser_id TEXT NOT NULL,
+        profile_id TEXT,
+        observed_at INTEGER NOT NULL
+      );
+      CREATE TEMP TABLE IF NOT EXISTS purge_focus_pages (
+        source_event_id INTEGER NOT NULL,
         title TEXT NOT NULL,
         canonical_browser_id TEXT NOT NULL,
         started_at INTEGER NOT NULL,
         ended_at INTEGER NOT NULL
       );
+      CREATE TEMP TABLE IF NOT EXISTS purge_app_session_matches (
+        session_id INTEGER PRIMARY KEY
+      );
+      CREATE TEMP TABLE IF NOT EXISTS purge_derived_session_matches (
+        session_id INTEGER PRIMARY KEY
+      );
       DELETE FROM purge_browser_aliases;
       DELETE FROM purge_site_pages;
+      DELETE FROM purge_focus_pages;
+      DELETE FROM purge_app_session_matches;
+      DELETE FROM purge_derived_session_matches;
     `)
     const insertAlias = db.prepare(`
       INSERT OR REPLACE INTO purge_browser_aliases (alias, canonical_id) VALUES (?, ?)
@@ -215,57 +233,63 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
       (SELECT canonical_id FROM purge_browser_aliases WHERE alias = lower(${expression})),
       lower(${expression})
     )`
-    const collectPages = (
-      table: string,
-      condition: string,
-      conditionParams: unknown[],
-      browserExpression: string,
-      startExpression: string,
-      endExpression: string,
-    ): void => {
-      for (const column of ['page_title', 'window_title']) {
-        try {
-          db.prepare(`
-            INSERT INTO purge_site_pages (title, canonical_browser_id, started_at, ended_at)
-            SELECT lower(trim(${column})), ${canonicalBrowser(browserExpression)},
-              ${startExpression}, ${endExpression}
-            FROM ${table}
-            WHERE (${condition})
-              AND ${column} IS NOT NULL AND trim(${column}) <> ''
-              AND ${browserExpression} IS NOT NULL AND trim(${browserExpression}) <> ''
-              AND ${endExpression} > ${startExpression}
-          `).run(...conditionParams)
-        } catch {
-          // Optional legacy tables do not all carry both title columns.
-        }
-      }
-    }
 
     const domainCondition = 'lower(domain) = ? OR lower(domain) LIKE ?'
-    collectPages(
-      'website_visits',
-      domainCondition,
-      params,
-      `coalesce(nullif(canonical_browser_id, ''), ${canonicalBrowser('browser_bundle_id')})`,
-      'visit_time',
-      'visit_time + max(duration_sec * 1000, 1)',
-    )
-    collectPages(
-      'derived_sessions',
-      domainCondition,
-      params,
-      'app_bundle_id',
-      'start_ts_ms',
-      'end_ts_ms',
-    )
-    collectPages(
-      'focus_events',
-      '(lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ?)',
-      urlPatterns,
-      'app_bundle_id',
-      'ts_ms',
-      'ts_ms + 1',
-    )
+    db.prepare(`
+      INSERT INTO purge_site_pages (
+        title, canonical_browser_id, raw_browser_id, profile_id, observed_at
+      )
+      SELECT lower(trim(page_title)),
+        ${canonicalBrowser("coalesce(nullif(canonical_browser_id, ''), browser_bundle_id)")},
+        lower(browser_bundle_id), lower(nullif(browser_profile_id, '')), visit_time
+      FROM website_visits
+      WHERE (${domainCondition})
+        AND page_title IS NOT NULL AND trim(page_title) <> ''
+        AND browser_bundle_id IS NOT NULL AND trim(browser_bundle_id) <> ''
+    `).run(...params)
+
+    for (const column of ['page_title', 'window_title']) {
+      db.prepare(`
+        INSERT INTO purge_site_pages (
+          title, canonical_browser_id, raw_browser_id, profile_id, observed_at
+        )
+        SELECT lower(trim(${column})), ${canonicalBrowser('app_bundle_id')},
+          lower(app_bundle_id), NULL, ts_ms
+        FROM focus_events
+        WHERE (lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ?)
+          AND ${column} IS NOT NULL AND trim(${column}) <> ''
+          AND app_bundle_id IS NOT NULL AND trim(app_bundle_id) <> ''
+      `).run(...urlPatterns)
+      db.prepare(`
+        INSERT INTO purge_focus_pages (
+          source_event_id, title, canonical_browser_id, started_at, ended_at
+        )
+        SELECT source.id, lower(trim(source.${column})), ${canonicalBrowser('source.app_bundle_id')},
+          source.ts_ms,
+          coalesce((
+            SELECT boundary.ts_ms
+            FROM focus_events boundary
+            WHERE (boundary.ts_ms > source.ts_ms
+                OR (boundary.ts_ms = source.ts_ms AND boundary.id > source.id))
+              AND (
+                boundary.url IS NOT NULL
+                OR boundary.event_type IN (
+                  'tab_changed', 'tab_sampled', 'app_activated', 'app_deactivated',
+                  'sleep', 'lock'
+                )
+                OR coalesce(${canonicalBrowser('boundary.app_bundle_id')}, '')
+                  <> ${canonicalBrowser('source.app_bundle_id')}
+              )
+            ORDER BY boundary.ts_ms, boundary.id
+            LIMIT 1
+          ), 9223372036854775807)
+        FROM focus_events source
+        WHERE (lower(source.url) LIKE ? OR lower(source.url) LIKE ?
+            OR lower(source.url) LIKE ? OR lower(source.url) LIKE ?)
+          AND source.${column} IS NOT NULL AND trim(source.${column}) <> ''
+          AND source.app_bundle_id IS NOT NULL AND trim(source.app_bundle_id) <> ''
+      `).run(...urlPatterns)
+    }
 
     const rows = db.prepare(`SELECT visit_time FROM website_visits ${where}`).all(...params) as { visit_time: number }[]
     for (const date of distinctLocalDates(rows.map((row) => row.visit_time))) affected.add(date)
@@ -312,30 +336,85 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
       // Derived projection tables are optional on older installs.
     }
 
-    const titleMatches = (column: string): string => `(
-      purge_site_pages.title = lower(trim(${column}))
+    const titleMatches = (pageTable: string, column: string): string => `(
+      ${pageTable}.title = lower(trim(${column}))
       OR (
-        substr(lower(trim(${column})), 1, length(purge_site_pages.title)) = purge_site_pages.title
-        AND substr(lower(trim(${column})), length(purge_site_pages.title) + 1, 3) IN (' - ', ' — ', ' – ')
+        substr(lower(trim(${column})), 1, length(${pageTable}.title)) = ${pageTable}.title
+        AND substr(lower(trim(${column})), length(${pageTable}.title) + 1, 3) IN (' - ', ' — ', ' – ')
       )
     )`
+    const sessionMatchToleranceMs = 5_000
+    const appSessionEnd = `coalesce(
+      app_sessions.end_time,
+      app_sessions.start_time + max(app_sessions.duration_sec * 1000, 1)
+    )`
+    const appSessionProfile = `lower(coalesce(
+      CASE
+        WHEN instr(coalesce(app_sessions.app_instance_id, ''), ':') > 0
+          THEN substr(app_sessions.app_instance_id, instr(app_sessions.app_instance_id, ':') + 1)
+      END,
+      CASE
+        WHEN instr(app_sessions.bundle_id, ':') > 0
+          AND app_sessions.bundle_id NOT GLOB '[A-Za-z]:[\\/]*'
+          THEN substr(app_sessions.bundle_id, instr(app_sessions.bundle_id, ':') + 1)
+      END,
+      ''
+    ))`
+    db.prepare(`
+      INSERT OR IGNORE INTO purge_app_session_matches (session_id)
+      SELECT session_id
+      FROM (
+        SELECT purge_site_pages.id AS page_id, app_sessions.id AS session_id,
+          row_number() OVER (
+            PARTITION BY purge_site_pages.id
+            ORDER BY
+              CASE
+                WHEN purge_site_pages.raw_browser_id IN (
+                  lower(app_sessions.bundle_id),
+                  lower(coalesce(app_sessions.app_instance_id, ''))
+                ) THEN 0
+                WHEN purge_site_pages.profile_id IS NOT NULL
+                  AND purge_site_pages.profile_id = ${appSessionProfile} THEN 1
+                ELSE 2
+              END,
+              CASE WHEN purge_site_pages.observed_at >= app_sessions.start_time
+                AND purge_site_pages.observed_at < ${appSessionEnd} THEN 0 ELSE 1 END,
+              CASE
+                WHEN purge_site_pages.observed_at < app_sessions.start_time
+                  THEN app_sessions.start_time - purge_site_pages.observed_at
+                WHEN purge_site_pages.observed_at >= ${appSessionEnd}
+                  THEN purge_site_pages.observed_at - ${appSessionEnd}
+                ELSE 0
+              END,
+              abs(purge_site_pages.observed_at - app_sessions.start_time),
+              app_sessions.id
+          ) AS candidate_rank
+        FROM purge_site_pages
+        JOIN app_sessions
+          ON app_sessions.window_title IS NOT NULL
+          AND ${titleMatches('purge_site_pages', 'app_sessions.window_title')}
+          AND purge_site_pages.canonical_browser_id = coalesce(
+            lower(nullif(app_sessions.canonical_app_id, '')),
+            ${canonicalBrowser('app_sessions.bundle_id')}
+          )
+          AND (
+            purge_site_pages.profile_id IS NULL
+            OR ${appSessionProfile} = ''
+            OR purge_site_pages.profile_id = ${appSessionProfile}
+            OR purge_site_pages.raw_browser_id IN (
+              lower(app_sessions.bundle_id),
+              lower(coalesce(app_sessions.app_instance_id, ''))
+            )
+          )
+          AND purge_site_pages.observed_at >= app_sessions.start_time - ?
+          AND purge_site_pages.observed_at <= ${appSessionEnd} + ?
+      )
+      WHERE candidate_rank = 1
+    `).run(sessionMatchToleranceMs, sessionMatchToleranceMs)
     const appTitleRows = db.prepare(`
       UPDATE app_sessions
       SET window_title = NULL
-      WHERE window_title IS NOT NULL
-        AND EXISTS (
-          SELECT 1 FROM purge_site_pages
-          WHERE ${titleMatches('app_sessions.window_title')}
-            AND canonical_browser_id = coalesce(
-              lower(nullif(app_sessions.canonical_app_id, '')),
-              ${canonicalBrowser('app_sessions.bundle_id')}
-            )
-            AND app_sessions.start_time < purge_site_pages.ended_at
-            AND coalesce(
-              app_sessions.end_time,
-              app_sessions.start_time + max(app_sessions.duration_sec * 1000, 1)
-            ) > purge_site_pages.started_at
-        )
+      WHERE id IN (SELECT session_id FROM purge_app_session_matches)
       RETURNING start_time
     `).all() as { start_time: number }[]
     for (const date of distinctLocalDates(appTitleRows.map((row) => row.start_time))) affected.add(date)
@@ -344,14 +423,19 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
     const focusTitleRows = db.prepare(`
       UPDATE focus_events
       SET window_title = NULL, page_title = NULL
-      WHERE EXISTS (
-          SELECT 1 FROM purge_site_pages
+      WHERE focus_events.url IS NULL
+        AND EXISTS (
+          SELECT 1 FROM purge_focus_pages
           WHERE canonical_browser_id = ${canonicalBrowser('focus_events.app_bundle_id')}
-            AND focus_events.ts_ms >= purge_site_pages.started_at
-            AND focus_events.ts_ms < purge_site_pages.ended_at
             AND (
-              ${titleMatches('focus_events.window_title')}
-              OR ${titleMatches('focus_events.page_title')}
+              focus_events.ts_ms > purge_focus_pages.started_at
+              OR (focus_events.ts_ms = purge_focus_pages.started_at
+                AND focus_events.id > purge_focus_pages.source_event_id)
+            )
+            AND focus_events.ts_ms < purge_focus_pages.ended_at
+            AND (
+              ${titleMatches('purge_focus_pages', 'focus_events.window_title')}
+              OR ${titleMatches('purge_focus_pages', 'focus_events.page_title')}
             )
         )
       RETURNING ts_ms
@@ -360,20 +444,65 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
     deletedRows += focusTitleRows.length
 
     try {
+      const derivedSessionEnd = 'derived_sessions.end_ts_ms'
+      const derivedSessionProfile = `lower(coalesce(
+        CASE
+          WHEN instr(coalesce(derived_sessions.app_bundle_id, ''), ':') > 0
+            AND derived_sessions.app_bundle_id NOT GLOB '[A-Za-z]:[\\/]*'
+            THEN substr(derived_sessions.app_bundle_id, instr(derived_sessions.app_bundle_id, ':') + 1)
+        END,
+        ''
+      ))`
+      db.prepare(`
+        INSERT OR IGNORE INTO purge_derived_session_matches (session_id)
+        SELECT session_id
+        FROM (
+          SELECT purge_site_pages.id AS page_id, derived_sessions.id AS session_id,
+            row_number() OVER (
+              PARTITION BY purge_site_pages.id
+              ORDER BY
+                CASE
+                  WHEN purge_site_pages.raw_browser_id = lower(derived_sessions.app_bundle_id) THEN 0
+                  WHEN purge_site_pages.profile_id IS NOT NULL
+                    AND purge_site_pages.profile_id = ${derivedSessionProfile} THEN 1
+                  ELSE 2
+                END,
+                CASE WHEN purge_site_pages.observed_at >= derived_sessions.start_ts_ms
+                  AND purge_site_pages.observed_at < ${derivedSessionEnd} THEN 0 ELSE 1 END,
+                CASE
+                  WHEN purge_site_pages.observed_at < derived_sessions.start_ts_ms
+                    THEN derived_sessions.start_ts_ms - purge_site_pages.observed_at
+                  WHEN purge_site_pages.observed_at >= ${derivedSessionEnd}
+                    THEN purge_site_pages.observed_at - ${derivedSessionEnd}
+                  ELSE 0
+                END,
+                abs(purge_site_pages.observed_at - derived_sessions.start_ts_ms),
+                derived_sessions.id
+            ) AS candidate_rank
+          FROM purge_site_pages
+          JOIN derived_sessions
+            ON derived_sessions.is_browser = 1
+            AND (
+              ${titleMatches('purge_site_pages', 'derived_sessions.window_title')}
+              OR ${titleMatches('purge_site_pages', 'derived_sessions.page_title')}
+            )
+            AND purge_site_pages.canonical_browser_id
+              = ${canonicalBrowser('derived_sessions.app_bundle_id')}
+            AND (
+              purge_site_pages.profile_id IS NULL
+              OR ${derivedSessionProfile} = ''
+              OR purge_site_pages.profile_id = ${derivedSessionProfile}
+              OR purge_site_pages.raw_browser_id = lower(derived_sessions.app_bundle_id)
+            )
+            AND purge_site_pages.observed_at >= derived_sessions.start_ts_ms - ?
+            AND purge_site_pages.observed_at <= ${derivedSessionEnd} + ?
+        )
+        WHERE candidate_rank = 1
+      `).run(sessionMatchToleranceMs, sessionMatchToleranceMs)
       const derivedTitleRows = db.prepare(`
         UPDATE derived_sessions
         SET window_title = NULL, page_title = NULL
-        WHERE is_browser = 1
-          AND EXISTS (
-            SELECT 1 FROM purge_site_pages
-            WHERE canonical_browser_id = ${canonicalBrowser('derived_sessions.app_bundle_id')}
-              AND derived_sessions.start_ts_ms < purge_site_pages.ended_at
-              AND derived_sessions.end_ts_ms > purge_site_pages.started_at
-              AND (
-                ${titleMatches('derived_sessions.window_title')}
-                OR ${titleMatches('derived_sessions.page_title')}
-              )
-          )
+        WHERE id IN (SELECT session_id FROM purge_derived_session_matches)
         RETURNING date
       `).all() as { date: string }[]
       for (const row of derivedTitleRows) affected.add(row.date)
@@ -460,6 +589,9 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
 
     db.exec(`
       DELETE FROM purge_site_pages;
+      DELETE FROM purge_focus_pages;
+      DELETE FROM purge_app_session_matches;
+      DELETE FROM purge_derived_session_matches;
       DELETE FROM purge_browser_aliases;
     `)
   })

--- a/src/main/services/trackingHistory.ts
+++ b/src/main/services/trackingHistory.ts
@@ -11,7 +11,7 @@ import { localDateString } from '../lib/localDate'
 import { materializeTimelineDayProjection } from '../core/query/projections'
 import { invalidateProjectionScope } from '../core/projections/invalidation'
 import { projectDay } from '../core/projections/chunk2'
-import { normalizeUrlForStorage, pageKeyForUrl } from '../lib/appIdentity'
+import { normalizeUrlForStorage, pageKeyForUrl, resolveCanonicalBrowser } from '../lib/appIdentity'
 
 export interface PurgeResult {
   deletedRows: number
@@ -164,28 +164,76 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
 
   const purge = db.transaction(() => {
     db.exec(`
+      CREATE TEMP TABLE IF NOT EXISTS purge_browser_aliases (
+        alias TEXT PRIMARY KEY,
+        canonical_id TEXT NOT NULL
+      );
       CREATE TEMP TABLE IF NOT EXISTS purge_site_pages (
         title TEXT NOT NULL,
-        bundle_id TEXT NOT NULL,
-        PRIMARY KEY (title, bundle_id)
+        canonical_browser_id TEXT NOT NULL,
+        started_at INTEGER NOT NULL,
+        ended_at INTEGER NOT NULL
       );
+      DELETE FROM purge_browser_aliases;
       DELETE FROM purge_site_pages;
     `)
+    const insertAlias = db.prepare(`
+      INSERT OR REPLACE INTO purge_browser_aliases (alias, canonical_id) VALUES (?, ?)
+    `)
+    const addBrowserAlias = (rawValue: string | null, canonicalValue: string | null): void => {
+      const rawIdentity = rawValue?.trim()
+      if (!rawIdentity) return
+      const baseIdentity = /^[a-z]:[\\/]/i.test(rawIdentity) ? rawIdentity : rawIdentity.split(':', 1)[0]
+      const raw = rawIdentity.toLowerCase()
+      const base = baseIdentity.toLowerCase()
+      const canonical = canonicalValue?.trim().toLowerCase()
+        || resolveCanonicalBrowser(baseIdentity).canonicalBrowserId
+        || base
+      insertAlias.run(raw, canonical)
+      insertAlias.run(base, canonical)
+      insertAlias.run(canonical, canonical)
+    }
+    const collectAliases = (sql: string): void => {
+      try {
+        const rows = db.prepare(sql).all() as Array<{ raw_id: string | null; canonical_id: string | null }>
+        for (const row of rows) addBrowserAlias(row.raw_id, row.canonical_id)
+      } catch {
+        // Derived projection tables are optional on older installs.
+      }
+    }
+    collectAliases(`
+      SELECT bundle_id AS raw_id, canonical_app_id AS canonical_id FROM app_sessions
+      UNION
+      SELECT app_bundle_id, NULL FROM focus_events
+    `)
+    collectAliases('SELECT app_bundle_id AS raw_id, NULL AS canonical_id FROM derived_sessions')
+    collectAliases(`
+      SELECT browser_bundle_id AS raw_id, canonical_browser_id AS canonical_id FROM website_visits
+    `)
+
+    const canonicalBrowser = (expression: string): string => `coalesce(
+      (SELECT canonical_id FROM purge_browser_aliases WHERE alias = lower(${expression})),
+      lower(${expression})
+    )`
     const collectPages = (
       table: string,
       condition: string,
       conditionParams: unknown[],
       browserExpression: string,
+      startExpression: string,
+      endExpression: string,
     ): void => {
       for (const column of ['page_title', 'window_title']) {
         try {
           db.prepare(`
-            INSERT OR IGNORE INTO purge_site_pages (title, bundle_id)
-            SELECT lower(trim(${column})), lower(${browserExpression})
+            INSERT INTO purge_site_pages (title, canonical_browser_id, started_at, ended_at)
+            SELECT lower(trim(${column})), ${canonicalBrowser(browserExpression)},
+              ${startExpression}, ${endExpression}
             FROM ${table}
             WHERE (${condition})
               AND ${column} IS NOT NULL AND trim(${column}) <> ''
               AND ${browserExpression} IS NOT NULL AND trim(${browserExpression}) <> ''
+              AND ${endExpression} > ${startExpression}
           `).run(...conditionParams)
         } catch {
           // Optional legacy tables do not all carry both title columns.
@@ -194,19 +242,29 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
     }
 
     const domainCondition = 'lower(domain) = ? OR lower(domain) LIKE ?'
-    const rawBrowser = `CASE
-      WHEN instr(browser_bundle_id, ':') > 0
-        THEN substr(browser_bundle_id, 1, instr(browser_bundle_id, ':') - 1)
-      ELSE browser_bundle_id
-    END`
-    collectPages('website_visits', domainCondition, params, rawBrowser)
-    collectPages('website_visits', domainCondition, params, 'canonical_browser_id')
-    collectPages('derived_sessions', domainCondition, params, 'app_bundle_id')
+    collectPages(
+      'website_visits',
+      domainCondition,
+      params,
+      `coalesce(nullif(canonical_browser_id, ''), ${canonicalBrowser('browser_bundle_id')})`,
+      'visit_time',
+      'visit_time + max(duration_sec * 1000, 1)',
+    )
+    collectPages(
+      'derived_sessions',
+      domainCondition,
+      params,
+      'app_bundle_id',
+      'start_ts_ms',
+      'end_ts_ms',
+    )
     collectPages(
       'focus_events',
       '(lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ?)',
       urlPatterns,
       'app_bundle_id',
+      'ts_ms',
+      'ts_ms + 1',
     )
 
     const rows = db.prepare(`SELECT visit_time FROM website_visits ${where}`).all(...params) as { visit_time: number }[]
@@ -254,17 +312,29 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
       // Derived projection tables are optional on older installs.
     }
 
+    const titleMatches = (column: string): string => `(
+      purge_site_pages.title = lower(trim(${column}))
+      OR (
+        substr(lower(trim(${column})), 1, length(purge_site_pages.title)) = purge_site_pages.title
+        AND substr(lower(trim(${column})), length(purge_site_pages.title) + 1, 3) IN (' - ', ' — ', ' – ')
+      )
+    )`
     const appTitleRows = db.prepare(`
       UPDATE app_sessions
       SET window_title = NULL
       WHERE window_title IS NOT NULL
         AND EXISTS (
           SELECT 1 FROM purge_site_pages
-          WHERE title = lower(trim(app_sessions.window_title))
-            AND bundle_id IN (
-              lower(app_sessions.bundle_id),
-              lower(coalesce(app_sessions.canonical_app_id, ''))
+          WHERE ${titleMatches('app_sessions.window_title')}
+            AND canonical_browser_id = coalesce(
+              lower(nullif(app_sessions.canonical_app_id, '')),
+              ${canonicalBrowser('app_sessions.bundle_id')}
             )
+            AND app_sessions.start_time < purge_site_pages.ended_at
+            AND coalesce(
+              app_sessions.end_time,
+              app_sessions.start_time + max(app_sessions.duration_sec * 1000, 1)
+            ) > purge_site_pages.started_at
         )
       RETURNING start_time
     `).all() as { start_time: number }[]
@@ -276,10 +346,12 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
       SET window_title = NULL, page_title = NULL
       WHERE EXISTS (
           SELECT 1 FROM purge_site_pages
-          WHERE bundle_id = lower(focus_events.app_bundle_id)
+          WHERE canonical_browser_id = ${canonicalBrowser('focus_events.app_bundle_id')}
+            AND focus_events.ts_ms >= purge_site_pages.started_at
+            AND focus_events.ts_ms < purge_site_pages.ended_at
             AND (
-              title = lower(trim(focus_events.window_title))
-              OR title = lower(trim(focus_events.page_title))
+              ${titleMatches('focus_events.window_title')}
+              OR ${titleMatches('focus_events.page_title')}
             )
         )
       RETURNING ts_ms
@@ -294,10 +366,12 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
         WHERE is_browser = 1
           AND EXISTS (
             SELECT 1 FROM purge_site_pages
-            WHERE bundle_id = lower(derived_sessions.app_bundle_id)
+            WHERE canonical_browser_id = ${canonicalBrowser('derived_sessions.app_bundle_id')}
+              AND derived_sessions.start_ts_ms < purge_site_pages.ended_at
+              AND derived_sessions.end_ts_ms > purge_site_pages.started_at
               AND (
-                title = lower(trim(derived_sessions.window_title))
-                OR title = lower(trim(derived_sessions.page_title))
+                ${titleMatches('derived_sessions.window_title')}
+                OR ${titleMatches('derived_sessions.page_title')}
               )
           )
         RETURNING date
@@ -384,7 +458,10 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
       }
     }
 
-    db.exec('DELETE FROM purge_site_pages')
+    db.exec(`
+      DELETE FROM purge_site_pages;
+      DELETE FROM purge_browser_aliases;
+    `)
   })
   purge()
   if (deletedRows > 0) clearGeneratedActivitySummaries(db)

--- a/tests/trackingExclusionsHistory.test.ts
+++ b/tests/trackingExclusionsHistory.test.ts
@@ -99,7 +99,7 @@ test('excluding a site removes its legacy browser title before projections rebui
     tsMs: start,
     monoNs: start,
     eventType: 'app_activated',
-    windowTitle,
+    windowTitle: null,
     url: null,
     pageTitle: null,
     source: 'nsworkspace_event',
@@ -198,13 +198,14 @@ test('excluding a site redacts a decorated legacy title from raw history, search
   const pageTitle = 'Shared dashboard'
   const windowTitle = `${pageTitle} — Google Chrome`
   const date = '2026-06-21'
-  const start = new Date(2026, 5, 21, 9, 0, 0, 0).getTime()
+  const visitTime = new Date(2026, 5, 21, 9, 0, 0, 0).getTime()
+  const sessionStart = visitTime + 2
   db.prepare(`
     INSERT INTO app_sessions (
       bundle_id, app_name, start_time, end_time, duration_sec, category,
       is_focused, window_title, raw_app_name, capture_source, capture_version
     ) VALUES ('com.google.Chrome', 'Google Chrome', ?, ?, 600, 'browsing', 0, ?, 'Google Chrome', 'test', 1)
-  `).run(start, start + 600_000, windowTitle)
+  `).run(sessionStart, sessionStart + 600_000, windowTitle)
   db.prepare(`
     INSERT INTO website_visits (
       domain, page_title, url, normalized_url, page_key,
@@ -213,9 +214,9 @@ test('excluding a site redacts a decorated legacy title from raw history, search
     ) VALUES (
       'private.example', ?, 'https://private.example/dashboard',
       'https://private.example/dashboard', 'private.example/dashboard',
-      ?, ?, 600, 'com.google.Chrome:Profile 1', 'chrome', 'Profile 1', 'test'
+      ?, ?, 0, 'com.google.Chrome:Profile 1', 'chrome', 'Profile 1', 'test'
     )
-  `).run(pageTitle, start, BigInt(start) * 1_000n)
+  `).run(pageTitle, visitTime, BigInt(visitTime) * 1_000n)
   setTestDb(db)
 
   try {
@@ -252,11 +253,11 @@ test('excluding a site redacts a decorated legacy title from raw history, search
   }
 })
 
-test('excluding a site preserves the same browser title outside the purged page interval', () => {
+test('excluding a site preserves an overlapping same-title session from another browser profile', () => {
   const db = createProductionTestDatabase()
   const title = 'Dashboard'
   const excludedStart = new Date(2026, 5, 22, 9, 0, 0, 0).getTime()
-  const safeStart = excludedStart + 60 * 60_000
+  const safeStart = excludedStart + 5 * 60_000
   const insertSession = db.prepare(`
     INSERT INTO app_sessions (
       bundle_id, app_name, start_time, end_time, duration_sec, category,
@@ -321,36 +322,77 @@ test('excluding a site preserves the same browser title outside the purged page 
   }
 })
 
-test('excluding a Safari site redacts URL-less focus titles through canonical identity', () => {
+test('excluding a site redacts same-page URL-less focus events until the next browser boundary', () => {
   const db = createProductionTestDatabase()
   const title = 'Travel plan'
   const start = new Date(2026, 5, 23, 11, 0, 0, 0).getTime()
-  db.prepare(`
-    INSERT INTO website_visits (
-      domain, page_title, url, normalized_url, page_key,
-      visit_time, visit_time_us, duration_sec, browser_bundle_id,
-      canonical_browser_id, browser_profile_id, source
-    ) VALUES (
-      'private.example', ?, 'https://private.example/travel',
-      'https://private.example/travel', 'private.example/travel',
-      ?, ?, 600, '/Applications/Safari.app/Contents/MacOS/Safari', 'safari', 'default', 'test'
-    )
-  `).run(title, start, BigInt(start) * 1_000n)
-  db.prepare(`
+  const insertFocusEvent = db.prepare(`
     INSERT INTO focus_events (
       ts_ms, mono_ns, event_type, app_bundle_id, app_name, pid,
       window_title, url, page_title, source, confidence, platform, schema_ver
-    ) VALUES (?, ?, 'app_activated', 'com.apple.Safari', 'Safari', 7,
-      ?, NULL, NULL, 'nsworkspace_event', 'observed', 'darwin', 2)
-  `).run(start + 1_000, start + 1_000, title)
+    ) VALUES (
+      @tsMs, @tsMs, @eventType, @bundleId, 'Safari', 7,
+      @windowTitle, @url, @pageTitle, @source, 'observed', 'darwin', 2
+    )
+  `)
+  insertFocusEvent.run({
+    tsMs: start,
+    eventType: 'tab_changed',
+    bundleId: 'safari',
+    windowTitle: title,
+    url: 'https://private.example/travel',
+    pageTitle: title,
+    source: 'apple_events_tab',
+  })
+  insertFocusEvent.run({
+    tsMs: start + 1_000,
+    eventType: 'window_changed',
+    bundleId: 'com.apple.Safari',
+    windowTitle: title,
+    url: null,
+    pageTitle: null,
+    source: 'nsworkspace_event',
+  })
+  insertFocusEvent.run({
+    tsMs: start + 2_000,
+    eventType: 'window_changed',
+    bundleId: 'com.apple.Safari',
+    windowTitle: title,
+    url: null,
+    pageTitle: null,
+    source: 'nsworkspace_event',
+  })
+  insertFocusEvent.run({
+    tsMs: start + 3_000,
+    eventType: 'tab_changed',
+    bundleId: 'safari',
+    windowTitle: 'Safe dashboard',
+    url: 'https://safe.example/dashboard',
+    pageTitle: 'Safe dashboard',
+    source: 'apple_events_tab',
+  })
+  insertFocusEvent.run({
+    tsMs: start + 4_000,
+    eventType: 'window_changed',
+    bundleId: 'com.apple.Safari',
+    windowTitle: title,
+    url: null,
+    pageTitle: null,
+    source: 'nsworkspace_event',
+  })
   setTestDb(db)
 
   try {
     deleteHistoryForSite({ domain: 'private.example' })
 
     assert.deepEqual(db.prepare(`
-      SELECT window_title, page_title, url FROM focus_events
-    `).get(), { window_title: null, page_title: null, url: null })
+      SELECT ts_ms, window_title, url FROM focus_events ORDER BY ts_ms
+    `).all(), [
+      { ts_ms: start + 1_000, window_title: null, url: null },
+      { ts_ms: start + 2_000, window_title: null, url: null },
+      { ts_ms: start + 3_000, window_title: 'Safe dashboard', url: 'https://safe.example/dashboard' },
+      { ts_ms: start + 4_000, window_title: title, url: null },
+    ])
   } finally {
     clearTestDb()
     db.close()

--- a/tests/trackingExclusionsHistory.test.ts
+++ b/tests/trackingExclusionsHistory.test.ts
@@ -141,7 +141,7 @@ test('excluding a site removes its legacy browser title before projections rebui
       'https://old-forum.example/thread/1', 'old-forum.example/thread/1',
       ?, ?, 1190, 'app.zen-browser.zen:default', 'zen', 'default', 'test'
     )
-  `).run(pageTitle, start + 10_000, BigInt(start + 10_000) * 1_000n)
+  `).run(pageTitle, start, BigInt(start) * 1_000n)
   setTestDb(db)
 
   try {
@@ -187,6 +187,170 @@ test('excluding a site removes its legacy browser title before projections rebui
       SELECT COUNT(*) AS count FROM timeline_blocks
       WHERE label_current = ? OR evidence_summary_json LIKE ?
     `).get(pageTitle, `%${pageTitle}%`) as { count: number }).count, 0)
+  } finally {
+    clearTestDb()
+    db.close()
+  }
+})
+
+test('excluding a site redacts a decorated legacy title from raw history, search, and a cold rebuild', () => {
+  const db = createProductionTestDatabase()
+  const pageTitle = 'Shared dashboard'
+  const windowTitle = `${pageTitle} — Google Chrome`
+  const date = '2026-06-21'
+  const start = new Date(2026, 5, 21, 9, 0, 0, 0).getTime()
+  db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec, category,
+      is_focused, window_title, raw_app_name, capture_source, capture_version
+    ) VALUES ('com.google.Chrome', 'Google Chrome', ?, ?, 600, 'browsing', 0, ?, 'Google Chrome', 'test', 1)
+  `).run(start, start + 600_000, windowTitle)
+  db.prepare(`
+    INSERT INTO website_visits (
+      domain, page_title, url, normalized_url, page_key,
+      visit_time, visit_time_us, duration_sec, browser_bundle_id,
+      canonical_browser_id, browser_profile_id, source
+    ) VALUES (
+      'private.example', ?, 'https://private.example/dashboard',
+      'https://private.example/dashboard', 'private.example/dashboard',
+      ?, ?, 600, 'com.google.Chrome:Profile 1', 'chrome', 'Profile 1', 'test'
+    )
+  `).run(pageTitle, start, BigInt(start) * 1_000n)
+  setTestDb(db)
+
+  try {
+    assert.equal((db.prepare(`
+      SELECT COUNT(*) AS count FROM app_sessions_fts WHERE app_sessions_fts MATCH ?
+    `).get(`"${pageTitle}"`) as { count: number }).count, 1)
+
+    deleteHistoryForSite({ domain: 'private.example' })
+
+    assert.equal((db.prepare(`
+      SELECT COUNT(*) AS count FROM app_sessions WHERE window_title = ?
+    `).get(windowTitle) as { count: number }).count, 0)
+    assert.equal((db.prepare(`
+      SELECT COUNT(*) AS count FROM app_sessions_fts WHERE app_sessions_fts MATCH ?
+    `).get(`"${pageTitle}"`) as { count: number }).count, 0)
+
+    db.prepare(`DELETE FROM timeline_block_members WHERE block_id IN (
+      SELECT id FROM timeline_blocks WHERE date = ?
+    )`).run(date)
+    db.prepare('DELETE FROM timeline_blocks WHERE date = ?').run(date)
+    db.prepare(`DELETE FROM derived_block_sessions WHERE block_id IN (
+      SELECT id FROM derived_blocks WHERE date = ?
+    )`).run(date)
+    db.prepare('DELETE FROM derived_blocks WHERE date = ?').run(date)
+    db.prepare('DELETE FROM derived_sessions WHERE date = ?').run(date)
+
+    projectDay(db, date, { finalize: true })
+    const rebuilt = materializeTimelineDayProjection(db, date, null)
+    assert.equal(JSON.stringify(rebuilt).includes(pageTitle), false)
+    assert.equal(JSON.stringify(rebuilt).includes(windowTitle), false)
+  } finally {
+    clearTestDb()
+    db.close()
+  }
+})
+
+test('excluding a site preserves the same browser title outside the purged page interval', () => {
+  const db = createProductionTestDatabase()
+  const title = 'Dashboard'
+  const excludedStart = new Date(2026, 5, 22, 9, 0, 0, 0).getTime()
+  const safeStart = excludedStart + 60 * 60_000
+  const insertSession = db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec, category,
+      is_focused, window_title, raw_app_name, canonical_app_id, app_instance_id,
+      capture_source, capture_version
+    ) VALUES (
+      'com.google.Chrome', 'Google Chrome', @start, @end, 600, 'browsing',
+      0, @title, 'Google Chrome', 'chrome', @profile, 'test', 2
+    )
+  `)
+  insertSession.run({ start: excludedStart, end: excludedStart + 600_000, title, profile: 'com.google.Chrome:Profile 1' })
+  insertSession.run({ start: safeStart, end: safeStart + 600_000, title, profile: 'com.google.Chrome:Profile 2' })
+  const insertVisit = db.prepare(`
+    INSERT INTO website_visits (
+      domain, page_title, url, normalized_url, page_key,
+      visit_time, visit_time_us, duration_sec, browser_bundle_id,
+      canonical_browser_id, browser_profile_id, source
+    ) VALUES (
+      @domain, @title, @url, @url, @url, @start, @startUs, 600,
+      @browserBundleId, 'chrome', @profile, 'test'
+    )
+  `)
+  insertVisit.run({
+    domain: 'private.example',
+    title,
+    url: 'https://private.example/dashboard',
+    start: excludedStart,
+    startUs: BigInt(excludedStart) * 1_000n,
+    browserBundleId: 'com.google.Chrome:Profile 1',
+    profile: 'Profile 1',
+  })
+  insertVisit.run({
+    domain: 'safe.example',
+    title,
+    url: 'https://safe.example/dashboard',
+    start: safeStart,
+    startUs: BigInt(safeStart) * 1_000n,
+    browserBundleId: 'com.google.Chrome:Profile 2',
+    profile: 'Profile 2',
+  })
+  setTestDb(db)
+
+  try {
+    deleteHistoryForSite({ domain: 'private.example' })
+
+    const sessions = db.prepare(`
+      SELECT start_time, window_title FROM app_sessions ORDER BY start_time
+    `).all() as Array<{ start_time: number; window_title: string | null }>
+    assert.deepEqual(sessions, [
+      { start_time: excludedStart, window_title: null },
+      { start_time: safeStart, window_title: title },
+    ])
+    assert.deepEqual(db.prepare(`
+      SELECT domain, page_title FROM website_visits ORDER BY visit_time
+    `).all(), [{ domain: 'safe.example', page_title: title }])
+    assert.equal((db.prepare(`
+      SELECT COUNT(*) AS count FROM app_sessions_fts WHERE app_sessions_fts MATCH ?
+    `).get(title) as { count: number }).count, 1)
+  } finally {
+    clearTestDb()
+    db.close()
+  }
+})
+
+test('excluding a Safari site redacts URL-less focus titles through canonical identity', () => {
+  const db = createProductionTestDatabase()
+  const title = 'Travel plan'
+  const start = new Date(2026, 5, 23, 11, 0, 0, 0).getTime()
+  db.prepare(`
+    INSERT INTO website_visits (
+      domain, page_title, url, normalized_url, page_key,
+      visit_time, visit_time_us, duration_sec, browser_bundle_id,
+      canonical_browser_id, browser_profile_id, source
+    ) VALUES (
+      'private.example', ?, 'https://private.example/travel',
+      'https://private.example/travel', 'private.example/travel',
+      ?, ?, 600, '/Applications/Safari.app/Contents/MacOS/Safari', 'safari', 'default', 'test'
+    )
+  `).run(title, start, BigInt(start) * 1_000n)
+  db.prepare(`
+    INSERT INTO focus_events (
+      ts_ms, mono_ns, event_type, app_bundle_id, app_name, pid,
+      window_title, url, page_title, source, confidence, platform, schema_ver
+    ) VALUES (?, ?, 'app_activated', 'com.apple.Safari', 'Safari', 7,
+      ?, NULL, NULL, 'nsworkspace_event', 'observed', 'darwin', 2)
+  `).run(start + 1_000, start + 1_000, title)
+  setTestDb(db)
+
+  try {
+    deleteHistoryForSite({ domain: 'private.example' })
+
+    assert.deepEqual(db.prepare(`
+      SELECT window_title, page_title, url FROM focus_events
+    `).get(), { window_title: null, page_title: null, url: null })
   } finally {
     clearTestDb()
     db.close()

--- a/tests/trackingExclusionsHistory.test.ts
+++ b/tests/trackingExclusionsHistory.test.ts
@@ -11,6 +11,8 @@ import {
   deleteHistoryForSite,
   deleteTrackedActivity,
 } from '../src/main/services/trackingHistory.ts'
+import { projectDay } from '../src/main/core/projections/chunk2.ts'
+import { materializeTimelineDayProjection } from '../src/main/core/query/projections.ts'
 
 function seed(db: Database.Database): void {
   const start = new Date(2026, 5, 18, 10, 0, 0, 0).getTime()
@@ -66,6 +68,125 @@ test('excluding a site removes old URL evidence from history and projections', (
     assert.equal((db.prepare(`SELECT COUNT(*) AS count FROM website_visits`).get() as { count: number }).count, 0)
     assert.equal((db.prepare(`SELECT COUNT(*) AS count FROM focus_events`).get() as { count: number }).count, 0)
     assert.equal((db.prepare(`SELECT COUNT(*) AS count FROM app_sessions`).get() as { count: number }).count, 1)
+  } finally {
+    clearTestDb()
+    db.close()
+  }
+})
+
+test('excluding a site removes its legacy browser title before projections rebuild', () => {
+  const db = createProductionTestDatabase()
+  const pageTitle = 'Legacy forum thread'
+  const windowTitle = `${pageTitle} — Zen`
+  const date = '2026-06-19'
+  const start = new Date(2026, 5, 19, 10, 0, 0, 0).getTime()
+  db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec, category,
+      is_focused, window_title, raw_app_name, capture_source, capture_version
+    ) VALUES ('app.zen-browser.zen', 'Zen', ?, ?, 1200, 'browsing', 0, ?, 'Zen', 'test', 2)
+  `).run(start, start + 20 * 60_000, windowTitle)
+  const insertFocusEvent = db.prepare(`
+    INSERT INTO focus_events (
+      ts_ms, mono_ns, event_type, app_bundle_id, app_name, pid,
+      window_title, url, page_title, source, confidence, platform, schema_ver
+    ) VALUES (
+      @tsMs, @monoNs, @eventType, 'app.zen-browser.zen', 'Zen', 42,
+      @windowTitle, @url, @pageTitle, @source, 'observed', 'darwin', 2
+    )
+  `)
+  insertFocusEvent.run({
+    tsMs: start,
+    monoNs: start,
+    eventType: 'app_activated',
+    windowTitle,
+    url: null,
+    pageTitle: null,
+    source: 'nsworkspace_event',
+  })
+  insertFocusEvent.run({
+    tsMs: start + 10_000,
+    monoNs: start + 10_000,
+    eventType: 'tab_changed',
+    windowTitle,
+    url: 'https://old-forum.example/thread/1',
+    pageTitle,
+    source: 'apple_events_tab',
+  })
+  insertFocusEvent.run({
+    tsMs: start + 20_000,
+    monoNs: start + 20_000,
+    eventType: 'window_changed',
+    windowTitle,
+    url: null,
+    pageTitle: null,
+    source: 'nsworkspace_event',
+  })
+  insertFocusEvent.run({
+    tsMs: start + 20 * 60_000,
+    monoNs: start + 20 * 60_000,
+    eventType: 'app_deactivated',
+    windowTitle: null,
+    url: null,
+    pageTitle: null,
+    source: 'nsworkspace_event',
+  })
+  db.prepare(`
+    INSERT INTO website_visits (
+      domain, page_title, url, normalized_url, page_key,
+      visit_time, visit_time_us, duration_sec, browser_bundle_id,
+      canonical_browser_id, browser_profile_id, source
+    ) VALUES (
+      'old-forum.example', ?, 'https://old-forum.example/thread/1',
+      'https://old-forum.example/thread/1', 'old-forum.example/thread/1',
+      ?, ?, 1190, 'app.zen-browser.zen:default', 'zen', 'default', 'test'
+    )
+  `).run(pageTitle, start + 10_000, BigInt(start + 10_000) * 1_000n)
+  setTestDb(db)
+
+  try {
+    projectDay(db, date, { finalize: true })
+    materializeTimelineDayProjection(db, date, null)
+    assert.equal((db.prepare(`
+      SELECT COUNT(*) AS count FROM derived_blocks WHERE label = ?
+    `).get(pageTitle) as { count: number }).count, 1)
+
+    const result = deleteHistoryForSite({ domain: 'old-forum.example' })
+    assert.ok(result.deletedRows >= 4)
+
+    const evidenceAndDerivedTables = [
+      'app_sessions',
+      'focus_events',
+      'website_visits',
+      'activity_segments',
+      'derived_sessions',
+      'derived_blocks',
+      'timeline_blocks',
+    ]
+    for (const residueTitle of [pageTitle, windowTitle]) {
+      for (const table of evidenceAndDerivedTables) {
+        const columns = db.prepare(`PRAGMA table_info("${table}")`).all() as Array<{ name: string; type: string }>
+        for (const column of columns.filter((entry) => !/INT|REAL|BLOB/i.test(entry.type ?? ''))) {
+          const residue = db.prepare(`
+            SELECT COUNT(*) AS count FROM "${table}"
+            WHERE instr(lower(CAST("${column.name}" AS TEXT)), lower(?)) > 0
+          `).get(residueTitle) as { count: number }
+          assert.equal(residue.count, 0, `${residueTitle} remained in ${table}.${column.name}`)
+        }
+      }
+    }
+
+    projectDay(db, date, { finalize: true })
+    const rebuilt = materializeTimelineDayProjection(db, date, null)
+    assert.equal(JSON.stringify(rebuilt).includes(pageTitle), false)
+    assert.equal(JSON.stringify(rebuilt).includes(windowTitle), false)
+    assert.equal((db.prepare(`
+      SELECT COUNT(*) AS count FROM derived_blocks WHERE label = ?
+    `).get(pageTitle) as { count: number }).count, 0)
+    assert.equal((db.prepare(`
+      SELECT COUNT(*) AS count FROM timeline_blocks
+      WHERE label_current = ? OR evidence_summary_json LIKE ?
+    `).get(pageTitle, `%${pageTitle}%`) as { count: number }).count, 0)
   } finally {
     clearTestDb()
     db.close()


### PR DESCRIPTION
When a site is excluded and its history is purged, remove matching page titles from browser sessions, canonical focus evidence, derived sessions, search indexes, and rebuilt timeline output. Matching is limited to the same canonical browser and overlapping page interval so unrelated pages with the same title are preserved. Includes focused deletion and cold-rebuild regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site history deletion to consistently remove matching page and window titles across browsing history, sessions, focus events, and search results.
  * Preserved matching titles outside the selected site and time range.
  * Fixed deletion handling for legacy titles, decorated titles, and URL-less focus entries.
  * Ensured rebuilt timelines and daily projections no longer include deleted history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->