### PR TITLE
Tighten site-purge profile matching (DEV-214 follow-up)

### DIFF
--- a/src/main/services/trackingHistory.ts
+++ b/src/main/services/trackingHistory.ts
@@ -233,6 +233,15 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
       (SELECT canonical_id FROM purge_browser_aliases WHERE alias = lower(${expression})),
       lower(${expression})
     )`
+    // Profile suffixes live on raw browser identities (bundle/instance), not paths.
+    const profileFromBrowserIdentity = (expression: string): string => `lower(nullif(
+      CASE
+        WHEN instr(${expression}, ':') > 0
+          AND ${expression} NOT GLOB '[A-Za-z]:[\\/]*'
+          THEN substr(${expression}, instr(${expression}, ':') + 1)
+      END,
+      ''
+    ))`
 
     const domainCondition = 'lower(domain) = ? OR lower(domain) LIKE ?'
     db.prepare(`
@@ -241,7 +250,12 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
       )
       SELECT lower(trim(page_title)),
         ${canonicalBrowser("coalesce(nullif(canonical_browser_id, ''), browser_bundle_id)")},
-        lower(browser_bundle_id), lower(nullif(browser_profile_id, '')), visit_time
+        lower(browser_bundle_id),
+        coalesce(
+          lower(nullif(browser_profile_id, '')),
+          ${profileFromBrowserIdentity('browser_bundle_id')}
+        ),
+        visit_time
       FROM website_visits
       WHERE (${domainCondition})
         AND page_title IS NOT NULL AND trim(page_title) <> ''
@@ -254,7 +268,7 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
           title, canonical_browser_id, raw_browser_id, profile_id, observed_at
         )
         SELECT lower(trim(${column})), ${canonicalBrowser('app_bundle_id')},
-          lower(app_bundle_id), NULL, ts_ms
+          lower(app_bundle_id), ${profileFromBrowserIdentity('app_bundle_id')}, ts_ms
         FROM focus_events
         WHERE (lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ? OR lower(url) LIKE ?)
           AND ${column} IS NOT NULL AND trim(${column}) <> ''
@@ -343,7 +357,8 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
         AND substr(lower(trim(${column})), length(${pageTable}.title) + 1, 3) IN (' - ', ' — ', ' – ')
       )
     )`
-    const sessionMatchToleranceMs = 5_000
+    // Allow a short start-side poll lag only; never match past session end.
+    const sessionStartToleranceMs = 5_000
     const appSessionEnd = `coalesce(
       app_sessions.end_time,
       app_sessions.start_time + max(app_sessions.duration_sec * 1000, 1)
@@ -360,6 +375,20 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
       END,
       ''
     ))`
+    // Unknown page profile must not wildcard into a profiled browser session.
+    const compatibleAppSessionProfile = `(
+      (
+        purge_site_pages.profile_id IS NULL
+        AND ${appSessionProfile} = ''
+      )
+      OR (
+        purge_site_pages.profile_id IS NOT NULL
+        AND (
+          ${appSessionProfile} = ''
+          OR purge_site_pages.profile_id = ${appSessionProfile}
+        )
+      )
+    )`
     db.prepare(`
       INSERT OR IGNORE INTO purge_app_session_matches (session_id)
       SELECT session_id
@@ -382,8 +411,6 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
               CASE
                 WHEN purge_site_pages.observed_at < app_sessions.start_time
                   THEN app_sessions.start_time - purge_site_pages.observed_at
-                WHEN purge_site_pages.observed_at >= ${appSessionEnd}
-                  THEN purge_site_pages.observed_at - ${appSessionEnd}
                 ELSE 0
               END,
               abs(purge_site_pages.observed_at - app_sessions.start_time),
@@ -397,20 +424,12 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
             lower(nullif(app_sessions.canonical_app_id, '')),
             ${canonicalBrowser('app_sessions.bundle_id')}
           )
-          AND (
-            purge_site_pages.profile_id IS NULL
-            OR ${appSessionProfile} = ''
-            OR purge_site_pages.profile_id = ${appSessionProfile}
-            OR purge_site_pages.raw_browser_id IN (
-              lower(app_sessions.bundle_id),
-              lower(coalesce(app_sessions.app_instance_id, ''))
-            )
-          )
+          AND ${compatibleAppSessionProfile}
           AND purge_site_pages.observed_at >= app_sessions.start_time - ?
-          AND purge_site_pages.observed_at <= ${appSessionEnd} + ?
+          AND purge_site_pages.observed_at < ${appSessionEnd}
       )
       WHERE candidate_rank = 1
-    `).run(sessionMatchToleranceMs, sessionMatchToleranceMs)
+    `).run(sessionStartToleranceMs)
     const appTitleRows = db.prepare(`
       UPDATE app_sessions
       SET window_title = NULL
@@ -453,6 +472,19 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
         END,
         ''
       ))`
+      const compatibleDerivedSessionProfile = `(
+        (
+          purge_site_pages.profile_id IS NULL
+          AND ${derivedSessionProfile} = ''
+        )
+        OR (
+          purge_site_pages.profile_id IS NOT NULL
+          AND (
+            ${derivedSessionProfile} = ''
+            OR purge_site_pages.profile_id = ${derivedSessionProfile}
+          )
+        )
+      )`
       db.prepare(`
         INSERT OR IGNORE INTO purge_derived_session_matches (session_id)
         SELECT session_id
@@ -472,8 +504,6 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
                 CASE
                   WHEN purge_site_pages.observed_at < derived_sessions.start_ts_ms
                     THEN derived_sessions.start_ts_ms - purge_site_pages.observed_at
-                  WHEN purge_site_pages.observed_at >= ${derivedSessionEnd}
-                    THEN purge_site_pages.observed_at - ${derivedSessionEnd}
                   ELSE 0
                 END,
                 abs(purge_site_pages.observed_at - derived_sessions.start_ts_ms),
@@ -488,17 +518,12 @@ export function deleteHistoryForSite(input: { domain: string }): PurgeResult {
             )
             AND purge_site_pages.canonical_browser_id
               = ${canonicalBrowser('derived_sessions.app_bundle_id')}
-            AND (
-              purge_site_pages.profile_id IS NULL
-              OR ${derivedSessionProfile} = ''
-              OR purge_site_pages.profile_id = ${derivedSessionProfile}
-              OR purge_site_pages.raw_browser_id = lower(derived_sessions.app_bundle_id)
-            )
+            AND ${compatibleDerivedSessionProfile}
             AND purge_site_pages.observed_at >= derived_sessions.start_ts_ms - ?
-            AND purge_site_pages.observed_at <= ${derivedSessionEnd} + ?
+            AND purge_site_pages.observed_at < ${derivedSessionEnd}
         )
         WHERE candidate_rank = 1
-      `).run(sessionMatchToleranceMs, sessionMatchToleranceMs)
+      `).run(sessionStartToleranceMs)
       const derivedTitleRows = db.prepare(`
         UPDATE derived_sessions
         SET window_title = NULL, page_title = NULL

--- a/tests/trackingExclusionsHistory.test.ts
+++ b/tests/trackingExclusionsHistory.test.ts
@@ -452,3 +452,131 @@ test('deleting a page removes every visit and clears generated recaps', () => {
     db.close()
   }
 })
+
+test('focus-sourced purge keys honor Chrome profile suffixes', () => {
+  const db = createProductionTestDatabase()
+  const title = 'Dashboard'
+  const excludedStart = new Date(2026, 5, 24, 9, 0, 0, 0).getTime()
+  const safeStart = excludedStart + 5 * 60_000
+  const insertSession = db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec, category,
+      is_focused, window_title, raw_app_name, canonical_app_id, app_instance_id,
+      capture_source, capture_version
+    ) VALUES (
+      'com.google.Chrome', 'Google Chrome', @start, @end, 600, 'browsing',
+      0, @title, 'Google Chrome', 'chrome', @profile, 'test', 2
+    )
+  `)
+  insertSession.run({
+    start: excludedStart,
+    end: excludedStart + 600_000,
+    title,
+    profile: 'com.google.Chrome:Profile 1',
+  })
+  insertSession.run({
+    start: safeStart,
+    end: safeStart + 600_000,
+    title,
+    profile: 'com.google.Chrome:Profile 2',
+  })
+  db.prepare(`
+    INSERT INTO focus_events (
+      ts_ms, mono_ns, event_type, app_bundle_id, app_name, pid,
+      window_title, url, page_title, source, confidence, platform, schema_ver
+    ) VALUES (?, ?, 'tab_changed', 'com.google.Chrome:Profile 1', 'Google Chrome', 11,
+      ?, 'https://private.example/dashboard', ?, 'apple_events_tab', 'observed', 'darwin', 2)
+  `).run(excludedStart, excludedStart, title, title)
+  setTestDb(db)
+
+  try {
+    deleteHistoryForSite({ domain: 'private.example' })
+
+    const sessions = db.prepare(`
+      SELECT start_time, window_title FROM app_sessions ORDER BY start_time
+    `).all() as Array<{ start_time: number; window_title: string | null }>
+    assert.deepEqual(sessions, [
+      { start_time: excludedStart, window_title: null },
+      { start_time: safeStart, window_title: title },
+    ])
+  } finally {
+    clearTestDb()
+    db.close()
+  }
+})
+
+test('unprofiled focus purge keys do not wildcard into profiled sessions', () => {
+  const db = createProductionTestDatabase()
+  const title = 'Dashboard'
+  const excludedStart = new Date(2026, 5, 25, 10, 0, 0, 0).getTime()
+  const profiledStart = excludedStart + 2_000
+  db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec, category,
+      is_focused, window_title, raw_app_name, canonical_app_id, app_instance_id,
+      capture_source, capture_version
+    ) VALUES (
+      'com.google.Chrome', 'Google Chrome', ?, ?, 600, 'browsing',
+      0, ?, 'Google Chrome', 'chrome', 'com.google.Chrome:Profile 2', 'test', 2
+    )
+  `).run(profiledStart, profiledStart + 600_000, title)
+  db.prepare(`
+    INSERT INTO focus_events (
+      ts_ms, mono_ns, event_type, app_bundle_id, app_name, pid,
+      window_title, url, page_title, source, confidence, platform, schema_ver
+    ) VALUES (?, ?, 'tab_changed', 'com.google.Chrome', 'Google Chrome', 12,
+      ?, 'https://private.example/dashboard', ?, 'apple_events_tab', 'observed', 'darwin', 2)
+  `).run(excludedStart, excludedStart, title, title)
+  setTestDb(db)
+
+  try {
+    deleteHistoryForSite({ domain: 'private.example' })
+
+    assert.equal((db.prepare(`
+      SELECT window_title FROM app_sessions
+    `).get() as { window_title: string | null }).window_title, title)
+  } finally {
+    clearTestDb()
+    db.close()
+  }
+})
+
+test('start-side poll lag does not redact a later same-title session past the page end', () => {
+  const db = createProductionTestDatabase()
+  const title = 'Dashboard'
+  const pageStart = new Date(2026, 5, 26, 14, 0, 0, 0).getTime()
+  const laterSessionStart = pageStart + 8_000
+  db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec, category,
+      is_focused, window_title, raw_app_name, canonical_app_id, app_instance_id,
+      capture_source, capture_version
+    ) VALUES (
+      'com.google.Chrome', 'Google Chrome', ?, ?, 600, 'browsing',
+      0, ?, 'Google Chrome', 'chrome', 'com.google.Chrome:Profile 1', 'test', 2
+    )
+  `).run(laterSessionStart, laterSessionStart + 600_000, title)
+  db.prepare(`
+    INSERT INTO website_visits (
+      domain, page_title, url, normalized_url, page_key,
+      visit_time, visit_time_us, duration_sec, browser_bundle_id,
+      canonical_browser_id, browser_profile_id, source
+    ) VALUES (
+      'private.example', ?, 'https://private.example/dashboard',
+      'https://private.example/dashboard', 'https://private.example/dashboard',
+      ?, ?, 0, 'com.google.Chrome:Profile 1', 'chrome', 'Profile 1', 'test'
+    )
+  `).run(title, pageStart, BigInt(pageStart) * 1_000n)
+  setTestDb(db)
+
+  try {
+    deleteHistoryForSite({ domain: 'private.example' })
+
+    assert.equal((db.prepare(`
+      SELECT window_title FROM app_sessions
+    `).get() as { window_title: string | null }).window_title, title)
+  } finally {
+    clearTestDb()
+    db.close()
+  }
+})


### PR DESCRIPTION
## Summary
- Parse browser profile suffixes when seeding purge keys from `focus_events`
- Stop treating a NULL page profile as a wildcard against profiled Chrome sessions
- Keep only start-side poll lag (no end-side 5s window) so a later same-title session is not redacted

## Test plan
- [x] `npm test -- trackingExclusionsHistory` (10 pass, including three new regressions)
- [x] `npm run typecheck`
- [x] eslint on touched files

Closes nothing new; follow-up hardening for DEV-214 after adversarial review.


Made with [Cursor](https://cursor.com)