### PR TITLE
Make wrapPreflight staleCapture test clock-stable (DEV-219)

### DIFF
--- a/src/main/services/wrapPreflight.ts
+++ b/src/main/services/wrapPreflight.ts
@@ -31,11 +31,12 @@ export function getWrapPreflight(
   date: string,
   // Injectable clock + boot time so the live-day / boot-gap logic is testable
   // without mocking the global clock. Default to the real values.
-  opts: { bootMs?: number } = {},
+  opts: { bootMs?: number; nowMs?: number } = {},
 ): WrapPreflightResult {
   const warnings: WrapPreflightWarning[] = []
-  const isLiveDay = date === localDateString()
-  const bootMs = opts.bootMs ?? (Date.now() - os.uptime() * 1000)
+  const nowMs = opts.nowMs ?? Date.now()
+  const isLiveDay = date === localDateString(new Date(nowMs))
+  const bootMs = opts.bootMs ?? (nowMs - os.uptime() * 1000)
 
   // Work time from the same trusted blocks every wrap number comes from.
   let workSeconds = 0
@@ -96,7 +97,7 @@ export function getWrapPreflight(
     WHERE start_time >= ? AND start_time < ?
   `).get(fromMs, toMs) as { last: number | null } | undefined
   if (lastRow?.last) {
-    lastActivityAgoMinutes = Math.max(0, Math.round((Date.now() - lastRow.last) / 60_000))
+    lastActivityAgoMinutes = Math.max(0, Math.round((nowMs - lastRow.last) / 60_000))
     if (isLiveDay && lastActivityAgoMinutes > STALE_CAPTURE_MINUTES) {
       warnings.push({
         kind: 'staleCapture',

--- a/tests/wrapPreflight.test.ts
+++ b/tests/wrapPreflight.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import Database from 'better-sqlite3'
 import { createProductionTestDatabase } from './support/testDatabase.ts'
+import { localDateString } from '../src/main/lib/localDate.ts'
 import { getWrapPreflight } from '../src/main/services/wrapPreflight.ts'
 
 // Wrap pre-flight: honest, specific warnings before generation. None block;
@@ -89,12 +90,13 @@ test('staleCapture warns only on the live day', () => {
   const past = getWrapPreflight(db, DATE)
   assert.equal(past.warnings.find((w) => w.kind === 'staleCapture'), undefined)
 
-  // The live day with the last session 3 hours ago must warn.
-  const today = new Date()
-  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
-  const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1000
+  // Pin an afternoon clock so "3 hours ago" stays inside the live local day.
+  // Wall-clock near midnight otherwise seeds yesterday and flakes on CI.
+  const nowMs = new Date(2026, 6, 19, 16, 0, 0, 0).getTime()
+  const todayStr = localDateString(new Date(nowMs))
+  const threeHoursAgo = nowMs - 3 * 60 * 60 * 1000
   seedSessions(db, 3, 1, threeHoursAgo - 40 * 60_000)
-  const live = getWrapPreflight(db, todayStr)
+  const live = getWrapPreflight(db, todayStr, { nowMs })
   const warning = live.warnings.find((w) => w.kind === 'staleCapture')
   assert.ok(warning, 'expected a staleCapture warning on the live day')
   assert.ok(/hours ago/.test(warning!.message))


### PR DESCRIPTION
## Summary
- Main CI failed after DEV-218 on a known midnight flake: `staleCapture warns only on the live day` seeds “3 hours ago” from wall clock, which can land on yesterday.
- Add injectable `nowMs` to `getWrapPreflight` (same pattern as `bootMs`) and pin the test to a fixed afternoon.
- Closes DEV-219.

## Test plan
- [x] `node scripts/run-tests.mjs wrapPreflight` (11 pass)
- [ ] CI `test` job green on Linux


Made with [Cursor](https://cursor.com)