### PR TITLE
Search, the AI tools, MCP, and sync read the shared facts (DEV-171)

### DIFF
--- a/src/main/agent/daylensTools.ts
+++ b/src/main/agent/daylensTools.ts
@@ -9,7 +9,15 @@ import { z } from 'zod'
 import type Database from 'better-sqlite3'
 import { executeTool } from '../services/aiTools'
 import { getMomentEvidence } from '../lib/momentEvidence'
-import { getSessionsForRange, getWebsiteVisitsForRange } from '../db/queries'
+import { getWebsiteVisitsForRange } from '../db/queries'
+import {
+  getCorrectedSessionsForRange,
+  getIgnoredBlockSpansForRange,
+} from '../services/activityFacts'
+import {
+  listFocusEventTimesInRange,
+  listMachineStateEventsBefore,
+} from '../db/focusEventRepository'
 import { sanitizeToolResult } from '@shared/aiSanitize'
 import { filterTrackingExcludedEvidence } from '@shared/evidencePrivacy'
 import { trackingControlsStateFromSettings } from '@shared/trackingControls'
@@ -36,19 +44,8 @@ function captureStateForDay(db: Database.Database, date: string) {
   const fromMs = dayStartMs(date)
   const toMs = fromMs + DAY_MS
   try {
-    const prior = db.prepare(`
-      SELECT ts_ms, event_type
-      FROM focus_events
-      WHERE ts_ms < ? AND event_type IN ('sleep', 'wake', 'lock', 'unlock')
-      ORDER BY ts_ms DESC
-      LIMIT 20
-    `).all(fromMs) as Array<{ ts_ms: number; event_type: string }>
-    const events = db.prepare(`
-      SELECT ts_ms, event_type
-      FROM focus_events
-      WHERE ts_ms >= ? AND ts_ms < ?
-      ORDER BY ts_ms
-    `).all(fromMs, toMs) as Array<{ ts_ms: number; event_type: string }>
+    const prior = listMachineStateEventsBefore(db, fromMs)
+    const events = listFocusEventTimesInRange(db, fromMs, toMs)
 
     const states = new Set<'asleep' | 'locked'>()
     for (const event of prior.reverse()) {
@@ -165,13 +162,22 @@ function timeChunks(
   }
 
   const dayStart = dayStartMs(date)
+  const spanStartMs = dayStart + startOffset * 60_000
+  const spanEndMs = dayStart + endOffset * 60_000
   const state = captureStateForDay(db, date)
-  const visits = getWebsiteVisitsForRange(db, dayStart + startOffset * 60_000, dayStart + endOffset * 60_000)
+  // Corrected facts: a deleted Timeline block's stretch is empty space in the
+  // chunk view too, for sessions and page visits alike.
+  const ignoredSpans = getIgnoredBlockSpansForRange(db, spanStartMs, spanEndMs)
+  const visits = getWebsiteVisitsForRange(db, spanStartMs, spanEndMs)
+    .filter((visit) => !ignoredSpans.some((span) => span.startMs <= visit.visitTime && span.endMs > visit.visitTime))
+  const spanSessions = getCorrectedSessionsForRange(db, spanStartMs, spanEndMs)
   const chunks = []
   for (let offset = startOffset; offset < endOffset; offset += incrementMinutes) {
     const chunkStart = dayStart + offset * 60_000
     const chunkEnd = chunkStart + incrementMinutes * 60_000
-    const sessions = getSessionsForRange(db, chunkStart, chunkEnd, { minimumDurationSeconds: 1 })
+    const sessions = spanSessions.filter((session) =>
+      session.startTime < chunkEnd
+      && (session.endTime ?? session.startTime + session.durationSeconds * 1000) > chunkStart)
     const activity = sessions.map((session) => ({
       appName: session.appName,
       windowTitle: session.windowTitle ?? null,

--- a/src/main/agent/systemTools.ts
+++ b/src/main/agent/systemTools.ts
@@ -10,6 +10,7 @@ import { promisify } from 'node:util'
 import os from 'node:os'
 import type Database from 'better-sqlite3'
 import { sanitizeForModel } from '@shared/aiSanitize'
+import { getTrackedWindowTitleCorpus } from '../db/queries'
 import { minimalChildEnv } from '../lib/childEnv'
 
 const execFileAsync = promisify(execFile)
@@ -101,15 +102,7 @@ async function discoverGitDirectories(roots: string[]): Promise<string[]> {
 function trackedEvidence(db: Database.Database | undefined, fromMs: number, toMs: number): string {
   if (!db) return ''
   try {
-    const rows = db.prepare(`
-      SELECT window_title AS title FROM focus_events
-      WHERE ts_ms >= ? AND ts_ms < ? AND window_title IS NOT NULL
-      UNION ALL
-      SELECT window_title AS title FROM app_sessions
-      WHERE start_time < ? AND COALESCE(end_time, start_time) >= ? AND window_title IS NOT NULL
-      LIMIT 10000
-    `).all(fromMs, toMs, toMs, fromMs) as Array<{ title: string }>
-    return rows.map((row) => row.title).join('\n').toLowerCase()
+    return getTrackedWindowTitleCorpus(db, fromMs, toMs)
   } catch {
     return ''
   }

--- a/src/main/db/focusEventRepository.ts
+++ b/src/main/db/focusEventRepository.ts
@@ -135,6 +135,76 @@ export function countFocusEventsInRange(
   return row.count
 }
 
+export interface FocusEventTimeAndType {
+  ts_ms: number
+  event_type: string
+}
+
+/** The most recent machine-state transitions strictly before a boundary —
+ *  lets a day reconstruct whether it began asleep or locked. Returned
+ *  newest-first, capped. */
+export function listMachineStateEventsBefore(
+  db: Database.Database,
+  beforeMs: number,
+  limit = 20,
+): FocusEventTimeAndType[] {
+  return db.prepare(`
+    SELECT ts_ms, event_type
+    FROM focus_events
+    WHERE ts_ms < ? AND event_type IN ('sleep', 'wake', 'lock', 'unlock')
+    ORDER BY ts_ms DESC
+    LIMIT ?
+  `).all(beforeMs, limit) as FocusEventTimeAndType[]
+}
+
+/** Event timestamps and types for a window, chronological. */
+export function listFocusEventTimesInRange(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+): FocusEventTimeAndType[] {
+  return db.prepare(`
+    SELECT ts_ms, event_type
+    FROM focus_events
+    WHERE ts_ms >= ? AND ts_ms < ?
+    ORDER BY ts_ms
+  `).all(fromMs, toMs) as FocusEventTimeAndType[]
+}
+
+export interface CaptureTitleSampleStats {
+  recentSamples: number
+  withTitle: number
+  lastCapturedAtMs: number | null
+}
+
+/** Capture-health counts: how many recent native-helper foreground samples
+ *  carried a window title. Counts only — no titles or identities leave the
+ *  repository. */
+export function getNativeCaptureTitleStats(
+  db: Database.Database,
+  sinceMs: number,
+): CaptureTitleSampleStats {
+  const row = db.prepare(`
+    SELECT
+      COUNT(*) AS recent_samples,
+      SUM(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN 1 ELSE 0 END) AS with_title,
+      MAX(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN ts_ms ELSE NULL END) AS last_captured_at
+    FROM focus_events
+    WHERE source IN ('nsworkspace_event', 'uia_foreground')
+      AND event_type IN ('app_activated', 'window_changed', 'space_changed')
+      AND ts_ms >= ?
+  `).get(sinceMs) as {
+    recent_samples: number
+    with_title: number | null
+    last_captured_at: number | null
+  }
+  return {
+    recentSamples: row.recent_samples,
+    withTitle: row.with_title ?? 0,
+    lastCapturedAtMs: row.last_captured_at,
+  }
+}
+
 export interface FocusEvidencePayload {
   eventType: FocusEvent['event_type']
   appBundleId: string | null

--- a/src/main/db/queries.ts
+++ b/src/main/db/queries.ts
@@ -3137,6 +3137,168 @@ export function getWebsiteVisitsForRange(
   `).all(fromMs, toMs) as WebsiteVisitRecord[]
 }
 
+// ─── Identity-scoped discovery reads (repository boundary) ───────────────────
+// Lightweight lookups that AI tools and other consumers need without touching
+// raw evidence tables themselves (capture spec, storage and repository
+// boundaries). They discover identity and candidate days; totals always come
+// from the corrected activity-fact reads.
+
+export interface SessionIdentitySelector {
+  canonicalAppIds: string[]
+  bundleIds: string[]
+}
+
+function sessionIdentityWhereClause(selector: SessionIdentitySelector): { clause: string; params: string[] } {
+  const clauses: string[] = []
+  const params: string[] = []
+  if (selector.canonicalAppIds.length > 0) {
+    clauses.push(`canonical_app_id IN (${selector.canonicalAppIds.map(() => '?').join(', ')})`)
+    params.push(...selector.canonicalAppIds)
+  }
+  if (selector.bundleIds.length > 0) {
+    clauses.push(`bundle_id IN (${selector.bundleIds.map(() => '?').join(', ')})`)
+    params.push(...selector.bundleIds)
+  }
+  return {
+    clause: clauses.length > 0 ? `(${clauses.join(' OR ')})` : '0',
+    params,
+  }
+}
+
+/** Distinct visited domains in a window — identity discovery for site-usage
+ *  lookups; carries no durations. */
+export function listDistinctVisitDomains(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+): string[] {
+  const rows = db.prepare(`
+    SELECT DISTINCT domain FROM website_visits
+    WHERE visit_time >= ? AND visit_time < ? AND domain IS NOT NULL AND domain != ''
+  `).all(fromMs, toMs) as { domain: string }[]
+  return rows.map((row) => row.domain)
+}
+
+/** Local calendar days on which any session matched the identity selector —
+ *  candidate-day discovery; per-day totals come from corrected reads. */
+export function listSessionActivityDays(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+  selector: SessionIdentitySelector,
+  limit = 90,
+): string[] {
+  if (selector.canonicalAppIds.length === 0 && selector.bundleIds.length === 0) return []
+  const identity = sessionIdentityWhereClause(selector)
+  const rows = db.prepare(`
+    SELECT DISTINCT strftime('%Y-%m-%d', start_time / 1000, 'unixepoch', 'localtime') AS day
+    FROM app_sessions
+    WHERE start_time >= ? AND start_time < ?
+      AND ${identity.clause}
+    ORDER BY day DESC
+    LIMIT ?
+  `).all(fromMs, toMs, ...identity.params, limit) as { day: string }[]
+  return rows.map((row) => row.day)
+}
+
+/** Recent distinct window titles for an identity selector — visible-context
+ *  evidence for “what was the user doing in this app”. */
+export function listRecentSessionWindowTitles(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+  selector: SessionIdentitySelector,
+  limit = 10,
+): string[] {
+  if (selector.canonicalAppIds.length === 0 && selector.bundleIds.length === 0) return []
+  const identity = sessionIdentityWhereClause(selector)
+  const rows = db.prepare(`
+    SELECT DISTINCT window_title FROM app_sessions
+    WHERE window_title IS NOT NULL
+      AND start_time >= ? AND start_time < ?
+      AND ${identity.clause}
+    ORDER BY start_time DESC LIMIT ?
+  `).all(fromMs, toMs, ...identity.params, limit) as { window_title: string }[]
+  return rows.map((row) => row.window_title)
+}
+
+/** Latest recorded display name per bundle id from legacy session rows —
+ *  identity fallback for bundle ids the apps registry has not resolved. */
+export function getLatestSessionAppNames(
+  db: Database.Database,
+  bundleIds: readonly string[],
+): Map<string, string> {
+  const map = new Map<string, string>()
+  if (bundleIds.length === 0) return map
+  const marks = bundleIds.map(() => '?').join(', ')
+  const rows = db.prepare(`
+    SELECT sessions.bundle_id, sessions.app_name
+    FROM app_sessions sessions
+    JOIN (
+      SELECT bundle_id, MAX(start_time) AS latest_start
+      FROM app_sessions
+      WHERE bundle_id IN (${marks})
+      GROUP BY bundle_id
+    ) latest
+      ON latest.bundle_id = sessions.bundle_id
+     AND latest.latest_start = sessions.start_time
+  `).all(...bundleIds) as Array<{ bundle_id: string; app_name: string }>
+  for (const row of rows) {
+    if (!map.has(row.bundle_id)) map.set(row.bundle_id, row.app_name)
+  }
+  return map
+}
+
+export interface LegacyCaptureTitleStats {
+  recentSamples: number
+  withTitle: number
+  lastCapturedAtMs: number | null
+}
+
+/** Capture-health counts over legacy session rows — the poll path's title
+ *  coverage on platforms without a native helper. Counts only. */
+export function getLegacySessionTitleStats(
+  db: Database.Database,
+  sinceMs: number,
+): LegacyCaptureTitleStats {
+  const row = db.prepare(`
+    SELECT
+      COUNT(*) AS recent_samples,
+      SUM(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN 1 ELSE 0 END) AS with_title,
+      MAX(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN start_time ELSE NULL END) AS last_captured_at
+    FROM app_sessions
+    WHERE start_time >= ?
+  `).get(sinceMs) as {
+    recent_samples: number
+    with_title: number | null
+    last_captured_at: number | null
+  }
+  return {
+    recentSamples: row.recent_samples,
+    withTitle: row.with_title ?? 0,
+    lastCapturedAtMs: row.last_captured_at,
+  }
+}
+
+/** Lower-cased captured window/title text in a window, for corroborating a
+ *  repository's activity against what was actually on screen. Titles only —
+ *  no identities, no durations. */
+export function getTrackedWindowTitleCorpus(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+): string {
+  const rows = db.prepare(`
+    SELECT window_title AS title FROM focus_events
+    WHERE ts_ms >= ? AND ts_ms < ? AND window_title IS NOT NULL
+    UNION ALL
+    SELECT window_title AS title FROM app_sessions
+    WHERE start_time < ? AND COALESCE(end_time, start_time) >= ? AND window_title IS NOT NULL
+    LIMIT 10000
+  `).all(fromMs, toMs, toMs, fromMs) as Array<{ title: string }>
+  return rows.map((row) => row.title).join('\n').toLowerCase()
+}
+
 export interface ActivityStateEventRecord {
   id: number
   eventTs: number

--- a/src/main/ipc/db.handlers.ts
+++ b/src/main/ipc/db.handlers.ts
@@ -5,12 +5,15 @@ import {
   getAppCharacter,
   getAllAppsForLabeling,
   getCategoryOverrideEffect,
+  getLatestSessionAppNames,
+  getLegacySessionTitleStats,
   getSessionsForRange,
   getSessionsForApp,
   setCategoryOverride,
   clearCategoryOverride,
   getCategoryOverrides,
 } from '../db/queries'
+import { getNativeCaptureTitleStats } from '../db/focusEventRepository'
 import {
   getWorkMemoryProfile,
   updateWorkMemoryFact,
@@ -209,20 +212,8 @@ function buildAppNameMap(db: ReturnType<typeof getDb>, bundleIds: string[]): Map
 
   const unresolvedBundleIds = uniqueBundleIds.filter((bundleId) => !map.has(bundleId))
   if (unresolvedBundleIds.length > 0) {
-    const legacyRows = db.prepare(`
-      SELECT sessions.bundle_id, sessions.app_name
-      FROM app_sessions sessions
-      JOIN (
-        SELECT bundle_id, MAX(start_time) AS latest_start
-        FROM app_sessions
-        WHERE bundle_id IN (${placeholders(unresolvedBundleIds)})
-        GROUP BY bundle_id
-      ) latest
-        ON latest.bundle_id = sessions.bundle_id
-       AND latest.latest_start = sessions.start_time
-    `).all(...unresolvedBundleIds) as Array<{ bundle_id: string; app_name: string }>
-    for (const r of legacyRows) {
-      if (!map.has(r.bundle_id)) map.set(r.bundle_id, r.app_name)
+    for (const [bundleId, appName] of getLatestSessionAppNames(db, unresolvedBundleIds)) {
+      if (!map.has(bundleId)) map.set(bundleId, appName)
     }
   }
 
@@ -910,41 +901,17 @@ export function registerDbHandlers(): void {
   ipcMain.handle(IPC.TRACKING.GET_DIAGNOSTICS, () => {
     const since = Date.now() - 15 * 60_000
     const db = getDb()
-    const titleRows = db.prepare(`
-      SELECT
-        COUNT(*) AS recent_samples,
-        SUM(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN 1 ELSE 0 END) AS with_title,
-        MAX(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN ts_ms ELSE NULL END) AS last_captured_at
-      FROM focus_events
-      WHERE source IN ('nsworkspace_event', 'uia_foreground')
-        AND event_type IN ('app_activated', 'window_changed', 'space_changed')
-        AND ts_ms >= ?
-    `).get(since) as {
-      recent_samples: number
-      with_title: number | null
-      last_captured_at: number | null
-    }
+    const nativeStats = getNativeCaptureTitleStats(db, since)
 
-    let recentSamples = titleRows.recent_samples
-    let recentSamplesWithTitle = titleRows.with_title ?? 0
-    let lastCapturedAt = titleRows.last_captured_at
+    let recentSamples = nativeStats.recentSamples
+    let recentSamplesWithTitle = nativeStats.withTitle
+    let lastCapturedAt = nativeStats.lastCapturedAtMs
 
     if ((process.platform === 'win32' || process.platform === 'linux') && recentSamplesWithTitle === 0) {
-      const sessionRows = db.prepare(`
-        SELECT
-          COUNT(*) AS recent_samples,
-          SUM(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN 1 ELSE 0 END) AS with_title,
-          MAX(CASE WHEN window_title IS NOT NULL AND trim(window_title) <> '' THEN start_time ELSE NULL END) AS last_captured_at
-        FROM app_sessions
-        WHERE start_time >= ?
-      `).get(since) as {
-        recent_samples: number
-        with_title: number | null
-        last_captured_at: number | null
-      }
-      recentSamples = Math.max(recentSamples, sessionRows.recent_samples)
-      recentSamplesWithTitle = Math.max(recentSamplesWithTitle, sessionRows.with_title ?? 0)
-      lastCapturedAt = lastCapturedAt ?? sessionRows.last_captured_at
+      const sessionStats = getLegacySessionTitleStats(db, since)
+      recentSamples = Math.max(recentSamples, sessionStats.recentSamples)
+      recentSamplesWithTitle = Math.max(recentSamplesWithTitle, sessionStats.withTitle)
+      lastCapturedAt = lastCapturedAt ?? sessionStats.lastCapturedAtMs
     }
 
     const browserStatus = getBrowserStatus()

--- a/src/main/services/aiTools.ts
+++ b/src/main/services/aiTools.ts
@@ -9,7 +9,11 @@ import {
   searchBrowser as dbSearchBrowser,
   searchArtifacts as dbSearchArtifacts,
   getWebsiteVisitsForRange,
+  listDistinctVisitDomains,
+  listRecentSessionWindowTitles,
+  listSessionActivityDays,
 } from '../db/queries'
+import { blockActiveSeconds } from '@shared/blockDuration'
 // AI facts read the corrected activity truth (invariant 7): a Timeline block
 // the user deleted is subtracted from every total the AI quotes, so the AI
 // never contradicts the Timeline or the Apps view.
@@ -441,13 +445,7 @@ function aggregateSiteUsage(
   const needle = normalizeAppLookupValue(lookupRaw)
   if (!needle || needle.length < 3) return null
 
-  const domainRows = db.prepare(`
-    SELECT DISTINCT domain FROM website_visits
-    WHERE visit_time >= ? AND visit_time < ? AND domain IS NOT NULL AND domain != ''
-  `).all(fromMs, toMs) as { domain: string }[]
-
-  const matchedDomains = domainRows
-    .map((r) => r.domain)
+  const matchedDomains = listDistinctVisitDomains(db, fromMs, toMs)
     .filter((domain) => {
       const dn = normalizeAppLookupValue(domain)
       if (!dn) return false
@@ -510,23 +508,6 @@ function aggregateSiteUsage(
       }))
       .filter((r) => r.totalSeconds > 0 || r.sessionCount > 0),
     titles: titleRows.map((visit) => visit.pageTitle as string),
-  }
-}
-
-function sessionIdentityWhereClause(canonicalIds: string[], bundleIds: string[]): { clause: string; params: string[] } {
-  const clauses: string[] = []
-  const params: string[] = []
-  if (canonicalIds.length > 0) {
-    clauses.push(`canonical_app_id IN (${canonicalIds.map(() => '?').join(', ')})`)
-    params.push(...canonicalIds)
-  }
-  if (bundleIds.length > 0) {
-    clauses.push(`bundle_id IN (${bundleIds.map(() => '?').join(', ')})`)
-    params.push(...bundleIds)
-  }
-  return {
-    clause: clauses.length > 0 ? `(${clauses.join(' OR ')})` : '0',
-    params,
   }
 }
 
@@ -725,10 +706,10 @@ export function execGetDaySummary(params: GetDaySummaryParams, db: Database.Data
     if (!label) continue
     const startMs = block.startTime
     const endMs = block.endTime
-    // Block duration is end - start of the rendered block, never a sum
-    // of session durations. The renderer is the source of truth here so
-    // the AI and the UI agree to the minute.
-    const durationSeconds = Math.max(0, Math.round((endMs - startMs) / 1000))
+    // A block's cited duration is its ACTIVE time — the same figure the
+    // Timeline rail totals — never the wall-clock span, which can enclose
+    // hours of absorbed gap and made the AI's day total exceed the screen's.
+    const durationSeconds = blockActiveSeconds(block)
     const appsInBlock = block.topApps
       .filter((a) => a.category !== 'system')
       .slice(0, 4)
@@ -772,11 +753,11 @@ export function execGetDaySummary(params: GetDaySummaryParams, db: Database.Data
     seenLabels.add(label)
   }
 
-  // Total tracked seconds is the sum of block durations — guarantees
-  // the AI's daily total matches the timeline view. App-summary sums
-  // can disagree with block sums due to overlap/idle gaps.
-  const totalTrackedSeconds = blocks.reduce((acc, b) => acc + b.durationSeconds, 0)
-  const focusSeconds = summaries.filter((a) => a.isFocused).reduce((s, a) => s + a.totalSeconds, 0)
+  // The day's totals ARE the Timeline payload's totals — the same shared
+  // corrected facts the screen renders — so the agent can never quote a
+  // different day length than the Timeline for the same date.
+  const totalTrackedSeconds = Math.round(livePayload.totalSeconds)
+  const focusSeconds = Math.round(livePayload.focusSeconds)
 
   // Per-app activity: which block did the app contribute most time to?
   // Lets D1-compliant answers lead with "Kiro — coding in the Building &
@@ -877,17 +858,12 @@ export function execGetAppUsage(params: GetAppUsageParams, db: Database.Database
   // session merging, and range clipping.
   const matchedCanonicalIds = [...new Set(matched.map((a) => a.canonicalAppId).filter((id): id is string => !!id))]
   const matchedBundleIds = [...new Set(matched.map((a) => a.bundleId).filter(Boolean))]
-  const identityFilter = sessionIdentityWhereClause(matchedCanonicalIds, matchedBundleIds)
-  const candidateDays = matched.length === 0 ? [] : (db.prepare(`
-    SELECT DISTINCT strftime('%Y-%m-%d', start_time / 1000, 'unixepoch', 'localtime') AS day
-    FROM app_sessions
-    WHERE start_time >= ? AND start_time < ?
-      AND ${identityFilter.clause}
-    ORDER BY day DESC
-    LIMIT 90
-  `).all(fromMs, toMs, ...identityFilter.params) as { day: string }[])
+  const identitySelector = { canonicalAppIds: matchedCanonicalIds, bundleIds: matchedBundleIds }
+  const candidateDays = matched.length === 0
+    ? []
+    : listSessionActivityDays(db, fromMs, toMs, identitySelector)
   const dailyBreakdown = candidateDays
-    .map(({ day }) => {
+    .map((day) => {
       const [dayFrom, dayTo] = localDayBounds(day)
       const daySummaries = getAppSummariesForRange(db, dayFrom, dayTo)
       const dayMatched = daySummaries.filter((a) => a.canonicalAppId && matchedCanonicalIds.includes(a.canonicalAppId))
@@ -900,13 +876,9 @@ export function execGetAppUsage(params: GetAppUsageParams, db: Database.Database
     .filter((d) => d.totalSeconds > 0)
 
   // Recent distinct window titles
-  const titleRows = matched.length === 0 ? [] : (db.prepare(`
-    SELECT DISTINCT window_title FROM app_sessions
-    WHERE window_title IS NOT NULL
-      AND start_time >= ? AND start_time < ?
-      AND ${identityFilter.clause}
-    ORDER BY start_time DESC LIMIT 10
-  `).all(fromMs, toMs, ...identityFilter.params) as { window_title: string }[])
+  const recentTitles = matched.length === 0
+    ? []
+    : listRecentSessionWindowTitles(db, fromMs, toMs, identitySelector)
 
   return {
     appName: matched[0]?.appName ?? params.appName,
@@ -916,7 +888,7 @@ export function execGetAppUsage(params: GetAppUsageParams, db: Database.Database
     startDate: params.startDate ?? toDateStr(fromMs),
     endDate: params.endDate ?? toDateStr(toMs),
     dailyBreakdown,
-    recentWindowTitles: titleRows.map((r) => r.window_title),
+    recentWindowTitles: recentTitles,
   }
 }
 
@@ -939,7 +911,6 @@ function execGetWeekSummary(params: GetWeekSummaryParams, db: Database.Database)
   const weekToMs = weekFromMs + 7 * 86_400_000
   const weekEnd = toDateStr(weekToMs - 1)
   const allSummaries = getAppSummariesForRange(db, weekFromMs, weekToMs)
-  const totalFocusSeconds = allSummaries.filter((a) => a.isFocused).reduce((s, a) => s + a.totalSeconds, 0)
 
   // Build per-day block summaries from the renderer's live path. This is
   // the activity-shaped view that lets weekly answers say
@@ -959,25 +930,29 @@ function execGetWeekSummary(params: GetWeekSummaryParams, db: Database.Database)
           label: userVisibleLabelForBlock(block),
           startTime: fmtHHMM(startMs),
           endTime: fmtHHMM(endMs),
-          durationSeconds: Math.max(0, Math.round((endMs - startMs) / 1000)),
+          // Active time, matching the Timeline rail — not the wall span.
+          durationSeconds: blockActiveSeconds(block),
           appsInBlock: block.topApps.filter((a) => a.category !== 'system').slice(0, 3).map((a) => a.appName),
         }
       })
       .filter((b) => b.label && b.durationSeconds > 0)
-    const dayTotalSeconds = dayBlocks.reduce((acc, b) => acc + b.durationSeconds, 0)
+    // The day total is the payload's own total, so weekly narratives quote
+    // the same day lengths the Timeline renders.
+    const dayTotalSeconds = Math.round(livePayload.totalSeconds)
     totalTrackedSeconds += dayTotalSeconds
     dailyBlockSummaries.push({
       date: dayStr,
       topBlocks: dayBlocks.sort((a, b) => b.durationSeconds - a.durationSeconds).slice(0, 6),
     })
-    // Focus seconds per day still come from session-level focus categorisation.
-    const daySessions = livePayload.blocks.flatMap((b) => b.sessions)
-    const dayFocusSeconds = daySessions
-      .filter((s) => s.isFocused)
-      .reduce((acc, s) => acc + s.durationSeconds, 0)
-    dailyBreakdown.push({ date: dayStr, totalSeconds: dayTotalSeconds, focusSeconds: dayFocusSeconds })
+    // Each day's focus figure is the payload's own clamped focusSeconds.
+    dailyBreakdown.push({
+      date: dayStr,
+      totalSeconds: dayTotalSeconds,
+      focusSeconds: Math.round(livePayload.focusSeconds),
+    })
   }
 
+  const totalFocusSeconds = dailyBreakdown.reduce((acc, d) => acc + d.focusSeconds, 0)
   const focusPct = totalTrackedSeconds > 0 ? Math.round((totalFocusSeconds / totalTrackedSeconds) * 100) : 0
   const bestDay = dailyBreakdown.reduce<{ date: string; focusPct: number } | null>((best, d) => {
     const pct = d.totalSeconds > 0 ? Math.round((d.focusSeconds / d.totalSeconds) * 100) : 0

--- a/tests/agentTools.test.ts
+++ b/tests/agentTools.test.ts
@@ -154,7 +154,11 @@ test('get_day_overview distinguishes locked time from unexplained capture gaps',
   assert.equal(chunks.chunks.length, 4)
   assert.ok(chunks.chunks.every((chunk: { durationMinutes: number }) => chunk.durationMinutes === 60))
   assert.equal(chunks.chunks[1].gap.label, 'machine locked')
-  assert.equal(chunks.chunks[2].gap.label, 'no data captured — possible tracking failure')
+  // The 10:05 activation is canonical evidence of observed foreground time,
+  // so the chunk shows captured activity (with a stable unknown identity)
+  // rather than claiming a tracking failure the events disprove.
+  assert.ok(chunks.chunks[2].activity.length > 0, 'canonical evidence fills the 10-11 chunk')
+  assert.ok(!chunks.chunks[2].gap, 'observed foreground time is not a gap')
   db.close()
 })
 

--- a/tests/repositoryBoundary.test.ts
+++ b/tests/repositoryBoundary.test.ts
@@ -1,0 +1,95 @@
+// Repository boundary (capture spec, storage and repository boundaries;
+// DEV-171): no renderer, AI tool, agent tool, MCP tool, or sync encoder may
+// query a raw evidence table directly. They read shared activity-fact
+// queries after projection and correction; raw SQL over evidence tables
+// belongs to the repository layer (src/main/db) and the capture writers.
+// This scan fails the moment a consumer regains a direct raw-table query.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const RAW_EVIDENCE_TABLES = ['app_sessions', 'website_visits', 'focus_events'] as const
+
+// SQL that READS a raw evidence table (FROM/JOIN over any of the raw names,
+// including their FTS shadows). Write statements are deliberately outside
+// this check: capture writers own inserts, and deletion centralization by
+// evidence identity is its own migration slice.
+const RAW_TABLE_PATTERN = new RegExp(
+  `(?:(?<!DELETE\\s)FROM|JOIN)\\s+(?:${RAW_EVIDENCE_TABLES.join('|')})(?:_fts)?\\b`,
+  'i',
+)
+
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trimStart()
+  return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')
+}
+
+// The consumer surfaces the specification names explicitly. Everything under
+// these roots must stay free of raw evidence SQL; the repository layer
+// (src/main/db) and the capture/projection internals are not listed here.
+const CONSUMER_ROOTS = [
+  'src/renderer',
+  'src/preload',
+  'src/main/ai',
+  'src/main/agent',
+  'src/main/ipc',
+  'packages/mcp-server/src',
+  'packages/remote-contract',
+] as const
+
+const CONSUMER_FILES = [
+  'src/main/services/aiTools.ts',
+  'src/main/services/naturalSearch.ts',
+  'src/main/services/mcpServer.ts',
+  'src/main/services/syncUploader.ts',
+  'src/main/services/syncState.ts',
+  'src/main/services/appDetail.ts',
+  'src/main/services/appActivityDigest.ts',
+  'src/main/services/activityFacts.ts',
+] as const
+
+function listSourceFiles(root: string): string[] {
+  const absolute = path.resolve(root)
+  if (!fs.existsSync(absolute)) return []
+  const out: string[] = []
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist') continue
+        walk(full)
+      } else if (/\.(ts|tsx|mts|cts)$/.test(entry.name)) {
+        out.push(full)
+      }
+    }
+  }
+  walk(absolute)
+  return out
+}
+
+test('no consumer surface queries a raw evidence table directly', () => {
+  const files = [
+    ...CONSUMER_ROOTS.flatMap((root) => listSourceFiles(root)),
+    ...CONSUMER_FILES.map((file) => path.resolve(file)).filter((file) => fs.existsSync(file)),
+  ]
+  assert.ok(files.length > 50, `boundary scan looks broken: only ${files.length} files found`)
+
+  const violations: string[] = []
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8')
+    const lines = content.split('\n')
+    lines.forEach((line, index) => {
+      if (isCommentLine(line)) return
+      if (RAW_TABLE_PATTERN.test(line)) {
+        violations.push(`${path.relative(process.cwd(), file)}:${index + 1}: ${line.trim()}`)
+      }
+    })
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `Consumer surfaces must read shared activity-fact queries, not raw evidence tables.\n${violations.join('\n')}`,
+  )
+})

--- a/tests/sharedFactsConsumers.test.ts
+++ b/tests/sharedFactsConsumers.test.ts
@@ -1,0 +1,142 @@
+// DEV-171: search, the agent's data tools, and the MCP path (which delegates
+// to the same executors) read the shared corrected facts. The agent's
+// day-overview total equals the Timeline payload's total for the same date,
+// and a correction changes search and tool results immediately.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type Database from 'better-sqlite3'
+import { createProductionTestDatabase } from './support/testDatabase.ts'
+import { executeTool, type DaySummaryResult } from '../src/main/services/aiTools.ts'
+import { getTimelineDayPayload, writeTimelineBlockReview } from '../src/main/services/workBlocks.ts'
+import { searchAll } from '../src/main/db/queries.ts'
+
+interface SearchSessionsToolResult {
+  hits: Array<{ windowTitle?: string | null }>
+  matchKind: 'strict' | 'broadened' | 'empty'
+}
+
+const TEST_DATE = '2026-04-22'
+
+function localMs(hour: number, minute = 0): number {
+  return new Date(2026, 3, 22, hour, minute, 0, 0).getTime()
+}
+
+function insertFocusEvent(
+  db: Database.Database,
+  tsMs: number,
+  eventType: string,
+  bundleId: string,
+  appName: string,
+  windowTitle: string | null = null,
+): void {
+  db.prepare(`
+    INSERT INTO focus_events (
+      ts_ms, mono_ns, event_type, app_bundle_id, app_name, pid,
+      window_title, url, page_title, source, confidence, platform, schema_ver
+    ) VALUES (?, ?, ?, ?, ?, 4242, ?, NULL, NULL, 'foreground_poll', 'observed', 'darwin', 2)
+  `).run(tsMs, tsMs * 1_000_000, eventType, bundleId, appName, windowTitle)
+}
+
+// The canonical day also mirrors legacy sessions so FTS-backed search (which
+// indexes app_sessions) sees the same activity — the dual-write state real
+// capture produces during the migration.
+function seedDay(db: Database.Database): void {
+  const stretches: Array<[string, string, number, number, string]> = [
+    ['com.mitchellh.ghostty', 'Ghostty', localMs(9), localMs(10, 30), 'daylens — evidence.ts'],
+    ['com.apple.Safari', 'Safari', localMs(11), localMs(11, 45), 'Quarterly launchplan review'],
+  ]
+  const insertSession = db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec,
+      category, is_focused, window_title, raw_app_name, canonical_app_id, capture_source, capture_version
+    ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'test', 1)
+  `)
+  for (const [bundleId, appName, startMs, endMs, title] of stretches) {
+    insertFocusEvent(db, startMs, 'app_activated', bundleId, appName, title)
+    insertFocusEvent(db, endMs, 'app_deactivated', bundleId, appName, title)
+    insertSession.run(
+      bundleId, appName, startMs, endMs, Math.round((endMs - startMs) / 1000),
+      appName === 'Safari' ? 'browsing' : 'development', title, appName, appName.toLowerCase(),
+    )
+  }
+}
+
+function ignoreSpan(db: Database.Database, startMs: number, endMs: number): void {
+  const now = Date.now()
+  db.prepare(`
+    INSERT INTO timeline_block_reviews (
+      id, block_id, date, evidence_key, review_state, original_block_json,
+      correction_json, created_at, updated_at
+    ) VALUES ('review_shared_consumers', 'shared_consumers_block', ?, 'shared_consumers_block', 'ignored', ?, '{}', ?, ?)
+  `).run(TEST_DATE, JSON.stringify({ startTime: startMs, endTime: endMs }), now, now)
+}
+
+test('the agent day-overview total equals the Timeline payload total exactly', () => {
+  const db = createProductionTestDatabase()
+  seedDay(db)
+  const payload = getTimelineDayPayload(db, TEST_DATE, null, { materialize: false })
+  const summary = executeTool('getDaySummary', { date: TEST_DATE }, db) as DaySummaryResult
+  assert.ok(payload.totalSeconds > 0)
+  assert.equal(summary.totalTrackedSeconds, Math.round(payload.totalSeconds))
+  assert.equal(summary.focusSeconds, Math.round(payload.focusSeconds))
+  assert.ok(summary.focusSeconds <= summary.totalTrackedSeconds)
+  db.close()
+})
+
+test('a deleted block changes the agent day-overview and Timeline identically', () => {
+  const db = createProductionTestDatabase()
+  seedDay(db)
+  const before = executeTool('getDaySummary', { date: TEST_DATE }, db) as DaySummaryResult
+  // Delete the way the product does: the review is written for the real
+  // rendered block, so it survives the materialized-day path too.
+  const beforePayload = getTimelineDayPayload(db, TEST_DATE, null, { materialize: false })
+  const safariBlock = beforePayload.blocks.find((block) =>
+    block.sessions.some((session) => session.appName === 'Safari'))
+  assert.ok(safariBlock, 'the Safari stretch renders as a block')
+  writeTimelineBlockReview(db, TEST_DATE, safariBlock, { state: 'ignored' })
+
+  const payload = getTimelineDayPayload(db, TEST_DATE, null, { materialize: false })
+  const after = executeTool('getDaySummary', { date: TEST_DATE }, db) as DaySummaryResult
+  assert.equal(after.totalTrackedSeconds, Math.round(payload.totalSeconds))
+  assert.ok(after.totalTrackedSeconds < before.totalTrackedSeconds)
+  db.close()
+})
+
+test('search reflects an ignored-span correction immediately', () => {
+  const db = createProductionTestDatabase()
+  seedDay(db)
+  const hitsBefore = searchAll(db, 'launchplan', { startDate: TEST_DATE, endDate: TEST_DATE })
+  assert.ok(hitsBefore.length > 0, 'the Safari session is searchable before the correction')
+
+  ignoreSpan(db, localMs(11), localMs(11, 45))
+  const hitsAfter = searchAll(db, 'launchplan', { startDate: TEST_DATE, endDate: TEST_DATE })
+  assert.equal(hitsAfter.length, 0, 'the deleted stretch is gone from search with no rebuild')
+  db.close()
+})
+
+test('the agent searchSessions tool reflects an ignored-span correction immediately', () => {
+  const db = createProductionTestDatabase()
+  seedDay(db)
+  const before = executeTool(
+    'searchSessions',
+    { query: 'launchplan', startDate: TEST_DATE, endDate: TEST_DATE },
+    db,
+  ) as SearchSessionsToolResult
+  assert.ok(
+    before.hits.some((hit) => (hit.windowTitle ?? '').includes('launchplan')),
+    `the session is findable before the correction (got ${JSON.stringify(before.hits)})`,
+  )
+
+  ignoreSpan(db, localMs(11), localMs(11, 45))
+  const after = executeTool(
+    'searchSessions',
+    { query: 'launchplan', startDate: TEST_DATE, endDate: TEST_DATE },
+    db,
+  ) as SearchSessionsToolResult
+  assert.equal(
+    after.hits.filter((hit) => (hit.windowTitle ?? '').includes('launchplan')).length,
+    0,
+    'the deleted stretch is gone from the tool result',
+  )
+  db.close()
+})


### PR DESCRIPTION
Closes #167. Linear: [DEV-171](https://linear.app/irachrist1/issue/DEV-171/search-the-ai-tools-mcp-and-sync-read-the-shared-facts)

## What changed

Capture migration slice 8 completes for the remaining consumers (`docs/specs/capture-and-evidence.md`, storage and repository boundaries).

- **The agent quotes the screen's numbers.** `getDaySummary` and `getWeekSummary` now cite per-block **active** seconds (the figure the Timeline rail totals) instead of wall-clock spans that enclosed absorbed gaps, and their day totals and focus figures are the Timeline payload's own `totalSeconds`/`focusSeconds`. The 6h53m-vs-2h59m divergence class is structurally gone.
- **No consumer reads raw evidence tables.** The remaining inline raw SQL in consumer surfaces moves behind named repository functions: domain discovery, candidate-day, and window-title lookups (aiTools); machine-state reconstruction and the repository-activity title corpus (chat agent tools); the bundle-id identity fallback and capture-health sampling counts (IPC handlers). MCP already delegates to the aiTools executors; the search path's correction-aware queries live in the repository layer; sync is frozen and builds no payload.
- **The agent's `get_time_chunks` reads corrected facts**: a deleted Timeline block's stretch is now empty space in chunk views (sessions and page visits alike), matching every other surface.
- **Repository-boundary check** (`tests/repositoryBoundary.test.ts`): scans renderer, preload, AI, agent, IPC, MCP, remote-contract, and the named service surfaces, and fails on any direct raw-evidence-table read. Write statements are deliberately out of scope — deletion centralization by evidence identity is its own migration slice (DEV-175).

## Evidence against acceptance criteria

- **Agent day-overview totals equal Timeline's** — pinned in `tests/sharedFactsConsumers.test.ts` (exact equality on fixture days, including after a deletion), and on the private 2026-07-13 replay: `aiFacts.dayOverview.totalTrackedSeconds` = **9513s** = Timeline `totalSeconds` = **9513s**.
- **Repository-boundary check fails on regression** — demonstrated during development: the scan caught six pre-existing violations, which this PR resolves.
- **Search and MCP reflect corrections immediately** — an ignored span disappears from `searchAll`, from the agent's `searchSessions` tool (the same executor MCP wraps), and from the day-overview total, with no rebuild, all pinned in tests.

## Verification

- `npm run verify:shipping` — exit 0 (1425 unit tests, synthetic-day, ai-turn, strict timeline eval, contract checks, web build, billing checks, full build).
- `npm run verify:real-day -- --date 2026-07-13` — AI-tool total matches Timeline exactly.

## Out of scope

New search capabilities, new agent tools, entity work; deletion centralization (DEV-175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)