### PR TITLE
Pin poll focus_events tests to darwin harness (DEV-218)

### DIFF
--- a/tests/incognitoNeverTracked.test.ts
+++ b/tests/incognitoNeverTracked.test.ts
@@ -94,6 +94,9 @@ test('poll: a private window creates no app session and cuts the one before it',
     __setTrackingFsmTestHarness({
       now: () => clock.now,
       idleSeconds: () => Math.max(0, (clock.now - clock.lastInput) / 1_000),
+      // Poll canonical emission is macOS/Windows-only; pin the harness so the
+      // focus_events assertions stay meaningful on the Linux CI runner.
+      platform: 'darwin',
       // The window title changes when the private window takes focus (as it
       // does for a real private window), so the tracker's same-title tab-read
       // cache can't mask the switch.

--- a/tests/trackingSleepGap.test.ts
+++ b/tests/trackingSleepGap.test.ts
@@ -206,8 +206,14 @@ test('normal poll cadence never triggers a gap flush', async () => {
 test('recovered live snapshot splits at local midnight', () => {
   const db = setupDb()
   try {
-    // Reset FSM module state (also clears any live session from prior tests).
-    __setTrackingFsmTestHarness(null)
+    // Pin darwin so recovery's canonical deactivation is emitted on Linux CI
+    // too (poll capture is macOS/Windows-only by contract).
+    __setTrackingFsmTestHarness({
+      now: () => Date.now(),
+      idleSeconds: () => 0,
+      activeWindow: () => null,
+      platform: 'darwin',
+    })
 
     // The real shape: a session opened at 23:57 whose snapshot was last
     // bumped at 03:08 the next day (then the app died). Recovery must persist


### PR DESCRIPTION
## Summary
- Main CI was red after the Wave 1 capture merges: two hermetic tests assert `focus_events` from the poll path, but `recordPollForegroundEvent` no-ops on Linux.
- Pin the tracking FSM harness to `platform: 'darwin'` in those scenarios (same pattern as `captureCanonicalParity` / other capture parity tests) so Linux CI exercises the contract under test.
- Closes DEV-218.

## Test plan
- [x] `node scripts/run-tests.mjs incognitoNeverTracked trackingSleepGap` (9 pass locally)
- [ ] CI `test` job green on Linux runner
- [ ] Remaining CI jobs on the PR stay green


Made with [Cursor](https://cursor.com)