### PR TITLE
Capture is on from install — remove the consent gate from onboarding

### DIFF
--- a/src/main/services/onboarding.ts
+++ b/src/main/services/onboarding.ts
@@ -4,11 +4,6 @@ import { grantedCaptureConsent, isCaptureConsentCurrent, type CaptureConsentStat
 import { getTrackingPermissionState } from './trackingPermissions'
 import { getSettingsAsync, setSettings } from './settings'
 
-// Stages at or before the point where the flow explains what Daylens captures.
-// Anyone who advanced past these under the pre-consent-state flow already
-// agreed to capture there — the recorded state just didn't exist yet.
-const PRE_CONSENT_STAGES: ReadonlySet<OnboardingStage> = new Set(['welcome', 'why'])
-
 function nextProofState(stage: OnboardingStage, current: ProofState): ProofState {
   if (stage === 'complete') return 'ready'
   if (stage === 'proof') return current === 'ready' ? 'ready' : 'collecting'
@@ -20,28 +15,17 @@ export async function reconcileOnboardingState(): Promise<AppSettings> {
   let changed = false
   const onboardingState = { ...settings.onboardingState }
 
-  // Grandfather installs that predate the recorded consent state: completing
-  // (or advancing past the capture explainer of) the old flow WAS the consent
-  // act, so record it rather than silently stopping their capture on update.
-  // Never overwrite an explicit decision — only 'unset' is reconciled.
+  // Installing is consent: capture is on from first launch, so 'unset' and
+  // stale-policy grants both reconcile to granted at the current policy
+  // version. Only an explicit decline (legacy installs; recoverable in
+  // Settings) is preserved.
   let captureConsent: CaptureConsentState = settings.captureConsent
-  const requiresCaptureReconsent = captureConsent.status === 'granted'
-    && !isCaptureConsentCurrent(captureConsent)
-  if (requiresCaptureReconsent) {
-    onboardingState.stage = 'why'
-    onboardingState.completedAt = null
-    onboardingState.proofState = 'idle'
-    changed = true
-  }
-  if (
-    captureConsent.status === 'unset'
-    && (settings.onboardingComplete || !PRE_CONSENT_STAGES.has(onboardingState.stage))
-  ) {
+  if (captureConsent.status !== 'declined' && !isCaptureConsentCurrent(captureConsent)) {
     captureConsent = grantedCaptureConsent(Date.now())
     changed = true
   }
 
-  if (settings.onboardingComplete && onboardingState.stage !== 'complete' && !requiresCaptureReconsent) {
+  if (settings.onboardingComplete && onboardingState.stage !== 'complete') {
     onboardingState.stage = 'complete'
     onboardingState.completedAt = onboardingState.completedAt ?? Date.now()
     onboardingState.proofState = 'ready'
@@ -49,7 +33,7 @@ export async function reconcileOnboardingState(): Promise<AppSettings> {
     changed = true
   }
 
-  if (process.platform === 'darwin' && onboardingState.stage !== 'complete' && !requiresCaptureReconsent) {
+  if (process.platform === 'darwin' && onboardingState.stage !== 'complete') {
     const permissionState = getTrackingPermissionState()
     if (onboardingState.trackingPermissionState !== permissionState) {
       onboardingState.trackingPermissionState = permissionState
@@ -74,7 +58,7 @@ export async function reconcileOnboardingState(): Promise<AppSettings> {
       onboardingState.proofState = 'idle'
       changed = true
     }
-  } else if (process.platform !== 'darwin' && onboardingState.stage !== 'complete' && !requiresCaptureReconsent) {
+  } else if (process.platform !== 'darwin' && onboardingState.stage !== 'complete') {
     const permissionState = getTrackingPermissionState()
     if (onboardingState.trackingPermissionState !== permissionState) {
       onboardingState.trackingPermissionState = permissionState

--- a/src/renderer/views/Onboarding.tsx
+++ b/src/renderer/views/Onboarding.tsx
@@ -1294,7 +1294,8 @@ export default function Onboarding({
     }
   }
 
-  // Explicit consent records the gate before platform permission and live proof.
+  // Capture is on from install; this just re-records the grant so legacy
+  // declined/stale states heal when someone walks the flow again.
   async function consentAndLeaveWhy() {
     try {
       await ipc.app.setCaptureConsent(true)
@@ -1309,7 +1310,6 @@ export default function Onboarding({
 
   async function skipWhy() {
     try {
-      await ipc.app.setCaptureConsent(false)
       await persistOnboarding('tour', { proofState: 'idle' })
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : String(error))
@@ -1569,14 +1569,14 @@ export default function Onboarding({
             {...railProps}
             expression="curious"
             eyebrow={eyebrow}
-            title="Before Daylens starts watching"
-            subtitle="Capture begins only after you agree. Here is exactly what that means."
+            title="What Daylens captures"
+            subtitle="Capture is on from the start. Here is exactly what that means."
             contentKey="consent"
-            primary={{ label: 'I agree — start capture', onClick: () => void consentAndLeaveWhy(), disabled: busy }}
-            skip={{ label: 'Not now', onClick: () => void skipWhy() }}
+            primary={{ label: 'Continue', onClick: () => void consentAndLeaveWhy(), disabled: busy }}
+            skip={{ label: 'Skip setup', onClick: () => void skipWhy() }}
           >
             <ConsentPanel />
-            <p className="ob-reassure">Declining leaves Daylens open with capture off. You can allow capture later in Settings.</p>
+            <p className="ob-reassure">You can pause capture or exclude apps and sites anytime in Settings.</p>
           </Stage>
         )
 

--- a/tests/captureConsentGate.test.ts
+++ b/tests/captureConsentGate.test.ts
@@ -220,7 +220,7 @@ test('completed installs are grandfathered to granted consent on upgrade', async
   __resetSettings()
 })
 
-test('a fresh install at the capture explainer stays unset — capture stays off', async () => {
+test('a fresh install is granted consent at first reconcile — install is consent', async () => {
   __resetSettings()
   __setSettings({
     onboardingComplete: false,
@@ -230,7 +230,8 @@ test('a fresh install at the capture explainer stays unset — capture stays off
 
   const settings = await reconcileOnboardingState()
 
-  assert.equal(settings.captureConsent.status, 'unset')
+  assert.equal(settings.captureConsent.status, 'granted')
+  assert.equal(settings.captureConsent.policyVersion, CAPTURE_POLICY_VERSION)
   __resetSettings()
 })
 
@@ -248,7 +249,7 @@ test('an explicit decline is never overwritten by reconciliation', async () => {
   __resetSettings()
 })
 
-test('a stale grant reopens onboarding at the consent explainer', async () => {
+test('a stale grant silently re-grants at the current policy version', async () => {
   __resetSettings()
   __setSettings({
     onboardingComplete: true,
@@ -258,20 +259,21 @@ test('a stale grant reopens onboarding at the consent explainer', async () => {
 
   const settings = await reconcileOnboardingState()
 
-  assert.equal(settings.onboardingComplete, false)
-  assert.equal(settings.onboardingState.stage, 'why')
-  assert.deepEqual(settings.captureConsent, STALE_GRANT)
+  assert.equal(settings.onboardingComplete, true)
+  assert.equal(settings.onboardingState.stage, 'complete')
+  assert.equal(settings.captureConsent.status, 'granted')
+  assert.equal(settings.captureConsent.policyVersion, CAPTURE_POLICY_VERSION)
   __resetSettings()
 })
 
-test('skipping capture declines consent and bypasses the proof gate', () => {
+test('skipping setup bypasses proof without touching the consent state', () => {
   const onboardingSource = fs.readFileSync(
     new URL('../src/renderer/views/Onboarding.tsx', import.meta.url),
     'utf8',
   )
   assert.match(
     onboardingSource,
-    /async function skipWhy\(\)[\s\S]*?setCaptureConsent\(false\)[\s\S]*?persistOnboarding\('tour', \{ proofState: 'idle' \}\)/,
+    /async function skipWhy\(\)[\s\S]*?persistOnboarding\('tour', \{ proofState: 'idle' \}\)/,
   )
 })
 
@@ -301,7 +303,7 @@ test('runtime wiring keeps non-capture services alive and history behind consent
   assert.match(indexSource, /function startBackgroundServices\(\)[\s\S]*startSync\(\)[\s\S]*startCaptureServices\(\)/)
 
   const skipWhy = onboardingSource.split('async function skipWhy()')[1]?.split('async function continueFromProof')[0] ?? ''
-  assert.ok(skipWhy.includes('setCaptureConsent(false)'))
+  assert.ok(!skipWhy.includes('setCaptureConsent'))
   assert.ok(skipWhy.includes("persistOnboarding('tour'"))
 
   assert.match(browserSource, /Math\.max\(cursorMs, consentFloorMs\(\)\)/)

--- a/tests/onboardingConsentFlow.test.ts
+++ b/tests/onboardingConsentFlow.test.ts
@@ -12,12 +12,12 @@ const reconcileSource = fs.readFileSync(
   'utf8',
 )
 
-test('onboarding flow orders consent, permission, proof, then privacy', () => {
+test('onboarding flow orders capture explainer, permission, proof, then privacy', () => {
   assert.match(
     onboardingSource,
     /const STAGE_FLOW: OnboardingStage\[\] = \[[\s\S]*?'why', 'permission', 'proof', 'privacy'/,
   )
-  assert.match(onboardingSource, /I agree — start capture/)
+  assert.match(onboardingSource, /Capture is on from the start/)
   assert.match(onboardingSource, /What Daylens captures/)
   assert.match(onboardingSource, /What it never captures/)
   assert.match(onboardingSource, /PROOF_TIMEOUT_MS/)
@@ -50,11 +50,13 @@ test('proof continue goes to privacy and exclusions persist immediately', () => 
   )
 })
 
-test('declining consent still bypasses proof with capture off', () => {
+test('skipping setup never declines capture — it only shortcuts the flow', () => {
   assert.match(
     onboardingSource,
-    /async function skipWhy\(\)[\s\S]*?setCaptureConsent\(false\)[\s\S]*?persistOnboarding\('tour', \{ proofState: 'idle' \}\)/,
+    /async function skipWhy\(\)[\s\S]*?persistOnboarding\('tour', \{ proofState: 'idle' \}\)/,
   )
+  const skipWhy = onboardingSource.split('async function skipWhy()')[1]?.split('async function continueFromProof')[0] ?? ''
+  assert.ok(!skipWhy.includes('setCaptureConsent'))
 })
 
 test('non-mac reconcile syncs helper or session support instead of forcing granted', () => {


### PR DESCRIPTION
Product decision: installing Daylens is consent. Recording starts as soon as OS permissions allow, with no separate agree/decline step in onboarding.

- First startup reconcile grants capture consent automatically; a stale (older-policy) grant silently re-grants instead of reopening onboarding.
- The onboarding "why" screen keeps its what-is-captured explainer but its buttons become Continue / Skip setup — no decline path.
- Skipping setup no longer turns capture off.
- Explicit legacy declines are preserved and recoverable in Settings; pause, app/site exclusions, and private-window rules are untouched.
- Related backlog trimmed: DEV-221 canceled, GitHub #237 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmihsiD1C3jC1TkCp8Re8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated onboarding messaging to clarify that capture is enabled from installation.
  * Added clearer consent re-confirmation guidance and improved reassurance text.
  * Continue is disabled while onboarding actions are processing.

* **Bug Fixes**
  * Existing onboarding remains complete when capture consent becomes outdated.
  * Skipping the setup flow no longer changes capture-consent settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->