### PR TITLE
Linux capture joins the canonical evidence contract (DEV-167)

### DIFF
--- a/scripts/verify-runtime-capture.js
+++ b/scripts/verify-runtime-capture.js
@@ -59,10 +59,40 @@ function verifyRuntimeCapture(report, statePathArg, fail) {
     }
   }
 
+  // Canonical evidence contract: every desktop platform mirrors foreground
+  // observations into focus_events, so each probe title must also appear as a
+  // canonical activation — a legacy-only capture is a silent regression.
+  if (!Array.isArray(captureProbe.canonicalEvents)) {
+    fail('The capture probe did not report canonical focus events.')
+  }
+  for (const [kind, title] of [
+    ['foreground', windowState.foreground.title],
+    ['fullscreen', windowState.fullscreen.title],
+  ]) {
+    const activation = captureProbe.canonicalEvents.find(
+      (candidate) =>
+        candidate.windowTitle === title
+        && (candidate.eventType === 'app_activated' || candidate.eventType === 'window_changed'),
+    )
+    if (!activation) {
+      fail(
+        `No canonical focus event captured the ${kind} probe title ${JSON.stringify(title)}. `
+        + `Canonical events: ${JSON.stringify(captureProbe.canonicalEvents)}`,
+      )
+    }
+    if (activation.platform !== report.platform) {
+      fail(
+        `The ${kind} canonical activation recorded platform ${JSON.stringify(activation.platform)} `
+        + `but the app ran on ${JSON.stringify(report.platform)}.`,
+      )
+    }
+  }
+
   return {
     foregroundTitle: windowState.foreground.title,
     fullscreenTitle: windowState.fullscreen.title,
     capturedSessions: captureProbe.sessions.length,
+    canonicalEvents: captureProbe.canonicalEvents.length,
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -373,11 +373,38 @@ function readSmokeCaptureSessions(): SmokeCaptureSession[] {
   `).all(SMOKE_FOREGROUND_TITLE, SMOKE_FULLSCREEN_TITLE) as SmokeCaptureSession[]
 }
 
+interface SmokeCanonicalEvent {
+  eventType: string
+  appName: string | null
+  windowTitle: string | null
+  source: string
+  platform: string
+}
+
+// The canonical mirror of the probe capture: every desktop platform now emits
+// foreground observations into focus_events, so a packaged smoke that only
+// proved legacy app_sessions would let canonical capture regress silently.
+function readSmokeCanonicalEvents(): SmokeCanonicalEvent[] {
+  if (!SMOKE_FOREGROUND_TITLE || !SMOKE_FULLSCREEN_TITLE) return []
+  return getDb().prepare(`
+    SELECT
+      event_type AS eventType,
+      app_name AS appName,
+      window_title AS windowTitle,
+      source,
+      platform
+    FROM focus_events
+    WHERE window_title IN (?, ?)
+    ORDER BY ts_ms ASC, mono_ns ASC, id ASC
+  `).all(SMOKE_FOREGROUND_TITLE, SMOKE_FULLSCREEN_TITLE) as SmokeCanonicalEvent[]
+}
+
 async function waitForSmokeCapture(): Promise<{
   required: boolean
   foregroundTitle: string | null
   fullscreenTitle: string | null
   sessions: SmokeCaptureSession[]
+  canonicalEvents: SmokeCanonicalEvent[]
 }> {
   if (!SMOKE_FOREGROUND_TITLE || !SMOKE_FULLSCREEN_TITLE) {
     await new Promise((resolve) => setTimeout(resolve, 2_500))
@@ -386,6 +413,7 @@ async function waitForSmokeCapture(): Promise<{
       foregroundTitle: SMOKE_FOREGROUND_TITLE,
       fullscreenTitle: SMOKE_FULLSCREEN_TITLE,
       sessions: [],
+      canonicalEvents: [],
     }
   }
 
@@ -400,6 +428,7 @@ async function waitForSmokeCapture(): Promise<{
         foregroundTitle: SMOKE_FOREGROUND_TITLE,
         fullscreenTitle: SMOKE_FULLSCREEN_TITLE,
         sessions,
+        canonicalEvents: readSmokeCanonicalEvents(),
       }
     }
     await new Promise((resolve) => setTimeout(resolve, 1_000))
@@ -409,7 +438,8 @@ async function waitForSmokeCapture(): Promise<{
   throw new Error(
     `Timed out waiting for packaged foreground/fullscreen capture. `
     + `Expected titles ${JSON.stringify([SMOKE_FOREGROUND_TITLE, SMOKE_FULLSCREEN_TITLE])}; `
-    + `captured ${JSON.stringify(sessions)}; tracker ${JSON.stringify(trackingStatus)}; `
+    + `captured ${JSON.stringify(sessions)}; canonical ${JSON.stringify(readSmokeCanonicalEvents())}; `
+    + `tracker ${JSON.stringify(trackingStatus)}; `
     + `live ${JSON.stringify(getCurrentSession())}.`,
   )
 }
@@ -461,6 +491,7 @@ async function runSmokeValidation(win: BrowserWindow, trigger: SmokeValidationTr
         foregroundTitle: SMOKE_FOREGROUND_TITLE,
         fullscreenTitle: SMOKE_FULLSCREEN_TITLE,
         sessions: readSmokeCaptureSessions(),
+        canonicalEvents: readSmokeCanonicalEvents(),
       },
       trackingStatus: { ...trackingStatus },
       linuxTracking: getLinuxTrackingDiagnostics(),

--- a/src/main/services/captureEvidence.ts
+++ b/src/main/services/captureEvidence.ts
@@ -9,11 +9,13 @@ import {
   type FocusEventType,
 } from '../core/evidence/focusEvent'
 
-// Canonical evidence emission for the poll-based capture path. The tracking
-// FSM (tracking.ts) keeps its legacy app_sessions write for parity
-// measurement; every observation it makes is ALSO recorded here as canonical
-// focus_events rows, so the canonical store — not the legacy tables — is the
-// record new consumers project from.
+// Canonical evidence emission for the poll-based capture path on every
+// desktop platform (capture migration slice 4 brings Linux onto the same
+// contract as macOS and Windows). The tracking FSM (tracking.ts) keeps its
+// legacy app_sessions write for parity measurement; every observation it
+// makes is ALSO recorded here as canonical focus_events rows, so the
+// canonical store — not the legacy tables — is the record new consumers
+// project from.
 //
 // Every caller sits downstream of the FSM's capture gates (pause, exclusions,
 // private windows, consent), so an emission is always an observation that was
@@ -79,7 +81,6 @@ export function recordPollForegroundEvent(
   observation: PollForegroundObservation,
   platform: NodeJS.Platform = process.platform,
 ): void {
-  if (platform === 'linux') return
   persist([{
     ...baseEvent(eventType, observation.tsMs, platform),
     app_bundle_id: observation.bundleId,
@@ -96,7 +97,6 @@ export function recordPollMachineStateEvent(
   tsMs: number,
   platform: NodeJS.Platform = process.platform,
 ): void {
-  if (platform === 'linux') return
   persist([baseEvent(eventType, tsMs, platform)])
 }
 

--- a/src/main/services/tracking.ts
+++ b/src/main/services/tracking.ts
@@ -1837,6 +1837,20 @@ async function poll(): Promise<void> {
       trackingStatus.backendTrace = backendTrace.length > 0
         ? backendTrace.slice(-8)
         : (support ? [support.supportMessage] : [])
+
+      // An unsupported session that produced no window is a capture-health
+      // fact, not an empty poll: report it once through the canonical
+      // capture_failed / capture_recovered transition instead of letting the
+      // generic no-window return below mark the poll healthy. Silent partial
+      // capture is exactly what the evidence contract forbids on Linux.
+      if (!win && support?.supportLevel === 'unsupported') {
+        flushActiveBrowserContext(getDb())
+        if (currentSession) currentSession.passivePresence = false
+        setPollHealth(support.supportMessage)
+        trackingStatus.lastRawWindow = null
+        trackingStatus.lastResolvedWindow = null
+        return
+      }
     } else {
       const awMod = getActiveWindowModule()
       if (!awMod) {

--- a/tests/captureCanonicalParity.test.ts
+++ b/tests/captureCanonicalParity.test.ts
@@ -279,14 +279,54 @@ test('a midnight legacy split emits one canonical deactivation', async () => {
   }
 })
 
-test('Linux polling remains outside the macOS and Windows canonical adapter', async () => {
+test('Linux polling joins the canonical adapter with its platform identity', async () => {
   __resetSettings()
   const rig = makeRig('linux')
   try {
     await rig.poll(BASE, { input: true })
     await rig.poll(BASE + 30_000, { input: true })
     flushCurrentSession()
-    assert.equal(pollEvents(rig.db).length, 0)
+
+    const events = pollEvents(rig.db)
+    assert.deepEqual(
+      events.map((event) => event.event_type),
+      ['app_activated', 'app_deactivated'],
+    )
+    const platforms = rig.db.prepare(`
+      SELECT DISTINCT platform FROM focus_events WHERE source = 'foreground_poll'
+    `).all() as Array<{ platform: string }>
+    assert.deepEqual(platforms, [{ platform: 'linux' }])
+  } finally {
+    rig.teardown()
+  }
+})
+
+test('Linux canonical events rebuild the same sessions as the legacy path', async () => {
+  __resetSettings()
+  const rig = makeRig('linux')
+  try {
+    await rig.poll(BASE, { input: true })
+    await rig.poll(BASE + 60_000, { input: true })
+    rig.setWindow(WIN_B)
+    await rig.poll(BASE + 120_000, { input: true })
+    await rig.poll(BASE + 180_000, { input: true })
+    flushCurrentSession()
+
+    const rebuilt = rebuildPollForegroundSessions(rig.db, BASE - 1, BASE + 86_400_000)
+      .filter((s) => (s.endMs - s.startMs) / 1_000 >= MIN_SESSION_SEC)
+    const legacy = rig.db.prepare(`
+      SELECT app_name AS appName, start_time AS startMs, end_time AS endMs
+      FROM app_sessions ORDER BY start_time ASC
+    `).all() as Array<{ appName: string; startMs: number; endMs: number }>
+
+    assert.equal(legacy.length, 2)
+    assert.deepEqual(
+      rebuilt.map((s) => ({ appName: s.appName, startMs: s.startMs, endMs: s.endMs })),
+      legacy,
+    )
+    for (let i = 1; i < rebuilt.length; i++) {
+      assert.ok(rebuilt[i].startMs >= rebuilt[i - 1].endMs, 'rebuilt sessions must not overlap')
+    }
   } finally {
     rig.teardown()
   }

--- a/tests/packagedRuntimeSmoke.test.ts
+++ b/tests/packagedRuntimeSmoke.test.ts
@@ -25,6 +25,7 @@ function fixture() {
     }),
   )
   const report = {
+    platform: 'linux',
     captureProbe: {
       required: true,
       foregroundTitle: 'Runtime Capture Foreground',
@@ -39,6 +40,22 @@ function fixture() {
           windowTitle: 'Runtime Capture Fullscreen',
           durationSec: 13,
           captureSource: 'foreground_poll',
+        },
+      ],
+      canonicalEvents: [
+        {
+          eventType: 'app_activated',
+          appName: 'Runtime Probe',
+          windowTitle: 'Runtime Capture Foreground',
+          source: 'foreground_poll',
+          platform: 'linux',
+        },
+        {
+          eventType: 'app_activated',
+          appName: 'Runtime Probe',
+          windowTitle: 'Runtime Capture Fullscreen',
+          source: 'foreground_poll',
+          platform: 'linux',
         },
       ],
     },
@@ -69,6 +86,40 @@ test('packaged runtime verifier fails clearly when fullscreen capture is absent'
     assert.throws(
       () => verifyRuntimeCapture(report, statePath, fail),
       /No persisted app session captured the fullscreen probe title/,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('packaged runtime verifier fails when the canonical record missed a probe title', () => {
+  const { dir, statePath, report, fail } = fixture()
+  try {
+    const captureProbe = report.captureProbe as {
+      canonicalEvents: Array<{ windowTitle: string }>
+    }
+    captureProbe.canonicalEvents = captureProbe.canonicalEvents.filter(
+      (event) => event.windowTitle !== 'Runtime Capture Fullscreen',
+    )
+    assert.throws(
+      () => verifyRuntimeCapture(report, statePath, fail),
+      /No canonical focus event captured the fullscreen probe title/,
+    )
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('packaged runtime verifier fails when a canonical event carries the wrong platform', () => {
+  const { dir, statePath, report, fail } = fixture()
+  try {
+    const captureProbe = report.captureProbe as {
+      canonicalEvents: Array<{ platform: string }>
+    }
+    captureProbe.canonicalEvents[0].platform = 'darwin'
+    assert.throws(
+      () => verifyRuntimeCapture(report, statePath, fail),
+      /recorded platform "darwin" but the app ran on "linux"/,
     )
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
Closes #163. Linear: [DEV-167](https://linear.app/irachrist1/issue/DEV-167/linux-capture-joins-the-canonical-evidence-contract)

## What changed

Capture migration slice 4 (`docs/specs/capture-and-evidence.md`): Linux foreground observations flow through the same canonical evidence contract as macOS and Windows.

- `captureEvidence.ts` no longer drops Linux events: `recordPollForegroundEvent` and `recordPollMachineStateEvent` persist canonical `focus_events` rows with `platform: 'linux'`. The legacy `app_sessions` write remains for parity measurement — the same dual-write posture macOS and Windows hold until slice 10 stops legacy writes everywhere. The Linux-only carve-out (its own path into legacy rows with no canonical record) is what this removes.
- **Honest capture health**: a Linux session whose support level is `unsupported` (a Wayland session with no compositor helper and no XWayland) and that produces no window now reports the session's support message through the existing canonical `capture_failed` / `capture_recovered` transition, instead of returning as a healthy empty poll. Silent partial capture becomes a visible health state. X11 reports ready; Hyprland/Sway ready via their compositor helpers; GNOME/KDE Wayland limited via XWayland — the support matrix in `getLinuxTrackingSupportInfo` is now load-bearing for health, not just diagnostics.
- **Packaged smoke proves canonical capture**: the smoke report now carries the canonical mirror of the probe capture (`captureProbe.canonicalEvents`), and the shared runtime verifier fails when a probe title is missing from canonical focus events or a canonical row carries the wrong platform. This strengthens the Linux, macOS, and Windows packaged workflows alike.

## Evidence against acceptance criteria

- **Canonical events rebuild the same sessions as the legacy path on X11** — `tests/captureCanonicalParity.test.ts` drives the real FSM on the Linux platform and asserts `rebuildPollForegroundSessions` deep-equals the legacy `app_sessions` rows; the Linux packaged runtime workflow (a real X11 session under Xvfb) now asserts the canonical probe capture end to end.
- **Unsupported sessions show an honest capture-health state** — implemented through the existing one-shot `capture_failed`/`capture_recovered` transition; no per-poll flooding.
- **The Linux packaged capture smoke passes** — the `verify-linux-runtime` workflow on this PR runs AppImage/deb/rpm smokes with the new canonical assertions.

The previous pinning test ("Linux polling remains outside the canonical adapter") is deliberately flipped to its successor ("Linux polling joins the canonical adapter with its platform identity").

## Verification

- `npm run verify:shipping` — exit 0.
- Full unit suite: 1412 pass, including the flipped parity tests and new verifier failure modes.
- `verify-linux-runtime` / `verify-macos-runtime` / `verify-windows-runtime` on this PR exercise the strengthened packaged capture checks on real runtimes.

## Out of scope

New Wayland capture capabilities beyond what the session exposes; stopping legacy writes (slice 10); browser evidence (slice 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)