### PR TITLE
Every correction previews its effect and can be undone (DEV-172)

### DIFF
--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -2358,6 +2358,40 @@ const migrations: Migration[] = [
       `)
     },
   },
+  {
+    version: 49,
+    description:
+      'Reversible evidence exclusions and the correction undo ledger (timeline spec, Corrections)',
+    up: () => {
+      const db = getDb()
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS evidence_exclusions (
+          id TEXT PRIMARY KEY,
+          date TEXT NOT NULL,
+          kind TEXT NOT NULL CHECK(kind IN ('app', 'site')),
+          bundle_id TEXT,
+          app_name TEXT,
+          domain TEXT,
+          span_start_ms INTEGER NOT NULL,
+          span_end_ms INTEGER NOT NULL,
+          created_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_evidence_exclusions_span
+          ON evidence_exclusions (span_start_ms, span_end_ms);
+        CREATE TABLE IF NOT EXISTS correction_undo_log (
+          id TEXT PRIMARY KEY,
+          date TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          description TEXT NOT NULL,
+          snapshot_json TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          undone_at INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_correction_undo_log_date
+          ON correction_undo_log (date, created_at);
+      `)
+    },
+  },
 ]
 
 export const LATEST_SCHEMA_VERSION = migrations.at(-1)?.version ?? 0

--- a/src/main/db/queries.ts
+++ b/src/main/db/queries.ts
@@ -822,6 +822,14 @@ export function searchSessions(
           AND app_sessions.start_time >= json_extract(review.original_block_json, '$.startTime')
           AND app_sessions.start_time < json_extract(review.original_block_json, '$.endTime')
       )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM evidence_exclusions exclusion
+        WHERE exclusion.kind = 'app'
+          AND (exclusion.bundle_id = app_sessions.bundle_id OR exclusion.app_name = app_sessions.app_name)
+          AND app_sessions.start_time >= exclusion.span_start_ms
+          AND app_sessions.start_time < exclusion.span_end_ms
+      )
     ORDER BY app_sessions.start_time DESC
     LIMIT ?
   `).all(SEARCH_HIGHLIGHT_START, SEARCH_HIGHLIGHT_END, ftsQuery, fromMs, toMs, limit) as {
@@ -965,6 +973,14 @@ export function searchBrowser(
         WHERE review.review_state = 'ignored'
           AND website_visits.visit_time >= json_extract(review.original_block_json, '$.startTime')
           AND website_visits.visit_time < json_extract(review.original_block_json, '$.endTime')
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM evidence_exclusions exclusion
+        WHERE exclusion.kind = 'site'
+          AND exclusion.domain = website_visits.domain
+          AND website_visits.visit_time >= exclusion.span_start_ms
+          AND website_visits.visit_time < exclusion.span_end_ms
       )
     ORDER BY website_visits.visit_time DESC
     LIMIT ?

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -412,6 +412,45 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_timeline_boundary_corrections_pair
 CREATE INDEX IF NOT EXISTS idx_timeline_boundary_corrections_date
   ON timeline_boundary_corrections (date);
 
+-- Reversible evidence exclusions (timeline spec, Corrections: "exclude
+-- specific evidence"). Unlike the permanent purge, an exclusion leaves the raw
+-- rows untouched: the corrected activity-fact reads subtract the matching
+-- identity inside the span, so Timeline, Apps, search, and the AI all skip it,
+-- and undo simply deletes the exclusion row.
+CREATE TABLE IF NOT EXISTS evidence_exclusions (
+  id TEXT PRIMARY KEY,
+  date TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK(kind IN ('app', 'site')),
+  bundle_id TEXT,
+  app_name TEXT,
+  domain TEXT,
+  span_start_ms INTEGER NOT NULL,
+  span_end_ms INTEGER NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_evidence_exclusions_span
+  ON evidence_exclusions (span_start_ms, span_end_ms);
+
+-- Undo ledger for correction commands. Each applied correction snapshots the
+-- correction-ledger rows it may touch (reviews, boundary corrections, label
+-- overrides, evidence exclusions, work-session attribution); undo restores the
+-- snapshot in one transaction. Raw evidence never appears here — only the
+-- correction overlay, so the log stays small and undo can never resurrect
+-- purged data.
+CREATE TABLE IF NOT EXISTS correction_undo_log (
+  id TEXT PRIMARY KEY,
+  date TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  description TEXT NOT NULL,
+  snapshot_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  undone_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_correction_undo_log_date
+  ON correction_undo_log (date, created_at);
+
 CREATE TABLE IF NOT EXISTS app_identities (
   app_instance_id TEXT PRIMARY KEY,
   bundle_id TEXT NOT NULL,

--- a/src/main/ipc/db.handlers.ts
+++ b/src/main/ipc/db.handlers.ts
@@ -38,6 +38,7 @@ import {
   findClientByName,
   listClients,
   listClientsDetailed,
+  listProjects,
   createClient,
   updateClient,
   archiveClient,
@@ -1032,6 +1033,10 @@ export function registerDbHandlers(): void {
 
   ipcMain.handle(IPC.ATTRIBUTION.LIST_CLIENTS_DETAILED, (): ClientRecord[] => {
     return listClientsDetailed(getDb())
+  })
+
+  ipcMain.handle(IPC.ATTRIBUTION.LIST_PROJECTS, () => {
+    return listProjects(getDb())
   })
 
   ipcMain.handle(IPC.ATTRIBUTION.CREATE_CLIENT, async (_e, payload: { name: string; color?: string | null }): Promise<ClientRecord> => {

--- a/src/main/ipc/db.handlers.ts
+++ b/src/main/ipc/db.handlers.ts
@@ -57,6 +57,7 @@ import { isWindowsFocusCaptureRunning } from '../services/windowsFocusCapture'
 import { deleteHistoryForApp, deleteHistoryForSite, deleteTrackedActivity } from '../services/trackingHistory'
 import { getProcessMetrics } from '../services/processMonitor'
 import { getBlockDetailPayload, getDistractionCostPayload, getRecapRange, writeTimelineBlockReview, mergeTimelineEpisodes, trimTimelineBlockSpan, invalidateTimelineDayBlocks } from '../services/workBlocks'
+import { applyCorrection, previewCorrection, undoCorrection } from '../services/correctionCommands'
 import { getTimelineRangeBlocks } from '../services/timelineCalendarRange'
 import { computeAppActivityDigest } from '../services/appActivityDigest'
 import { analyzeTimelineDay } from '../services/analyzeDay'
@@ -85,6 +86,10 @@ import type {
   TimelineBlockReviewUpdate,
   TimelineBlockEditPayload,
   TimelineBlockEditResult,
+  CorrectionCommand,
+  CorrectionPreview,
+  CorrectionApplyResult,
+  CorrectionUndoResult,
   PurgeTrackedEvidencePayload,
   WorkMemorySettingsSummary,
 } from '@shared/types'
@@ -845,6 +850,36 @@ export function registerDbHandlers(): void {
     invalidateProjectionScope('apps', 'block_purge')
     invalidateProjectionScope('insights', 'block_purge')
     return { purged: true }
+  })
+
+  // ─── Correction commands (timeline spec, Corrections; DEV-172) ────────────
+  // Preview computes the exact cross-surface effect of a correction without
+  // persisting anything; apply commits it atomically with an undo entry; undo
+  // restores the correction ledger to the pre-apply snapshot. Permanent purges
+  // stay on their own destructive, confirmed paths above.
+  ipcMain.handle(IPC.DB.PREVIEW_CORRECTION, (_e, command: CorrectionCommand): CorrectionPreview => {
+    return previewCorrection(getDb(), command, getLiveSessionForDate(command.date))
+  })
+
+  ipcMain.handle(IPC.DB.APPLY_CORRECTION, (_e, command: CorrectionCommand): CorrectionApplyResult => {
+    const db = getDb()
+    // A merge touching the still-live block needs the in-flight session
+    // persisted first, or the block re-splits on the next tracking tick —
+    // same guard as the legacy merge channel.
+    if (command.kind === 'merge') flushCurrentSession()
+    const result = applyCorrection(db, command, getLiveSessionForDate(command.date))
+    invalidateProjectionScope('timeline', 'correction_command', { date: command.date })
+    invalidateProjectionScope('apps', 'correction_command', { date: command.date })
+    invalidateProjectionScope('insights', 'correction_command', { date: command.date })
+    return result
+  })
+
+  ipcMain.handle(IPC.DB.UNDO_CORRECTION, (_e, correctionId: string): CorrectionUndoResult => {
+    const result = undoCorrection(getDb(), correctionId)
+    invalidateProjectionScope('timeline', 'correction_undo')
+    invalidateProjectionScope('apps', 'correction_undo')
+    invalidateProjectionScope('insights', 'correction_undo')
+    return result
   })
 
   ipcMain.handle(IPC.DB.MERGE_TIMELINE_EPISODES, (_e, payload: { blockIds: [string, string]; date?: string | null }): DayTimelinePayload => {

--- a/src/main/services/activityFacts.ts
+++ b/src/main/services/activityFacts.ts
@@ -47,11 +47,78 @@ const APP_CATEGORIES = new Set<AppCategory>([
   'system', 'uncategorized',
 ])
 
-function reviewsTableExists(db: Database.Database): boolean {
+function tableExists(db: Database.Database, name: string): boolean {
   const row = db.prepare(
-    `SELECT name FROM sqlite_master WHERE type='table' AND name='timeline_block_reviews' LIMIT 1`,
-  ).get() as { name: string } | undefined
+    `SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1`,
+  ).get(name) as { name: string } | undefined
   return Boolean(row)
+}
+
+function reviewsTableExists(db: Database.Database): boolean {
+  return tableExists(db, 'timeline_block_reviews')
+}
+
+// ─── Reversible evidence exclusions (timeline spec, Corrections) ─────────────
+// "Exclude specific evidence" hides one app or site inside a span from every
+// corrected read — Timeline, Apps, search, AI — without touching the raw rows,
+// so the correction can be undone. Matching mirrors the permanent purge's
+// identity rule (bundle id OR display name; domain for sites).
+
+export interface EvidenceExclusionSpan {
+  id: string
+  kind: 'app' | 'site'
+  bundleId: string | null
+  appName: string | null
+  domain: string | null
+  startMs: number
+  endMs: number
+}
+
+export function getEvidenceExclusionsForRange(
+  db: Database.Database,
+  fromMs: number,
+  toMs: number,
+): EvidenceExclusionSpan[] {
+  if (!tableExists(db, 'evidence_exclusions')) return []
+  const rows = db.prepare(`
+    SELECT id, kind, bundle_id, app_name, domain, span_start_ms, span_end_ms
+    FROM evidence_exclusions
+    WHERE span_start_ms < ? AND span_end_ms > ?
+  `).all(toMs, fromMs) as Array<{
+    id: string
+    kind: 'app' | 'site'
+    bundle_id: string | null
+    app_name: string | null
+    domain: string | null
+    span_start_ms: number
+    span_end_ms: number
+  }>
+  return rows.map((row) => ({
+    id: row.id,
+    kind: row.kind,
+    bundleId: row.bundle_id,
+    appName: row.app_name,
+    domain: row.domain,
+    startMs: row.span_start_ms,
+    endMs: row.span_end_ms,
+  }))
+}
+
+function sessionMatchesExclusion(session: AppSession, exclusion: EvidenceExclusionSpan): boolean {
+  if (exclusion.kind !== 'app') return false
+  return Boolean(
+    (exclusion.bundleId && session.bundleId === exclusion.bundleId)
+    || (exclusion.appName && session.appName === exclusion.appName),
+  )
+}
+
+function excludedSpansForSession(
+  session: AppSession,
+  exclusions: readonly EvidenceExclusionSpan[],
+): CorrectionSpan[] {
+  return exclusions
+    .filter((exclusion) => sessionMatchesExclusion(session, exclusion))
+    .map((exclusion) => ({ startMs: exclusion.startMs, endMs: exclusion.endMs }))
 }
 
 /** The time spans of every Timeline block the user deleted, clipped to the
@@ -206,8 +273,13 @@ export function applyTimelineCorrectionsToSessions(
 ): AppSession[] {
   const spans = getIgnoredBlockSpansForRange(db, fromMs, toMs)
   const categorySpans = getCategoryCorrectionSpansForRange(db, fromMs, toMs)
-  if (spans.length === 0 && categorySpans.length === 0) return [...sessions]
-  return sessions.flatMap((session) => correctedPiecesForSession(session, fromMs, toMs, spans, categorySpans))
+  const exclusions = getEvidenceExclusionsForRange(db, fromMs, toMs)
+  if (spans.length === 0 && categorySpans.length === 0 && exclusions.length === 0) return [...sessions]
+  return sessions.flatMap((session) => {
+    const excluded = excludedSpansForSession(session, exclusions)
+    const ignoredForSession = excluded.length > 0 ? mergeCorrectionSpans([...spans, ...excluded]) : spans
+    return correctedPiecesForSession(session, fromMs, toMs, ignoredForSession, categorySpans)
+  })
 }
 
 /** Aggregate corrected sessions into per-app usage summaries. Also feeds the
@@ -332,19 +404,45 @@ export function getCorrectedDomainIntervals(
   domainFilter?: (domain: string) => boolean,
 ): CorrectedDomainInterval[] {
   const ignored = getIgnoredBlockSpansForRange(db, fromMs, toMs)
+  const siteExclusions = getEvidenceExclusionsForRange(db, fromMs, toMs)
+    .filter((exclusion) => exclusion.kind === 'site' && exclusion.domain)
   // Page credit clips against the same corrected foreground ownership the app
   // totals are built from, so a domain's time can never exceed its browser's.
   const reconciled = getReconciledDomainIntervals(
     db, fromMs, toMs, domainFilter,
     (chunkFromMs, chunkToMs) => getCorrectedSessionsForRange(db, chunkFromMs, chunkToMs),
   )
-  return reconciled.flatMap((interval) =>
-    subtractSpansFromInterval(interval.start, interval.end, ignored).map((piece) => ({
+  return reconciled.flatMap((interval) => {
+    const excludedForDomain = siteExclusions
+      .filter((exclusion) => exclusion.domain === interval.domain)
+      .map((exclusion) => ({ startMs: exclusion.startMs, endMs: exclusion.endMs }))
+    const subtracted = excludedForDomain.length > 0
+      ? mergeCorrectionSpans([...ignored, ...excludedForDomain])
+      : ignored
+    return subtractSpansFromInterval(interval.start, interval.end, subtracted).map((piece) => ({
       domain: interval.domain,
       visitId: interval.visitId,
       ...piece,
-    })),
+    }))
+  })
+}
+
+/** Drop website summaries whose domain the user excluded anywhere inside the
+ *  queried range — the per-block site lists read raw summaries, and an
+ *  excluded site must vanish from the block's evidence, not just its totals. */
+export function filterExcludedWebsiteSummaries(
+  db: Database.Database,
+  summaries: readonly WebsiteSummary[],
+  fromMs: number,
+  toMs: number,
+): WebsiteSummary[] {
+  const excludedDomains = new Set(
+    getEvidenceExclusionsForRange(db, fromMs, toMs)
+      .filter((exclusion) => exclusion.kind === 'site' && exclusion.domain)
+      .map((exclusion) => exclusion.domain as string),
   )
+  if (excludedDomains.size === 0) return [...summaries]
+  return summaries.filter((summary) => !excludedDomains.has(summary.domain))
 }
 
 /** Website facts corrected by the same interval ledger as app facts. */

--- a/src/main/services/correctionCommands.ts
+++ b/src/main/services/correctionCommands.ts
@@ -1,0 +1,495 @@
+// Correction commands (timeline spec, Corrections; DEV-172).
+//
+// Every non-destructive correction — rename, category, trim, merge, split,
+// exclude a block, exclude specific evidence, assign a client — flows through
+// one typed command with three verbs:
+//
+//   previewCorrection  — applies the command inside a SQLite savepoint, reads
+//                        the corrected day and Apps facts, rolls back, and
+//                        returns the delta. The preview IS the apply, dry-run:
+//                        it can never drift from what apply will do.
+//   applyCorrection    — one transaction: snapshot the correction-ledger rows
+//                        the command may touch, apply, record the undo entry.
+//                        A conflicting correction throws before or inside the
+//                        transaction and nothing lands (spec: "Conflicting
+//                        corrections do not apply partially").
+//   undoCorrection     — restores the snapshot in one transaction. Only the
+//                        newest un-undone correction of a date can be undone,
+//                        so interleaved restores can't corrupt the ledger.
+//
+// Permanent purges are NOT commands. They destroy raw rows, require their own
+// confirmation, and have no undo — the spec keeps them clearly separated.
+import { randomUUID } from 'node:crypto'
+import type Database from 'better-sqlite3'
+import type {
+  AppCategory,
+  CorrectionAppDelta,
+  CorrectionApplyResult,
+  CorrectionBlockDelta,
+  CorrectionCommand,
+  CorrectionPreview,
+  CorrectionUndoResult,
+  DayTimelinePayload,
+  LiveSession,
+  WorkContextBlock,
+} from '@shared/types'
+import { localDayBounds } from '../lib/localDate'
+import { materializeTimelineDayProjection } from '../core/query/projections'
+import { getCorrectedAppSummariesForRange } from './activityFacts'
+import { applyTimelineBlockEdit } from './timelineBlockEdits'
+import {
+  invalidateTimelineDayBlocks,
+  mergeTimelineEpisodes,
+  writeSplitCorrection,
+  writeTimelineBlockReview,
+} from './workBlocks'
+
+const MIN_SPLIT_EDGE_MS = 60_000
+
+interface ResolvedCommand {
+  payload: DayTimelinePayload
+  blocks: WorkContextBlock[]
+}
+
+interface LedgerSnapshot {
+  affectedBlockIds: string[]
+  reviews: Array<Record<string, unknown>>
+  boundary: Array<Record<string, unknown>>
+  labelOverrides: Array<Record<string, unknown>>
+  exclusions: Array<Record<string, unknown>>
+  workSessions: Array<{
+    id: string
+    client_id: string | null
+    project_id: string | null
+    attribution_status: string | null
+    attribution_confidence: number | null
+  }>
+  segmentAttributions: Array<{
+    segment_id: string
+    client_id: string | null
+    project_id: string | null
+    decision_source: string | null
+    confidence: number | null
+  }>
+}
+
+function blockIdsOf(command: CorrectionCommand): string[] {
+  if (command.kind === 'merge') return command.blockIds
+  return [command.blockId]
+}
+
+function resolveCommand(
+  db: Database.Database,
+  command: CorrectionCommand,
+  live: LiveSession | null,
+): ResolvedCommand {
+  const payload = materializeTimelineDayProjection(db, command.date, live)
+  const blocks = blockIdsOf(command).map((blockId) => {
+    const block = payload.blocks.find((candidate) => candidate.id === blockId)
+    if (!block) throw new Error('Block not found — the day may have just rebuilt. Reopen it and try again.')
+    return block
+  })
+  if (command.kind === 'merge' && blocks.length < 2) {
+    throw new Error('Pick at least two blocks to merge.')
+  }
+  if (command.kind === 'split') {
+    const [block] = blocks
+    if (command.cutMs < block.startTime + MIN_SPLIT_EDGE_MS || command.cutMs > block.endTime - MIN_SPLIT_EDGE_MS) {
+      throw new Error('Pick a split point at least a minute inside the block.')
+    }
+  }
+  if (command.kind === 'exclude-evidence') {
+    const ref = command.evidence
+    const identity = ref.kind === 'site' ? ref.domain?.trim() : (ref.bundleId ?? ref.appName)?.trim()
+    if (!identity) throw new Error('Nothing to exclude.')
+  }
+  return { payload, blocks }
+}
+
+function clientNameFor(db: Database.Database, clientId: string | null): string | null {
+  if (!clientId) return null
+  const row = db.prepare(`SELECT name FROM clients WHERE id = ?`).get(clientId) as { name: string } | undefined
+  return row?.name ?? null
+}
+
+function describeCommand(
+  db: Database.Database,
+  command: CorrectionCommand,
+  blocks: readonly WorkContextBlock[],
+): string {
+  const label = (block: WorkContextBlock): string => block.label.current
+  switch (command.kind) {
+    case 'edit': {
+      const parts: string[] = []
+      if (command.label && command.label.trim() !== blocks[0].label.current) {
+        parts.push(`Rename "${label(blocks[0])}" to "${command.label.trim()}"`)
+      }
+      if (command.category && command.category !== blocks[0].dominantCategory) {
+        parts.push(parts.length > 0 ? `change its category to ${command.category}` : `Change the category of "${label(blocks[0])}" to ${command.category}`)
+      }
+      if (command.startMs !== undefined || command.endMs !== undefined) {
+        parts.push(parts.length > 0 ? 'adjust its time range' : `Adjust the time range of "${label(blocks[0])}"`)
+      }
+      return parts.length > 0 ? parts.join(', ') : `Edit "${label(blocks[0])}"`
+    }
+    case 'merge':
+      return `Merge ${blocks.length} blocks into one`
+    case 'split': {
+      const at = new Date(command.cutMs).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+      return `Split "${label(blocks[0])}" at ${at}`
+    }
+    case 'exclude-block':
+      return `Remove "${label(blocks[0])}" from the day`
+    case 'exclude-evidence': {
+      const subject = command.evidence.kind === 'site'
+        ? command.evidence.domain
+        : (command.evidence.appName ?? command.evidence.bundleId)
+      return `Exclude ${subject} from "${label(blocks[0])}"`
+    }
+    case 'assign-client': {
+      const name = clientNameFor(db, command.clientId)
+      return name
+        ? `Assign "${label(blocks[0])}" to ${name}`
+        : `Remove the client assignment from "${label(blocks[0])}"`
+    }
+  }
+}
+
+// The single write path preview and apply share. Resolution already validated
+// the command; everything here writes only correction-ledger rows (reviews,
+// boundary corrections, label overrides, evidence exclusions, work-session
+// attribution) — never raw evidence.
+function applyCommandToLedger(
+  db: Database.Database,
+  command: CorrectionCommand,
+  resolved: ResolvedCommand,
+): void {
+  switch (command.kind) {
+    case 'edit': {
+      applyTimelineBlockEdit(db, resolved.blocks[0], {
+        blockId: command.blockId,
+        date: command.date,
+        label: command.label,
+        category: command.category,
+        startMs: command.startMs,
+        endMs: command.endMs,
+      })
+      return
+    }
+    case 'merge': {
+      mergeTimelineEpisodes(db, command.date, [...resolved.blocks])
+      return
+    }
+    case 'split': {
+      writeSplitCorrection(db, command.date, command.cutMs)
+      invalidateTimelineDayBlocks(db, command.date)
+      return
+    }
+    case 'exclude-block': {
+      writeTimelineBlockReview(db, command.date, resolved.blocks[0], { state: 'ignored' })
+      return
+    }
+    case 'exclude-evidence': {
+      const block = resolved.blocks[0]
+      const ref = command.evidence
+      db.prepare(`
+        INSERT INTO evidence_exclusions (id, date, kind, bundle_id, app_name, domain, span_start_ms, span_end_ms, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        `excl_${randomUUID().replace(/-/g, '').slice(0, 18)}`,
+        command.date,
+        ref.kind,
+        ref.bundleId ?? null,
+        ref.appName ?? null,
+        ref.domain ?? null,
+        block.startTime,
+        block.endTime,
+        Date.now(),
+      )
+      invalidateTimelineDayBlocks(db, command.date)
+      return
+    }
+    case 'assign-client': {
+      const block = resolved.blocks[0]
+      const now = Date.now()
+      const sessions = db.prepare(`
+        SELECT id FROM work_sessions WHERE started_at < ? AND ended_at > ?
+      `).all(block.endTime, block.startTime) as Array<{ id: string }>
+      for (const { id } of sessions) {
+        db.prepare(`
+          UPDATE work_sessions
+          SET client_id = ?, project_id = ?,
+              attribution_status = CASE WHEN ? IS NOT NULL THEN 'attributed' ELSE 'unattributed' END,
+              attribution_confidence = CASE WHEN ? IS NOT NULL THEN 1.0 ELSE NULL END,
+              updated_at = ?
+          WHERE id = ?
+        `).run(command.clientId, command.projectId ?? null, command.clientId, command.clientId, now, id)
+        db.prepare(`
+          UPDATE segment_attributions
+          SET client_id = ?, project_id = ?, decision_source = 'user', confidence = 1.0
+          WHERE rank = 1 AND segment_id IN (
+            SELECT segment_id FROM work_session_segments WHERE work_session_id = ?
+          )
+        `).run(command.clientId, command.projectId ?? null, id)
+      }
+      return
+    }
+  }
+}
+
+function captureSnapshot(
+  db: Database.Database,
+  command: CorrectionCommand,
+  resolved: ResolvedCommand,
+): LedgerSnapshot {
+  const affectedBlockIds = resolved.blocks.map((block) => block.id)
+  const blockIdMarks = affectedBlockIds.map(() => '?').join(', ') || `''`
+  const reviews = db.prepare(`
+    SELECT * FROM timeline_block_reviews WHERE date = ? OR block_id IN (${blockIdMarks})
+  `).all(command.date, ...affectedBlockIds) as Array<Record<string, unknown>>
+  const boundary = db.prepare(`
+    SELECT * FROM timeline_boundary_corrections WHERE date = ?
+  `).all(command.date) as Array<Record<string, unknown>>
+  const labelOverrides = affectedBlockIds.length === 0 ? [] : db.prepare(`
+    SELECT * FROM block_label_overrides WHERE block_id IN (${blockIdMarks})
+  `).all(...affectedBlockIds) as Array<Record<string, unknown>>
+  const exclusions = db.prepare(`
+    SELECT * FROM evidence_exclusions WHERE date = ?
+  `).all(command.date) as Array<Record<string, unknown>>
+
+  let workSessions: LedgerSnapshot['workSessions'] = []
+  let segmentAttributions: LedgerSnapshot['segmentAttributions'] = []
+  if (command.kind === 'assign-client') {
+    const block = resolved.blocks[0]
+    workSessions = db.prepare(`
+      SELECT id, client_id, project_id, attribution_status, attribution_confidence
+      FROM work_sessions WHERE started_at < ? AND ended_at > ?
+    `).all(block.endTime, block.startTime) as LedgerSnapshot['workSessions']
+    const sessionMarks = workSessions.map(() => '?').join(', ')
+    segmentAttributions = workSessions.length === 0 ? [] : db.prepare(`
+      SELECT segment_id, client_id, project_id, decision_source, confidence
+      FROM segment_attributions
+      WHERE rank = 1 AND segment_id IN (
+        SELECT segment_id FROM work_session_segments WHERE work_session_id IN (${sessionMarks})
+      )
+    `).all(...workSessions.map((session) => session.id)) as LedgerSnapshot['segmentAttributions']
+  }
+
+  return { affectedBlockIds, reviews, boundary, labelOverrides, exclusions, workSessions, segmentAttributions }
+}
+
+function restoreRows(
+  db: Database.Database,
+  table: string,
+  rows: readonly Record<string, unknown>[],
+): void {
+  for (const row of rows) {
+    const columns = Object.keys(row)
+    db.prepare(`
+      INSERT INTO ${table} (${columns.join(', ')}) VALUES (${columns.map(() => '?').join(', ')})
+    `).run(...columns.map((column) => row[column]))
+  }
+}
+
+function restoreSnapshot(db: Database.Database, dateStr: string, snapshot: LedgerSnapshot): void {
+  const blockIdMarks = snapshot.affectedBlockIds.map(() => '?').join(', ') || `''`
+  db.prepare(`DELETE FROM timeline_block_reviews WHERE date = ? OR block_id IN (${blockIdMarks})`)
+    .run(dateStr, ...snapshot.affectedBlockIds)
+  db.prepare(`DELETE FROM timeline_boundary_corrections WHERE date = ?`).run(dateStr)
+  if (snapshot.affectedBlockIds.length > 0) {
+    db.prepare(`DELETE FROM block_label_overrides WHERE block_id IN (${blockIdMarks})`)
+      .run(...snapshot.affectedBlockIds)
+  }
+  db.prepare(`DELETE FROM evidence_exclusions WHERE date = ?`).run(dateStr)
+  restoreRows(db, 'timeline_block_reviews', snapshot.reviews)
+  restoreRows(db, 'timeline_boundary_corrections', snapshot.boundary)
+  restoreRows(db, 'block_label_overrides', snapshot.labelOverrides)
+  restoreRows(db, 'evidence_exclusions', snapshot.exclusions)
+  for (const session of snapshot.workSessions) {
+    // Attribution ids churn on reprojection; a vanished session simply has
+    // nothing to restore.
+    db.prepare(`
+      UPDATE work_sessions
+      SET client_id = ?, project_id = ?, attribution_status = ?, attribution_confidence = ?, updated_at = ?
+      WHERE id = ?
+    `).run(
+      session.client_id, session.project_id, session.attribution_status,
+      session.attribution_confidence, Date.now(), session.id,
+    )
+  }
+  for (const attribution of snapshot.segmentAttributions) {
+    db.prepare(`
+      UPDATE segment_attributions
+      SET client_id = ?, project_id = ?, decision_source = ?, confidence = ?
+      WHERE rank = 1 AND segment_id = ?
+    `).run(
+      attribution.client_id, attribution.project_id, attribution.decision_source,
+      attribution.confidence, attribution.segment_id,
+    )
+  }
+}
+
+function blockDeltas(
+  targets: readonly WorkContextBlock[],
+  after: DayTimelinePayload,
+): CorrectionBlockDelta[] {
+  return targets.map((target) => {
+    const midpoint = target.startTime + (target.endTime - target.startTime) / 2
+    const successor = after.blocks.find((candidate) =>
+      candidate.startTime <= midpoint && candidate.endTime > midpoint
+      && candidate.review?.state !== 'ignored')
+      ?? null
+    return {
+      blockId: target.id,
+      labelBefore: target.label.current,
+      labelAfter: successor ? successor.label.current : null,
+      startMsBefore: target.startTime,
+      endMsBefore: target.endTime,
+      startMsAfter: successor?.startTime ?? null,
+      endMsAfter: successor?.endTime ?? null,
+      categoryBefore: target.dominantCategory,
+      categoryAfter: successor?.dominantCategory ?? null,
+    }
+  })
+}
+
+function appDeltas(
+  before: ReturnType<typeof getCorrectedAppSummariesForRange>,
+  after: ReturnType<typeof getCorrectedAppSummariesForRange>,
+): CorrectionAppDelta[] {
+  const names = new Set([...before.map((app) => app.appName), ...after.map((app) => app.appName)])
+  const deltas: CorrectionAppDelta[] = []
+  for (const appName of names) {
+    const secondsBefore = before.find((app) => app.appName === appName)?.totalSeconds ?? 0
+    const secondsAfter = after.find((app) => app.appName === appName)?.totalSeconds ?? 0
+    if (Math.abs(secondsBefore - secondsAfter) >= 30) deltas.push({ appName, secondsBefore, secondsAfter })
+  }
+  return deltas.sort((a, b) => Math.abs(b.secondsAfter - b.secondsBefore) - Math.abs(a.secondsAfter - a.secondsBefore))
+}
+
+function surfaceNotes(
+  db: Database.Database,
+  command: CorrectionCommand,
+  blocks: readonly WorkContextBlock[],
+  category: AppCategory | undefined,
+): string[] {
+  const notes: string[] = []
+  switch (command.kind) {
+    case 'edit':
+      if (command.label?.trim()) {
+        notes.push(`Search and the AI will know this block as "${command.label.trim()}".`)
+      }
+      if (category) notes.push(`Apps and Timeline recolor this stretch as ${category}.`)
+      if (command.startMs !== undefined) {
+        notes.push('Trimmed-off minutes re-form into their own block; nothing is lost.')
+      }
+      break
+    case 'merge':
+      notes.push('The merged block survives every re-analysis; search finds one block instead of several.')
+      break
+    case 'split':
+      notes.push('The cut survives every re-analysis; each side keeps its own evidence.')
+      break
+    case 'exclude-block':
+      notes.push(`This stretch disappears from Timeline, Apps totals, search, and AI answers for ${command.date}. Raw capture is kept; undo brings it back.`)
+      break
+    case 'exclude-evidence': {
+      const subject = command.evidence.kind === 'site'
+        ? command.evidence.domain
+        : (command.evidence.appName ?? command.evidence.bundleId)
+      notes.push(`${subject} disappears from this block's evidence, the Apps totals, search, and AI answers. Raw capture is kept; undo brings it back.`)
+      break
+    }
+    case 'assign-client': {
+      const name = clientNameFor(db, command.clientId)
+      notes.push(name
+        ? `Time in "${blocks[0].label.current}" counts toward ${name} in client rollups and reports.`
+        : `Time in "${blocks[0].label.current}" no longer counts toward any client.`)
+      break
+    }
+  }
+  return notes
+}
+
+export function previewCorrection(
+  db: Database.Database,
+  command: CorrectionCommand,
+  live: LiveSession | null,
+): CorrectionPreview {
+  const [dayFromMs, dayToMs] = localDayBounds(command.date)
+  const resolved = resolveCommand(db, command, live)
+  const appsBefore = getCorrectedAppSummariesForRange(db, dayFromMs, dayToMs, live)
+  const description = describeCommand(db, command, resolved.blocks)
+
+  db.exec('SAVEPOINT correction_preview')
+  try {
+    applyCommandToLedger(db, command, resolved)
+    const after = materializeTimelineDayProjection(db, command.date, live)
+    const appsAfter = getCorrectedAppSummariesForRange(db, dayFromMs, dayToMs, live)
+    const category = command.kind === 'edit' ? command.category : undefined
+    return {
+      description,
+      totalSecondsBefore: Math.round(resolved.payload.totalSeconds),
+      totalSecondsAfter: Math.round(after.totalSeconds),
+      blockCountBefore: resolved.payload.blocks.length,
+      blockCountAfter: after.blocks.length,
+      blocks: blockDeltas(resolved.blocks, after),
+      apps: appDeltas(appsBefore, appsAfter),
+      surfaces: surfaceNotes(db, command, resolved.blocks, category),
+    }
+  } finally {
+    db.exec('ROLLBACK TO correction_preview')
+    db.exec('RELEASE correction_preview')
+  }
+}
+
+export function applyCorrection(
+  db: Database.Database,
+  command: CorrectionCommand,
+  live: LiveSession | null,
+): CorrectionApplyResult {
+  const resolved = resolveCommand(db, command, live)
+  const description = describeCommand(db, command, resolved.blocks)
+  const snapshot = captureSnapshot(db, command, resolved)
+  const correctionId = `corr_${randomUUID().replace(/-/g, '').slice(0, 18)}`
+  const commit = db.transaction(() => {
+    applyCommandToLedger(db, command, resolved)
+    db.prepare(`
+      INSERT INTO correction_undo_log (id, date, kind, description, snapshot_json, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(correctionId, command.date, command.kind, description, JSON.stringify(snapshot), Date.now())
+  })
+  commit()
+  return { correctionId, description }
+}
+
+interface UndoRow {
+  id: string
+  date: string
+  kind: string
+  description: string
+  snapshot_json: string
+  created_at: number
+  undone_at: number | null
+}
+
+export function undoCorrection(db: Database.Database, correctionId: string): CorrectionUndoResult {
+  const row = db.prepare(`SELECT * FROM correction_undo_log WHERE id = ?`).get(correctionId) as UndoRow | undefined
+  if (!row) throw new Error('Nothing to undo.')
+  if (row.undone_at != null) return { undone: false, description: row.description }
+  const newer = db.prepare(`
+    SELECT id FROM correction_undo_log
+    WHERE date = ? AND undone_at IS NULL AND created_at > ? AND id != ?
+    LIMIT 1
+  `).get(row.date, row.created_at, row.id) as { id: string } | undefined
+  if (newer) throw new Error('A newer correction exists for this day — undo that one first.')
+
+  const snapshot = JSON.parse(row.snapshot_json) as LedgerSnapshot
+  const commit = db.transaction(() => {
+    restoreSnapshot(db, row.date, snapshot)
+    db.prepare(`UPDATE correction_undo_log SET undone_at = ? WHERE id = ?`).run(Date.now(), row.id)
+    invalidateTimelineDayBlocks(db, row.date)
+  })
+  commit()
+  return { undone: true, description: row.description }
+}

--- a/src/main/services/correctionCommands.ts
+++ b/src/main/services/correctionCommands.ts
@@ -112,6 +112,12 @@ function clientNameFor(db: Database.Database, clientId: string | null): string |
   return row?.name ?? null
 }
 
+function projectNameFor(db: Database.Database, projectId: string | null | undefined): string | null {
+  if (!projectId) return null
+  const row = db.prepare(`SELECT name FROM projects WHERE id = ?`).get(projectId) as { name: string } | undefined
+  return row?.name ?? null
+}
+
 function describeCommand(
   db: Database.Database,
   command: CorrectionCommand,
@@ -148,9 +154,11 @@ function describeCommand(
     }
     case 'assign-client': {
       const name = clientNameFor(db, command.clientId)
-      return name
-        ? `Assign "${label(blocks[0])}" to ${name}`
-        : `Remove the client assignment from "${label(blocks[0])}"`
+      if (!name) return `Remove the client assignment from "${label(blocks[0])}"`
+      const project = projectNameFor(db, command.projectId)
+      return project
+        ? `Assign "${label(blocks[0])}" to ${name} · ${project}`
+        : `Assign "${label(blocks[0])}" to ${name}`
     }
   }
 }
@@ -215,6 +223,11 @@ function applyCommandToLedger(
       const sessions = db.prepare(`
         SELECT id FROM work_sessions WHERE started_at < ? AND ended_at > ?
       `).all(block.endTime, block.startTime) as Array<{ id: string }>
+      if (sessions.length === 0 && (command.clientId != null || command.projectId != null)) {
+        throw new Error(
+          'Nothing to attribute in this block yet — attribution needs a work session overlapping the block.',
+        )
+      }
       for (const { id } of sessions) {
         db.prepare(`
           UPDATE work_sessions
@@ -402,9 +415,14 @@ function surfaceNotes(
     }
     case 'assign-client': {
       const name = clientNameFor(db, command.clientId)
-      notes.push(name
-        ? `Time in "${blocks[0].label.current}" counts toward ${name} in client rollups and reports.`
-        : `Time in "${blocks[0].label.current}" no longer counts toward any client.`)
+      const project = projectNameFor(db, command.projectId)
+      if (!name) {
+        notes.push(`Time in "${blocks[0].label.current}" no longer counts toward any client.`)
+      } else if (project) {
+        notes.push(`Time in "${blocks[0].label.current}" counts toward ${name} · ${project} in client rollups and reports.`)
+      } else {
+        notes.push(`Time in "${blocks[0].label.current}" counts toward ${name} in client rollups and reports.`)
+      }
       break
     }
   }

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -77,7 +77,7 @@ import {
 } from './workMemory'
 import { isBrowserApplication } from './browserRegistry'
 import { getBackgroundProcessEvidence } from './backgroundProcessEvidence'
-import { getCorrectedWebsiteSummariesForRange } from './activityFacts'
+import { filterExcludedWebsiteSummaries, getCorrectedWebsiteSummariesForRange } from './activityFacts'
 import { queryCorrectedActivityFactsForRange } from '../core/query/activityFactsQuery'
 
 /**
@@ -1889,7 +1889,7 @@ function writeBoundaryCorrection(
 // wall-clock timestamp (span_start_ms): session ids churn across the
 // app_sessions ↔ derived_sessions namespaces, but the moment the user pointed
 // at does not. Enforced by enforceUserCuts as the last pipeline pass.
-function writeSplitCorrection(db: Database.Database, dateStr: string, cutMs: number): void {
+export function writeSplitCorrection(db: Database.Database, dateStr: string, cutMs: number): void {
   const now = Date.now()
   const id = `cut_${sha1(`${dateStr}:${cutMs}`).slice(0, 18)}`
   // The (left, right) session-id pair has a unique index; a cut is anchored to
@@ -2712,7 +2712,9 @@ function buildBlockFromCandidate(
   const coherence = coherenceScore(distribution)
   const switchCount = countAppSwitches(candidate.sessions)
   const computedAt = Date.now()
-  const websites = getWebsiteSummariesForRange(db, blockStart, blockEnd).slice(0, 5)
+  const websites = filterExcludedWebsiteSummaries(
+    db, getWebsiteSummariesForRange(db, blockStart, blockEnd), blockStart, blockEnd,
+  ).slice(0, 5)
   const keyPagesByDomain = getTopPagesForDomains(db, blockStart, blockEnd, websites.map((site) => site.domain), 2)
   const keyPages = websites.flatMap((site) => keyPagesByDomain[site.domain] ?? [])
     .map((page) => page.title?.trim())
@@ -4844,7 +4846,9 @@ function loadPersistedTimelineBlocksForDay(
       blockSessions = sessions.filter((s) => s.startTime >= row.start_time && s.startTime < row.end_time)
     }
 
-    const websites = getWebsiteSummariesForRange(db, row.start_time, row.end_time).slice(0, 5)
+    const websites = filterExcludedWebsiteSummaries(
+      db, getWebsiteSummariesForRange(db, row.start_time, row.end_time), row.start_time, row.end_time,
+    ).slice(0, 5)
 
     const keyPagesByDomain = getTopPagesForDomains(db, row.start_time, row.end_time, websites.map((site) => site.domain), 2)
     const keyPages = websites.flatMap((site) => keyPagesByDomain[site.domain] ?? [])

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -34,6 +34,7 @@ import type {
   IntercomIdentity,
   CategoryOverrideEffect,
   ClientRecord,
+  AttributionProject,
   BreakRecommendation,
   CalendarRangeDay,
   DayTimelinePayload,
@@ -390,6 +391,7 @@ const api = {
   },
   attribution: {
     listClientsDetailed: (): Promise<ClientRecord[]> => ipcRenderer.invoke(IPC.ATTRIBUTION.LIST_CLIENTS_DETAILED),
+    listProjects: (): Promise<AttributionProject[]> => ipcRenderer.invoke(IPC.ATTRIBUTION.LIST_PROJECTS),
     createClient: (payload: { name: string; color?: string | null }): Promise<ClientRecord> =>
       ipcRenderer.invoke(IPC.ATTRIBUTION.CREATE_CLIENT, payload),
     ensureClients: (names: string[]): Promise<ClientRecord[]> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,10 @@ import type {
   SyncStatus,
   TimelineBlockReviewUpdate,
   TimelineBlockEditPayload,
+  CorrectionCommand,
+  CorrectionPreview,
+  CorrectionApplyResult,
+  CorrectionUndoResult,
   TimelineBlockEditResult,
   PurgeTrackedEvidencePayload,
   MemoryBackfillResult,
@@ -187,6 +191,12 @@ const api = {
       ipcRenderer.invoke(IPC.DB.PURGE_TRACKED_EVIDENCE, payload),
     purgeTimelineBlock: (payload: { blockId: string; date?: string | null }): Promise<{ purged: boolean }> =>
       ipcRenderer.invoke(IPC.DB.PURGE_TIMELINE_BLOCK, payload),
+    previewCorrection: (command: CorrectionCommand): Promise<CorrectionPreview> =>
+      ipcRenderer.invoke(IPC.DB.PREVIEW_CORRECTION, command),
+    applyCorrection: (command: CorrectionCommand): Promise<CorrectionApplyResult> =>
+      ipcRenderer.invoke(IPC.DB.APPLY_CORRECTION, command),
+    undoCorrection: (correctionId: string): Promise<CorrectionUndoResult> =>
+      ipcRenderer.invoke(IPC.DB.UNDO_CORRECTION, correctionId),
     getAppDetail: (canonicalAppId: string, days?: number | string): Promise<AppDetailPayload> =>
       ipcRenderer.invoke(IPC.DB.GET_APP_DETAIL, canonicalAppId, days),
     getAppActivityDigest: (days?: number): Promise<AppActivityDigest[]> =>

--- a/src/renderer/components/CorrectionFlow.tsx
+++ b/src/renderer/components/CorrectionFlow.tsx
@@ -1,0 +1,351 @@
+// The correction preview → apply → undo flow (timeline spec, Corrections;
+// DEV-172). Every non-destructive correction runs through one gesture: the
+// caller builds a CorrectionCommand, this hook fetches the exact cross-surface
+// preview (the preview IS the apply, dry-run — computed in a savepoint in the
+// main process), shows it in a dialog, applies atomically on confirm, and
+// leaves an Undo toast up until the next correction replaces it. Permanent
+// purges never come through here — they keep their native confirm and no undo.
+import { useCallback, useState, type CSSProperties, type ReactNode } from 'react'
+import type { CorrectionCommand, CorrectionPreview } from '@shared/types'
+import { activityCategoryLabel } from '@shared/activityCategories'
+import { ipc } from '../lib/ipc'
+import { sanitizeIpcError } from '../lib/ipcError'
+import { formatDuration } from '../lib/format'
+import { formatDisplayAppName } from '../lib/apps'
+
+interface PendingPreview {
+  command: CorrectionCommand
+  preview: CorrectionPreview
+  resolve: (applied: boolean) => void
+}
+
+interface AppliedCorrection {
+  correctionId: string
+  description: string
+}
+
+export interface CorrectionFlow {
+  /**
+   * Preview the command and let the user confirm or cancel. Resolves true
+   * only after the correction has applied (the caller can then adjust
+   * selection state); resolves false on cancel. Throws if the preview itself
+   * fails — the caller owns that error surface.
+   */
+  request: (command: CorrectionCommand) => Promise<boolean>
+  /** Render once, near the top of the view — the dialog and the undo toast. */
+  overlay: ReactNode
+}
+
+export function useCorrectionFlow(onApplied: () => void | Promise<void>): CorrectionFlow {
+  const [pending, setPending] = useState<PendingPreview | null>(null)
+  const [applying, setApplying] = useState(false)
+  const [applyError, setApplyError] = useState<string | null>(null)
+  const [applied, setApplied] = useState<AppliedCorrection | null>(null)
+  const [undoBusy, setUndoBusy] = useState(false)
+  const [undoError, setUndoError] = useState<string | null>(null)
+
+  const request = useCallback(async (command: CorrectionCommand): Promise<boolean> => {
+    const preview = await ipc.db.previewCorrection(command)
+    setApplyError(null)
+    return new Promise<boolean>((resolve) => {
+      setPending((current) => {
+        // A second request while a dialog is open cancels the first — the
+        // dialog is modal, so this only happens across stale async paths.
+        current?.resolve(false)
+        return { command, preview, resolve }
+      })
+    })
+  }, [])
+
+  const cancel = () => {
+    if (applying || !pending) return
+    pending.resolve(false)
+    setPending(null)
+    setApplyError(null)
+  }
+
+  const apply = async () => {
+    if (applying || !pending) return
+    setApplying(true)
+    setApplyError(null)
+    try {
+      const result = await ipc.db.applyCorrection(pending.command)
+      setPending(null)
+      pending.resolve(true)
+      setApplied(result)
+      setUndoError(null)
+      await onApplied()
+    } catch (err) {
+      setApplyError(sanitizeIpcError(err, "Couldn't apply the correction. Try again in a moment.").message)
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  const undo = async () => {
+    if (undoBusy || !applied) return
+    setUndoBusy(true)
+    setUndoError(null)
+    try {
+      const result = await ipc.db.undoCorrection(applied.correctionId)
+      if (result.undone) {
+        setApplied(null)
+        await onApplied()
+      } else {
+        setUndoError(result.description)
+      }
+    } catch (err) {
+      setUndoError(sanitizeIpcError(err, "Couldn't undo the correction.").message)
+    } finally {
+      setUndoBusy(false)
+    }
+  }
+
+  const overlay = (
+    <>
+      {pending && (
+        <CorrectionPreviewDialog
+          preview={pending.preview}
+          applying={applying}
+          error={applyError}
+          onCancel={cancel}
+          onApply={() => { void apply() }}
+        />
+      )}
+      {!pending && applied && (
+        <CorrectionUndoToast
+          description={applied.description}
+          busy={undoBusy}
+          error={undoError}
+          onUndo={() => { void undo() }}
+          onDismiss={() => { setApplied(null); setUndoError(null) }}
+        />
+      )}
+    </>
+  )
+
+  return { request, overlay }
+}
+
+// ─── Preview dialog ──────────────────────────────────────────────────────────
+// One sentence naming the correction, then exactly what changes: the day
+// total, each affected block before → after, each app's day total, and plain
+// sentences on the consuming surfaces (search, AI, client rollups).
+
+const timeOf = (ms: number): string =>
+  new Date(ms).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+
+function CorrectionPreviewDialog({
+  preview,
+  applying,
+  error,
+  onCancel,
+  onApply,
+}: {
+  preview: CorrectionPreview
+  applying: boolean
+  error: string | null
+  onCancel: () => void
+  onApply: () => void
+}) {
+  const totalChanged = preview.totalSecondsBefore !== preview.totalSecondsAfter
+  const countChanged = preview.blockCountBefore !== preview.blockCountAfter
+
+  const sectionTitle: CSSProperties = {
+    fontSize: 10.5,
+    fontWeight: 800,
+    letterSpacing: '0.10em',
+    color: 'var(--color-text-tertiary)',
+    textTransform: 'uppercase',
+    marginBottom: 8,
+  }
+
+  return (
+    <div
+      data-timeline-inspector="true"
+      style={{ position: 'fixed', inset: 0, zIndex: 90, background: 'rgba(0,0,0,0.45)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}
+      onClick={() => { if (!applying) onCancel() }}
+    >
+      <div
+        role="dialog"
+        aria-label="Preview correction"
+        style={{
+          width: 480,
+          maxWidth: '100%',
+          maxHeight: '80vh',
+          overflowY: 'auto',
+          borderRadius: 16,
+          border: '1px solid var(--color-border-ghost)',
+          background: 'var(--color-surface)',
+          boxShadow: '0 24px 64px rgba(0,0,0,0.35)',
+          padding: '18px 22px 18px',
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--color-text-primary)', lineHeight: 1.4 }}>
+          {preview.description}
+        </div>
+
+        {(totalChanged || countChanged) && (
+          <div style={{ fontSize: 12.5, color: 'var(--color-text-secondary)', marginTop: 8, lineHeight: 1.6 }}>
+            {totalChanged && (
+              <div>
+                Day total: {formatDuration(preview.totalSecondsBefore)} → {formatDuration(preview.totalSecondsAfter)}
+              </div>
+            )}
+            {countChanged && (
+              <div>
+                Blocks: {preview.blockCountBefore} → {preview.blockCountAfter}
+              </div>
+            )}
+          </div>
+        )}
+
+        {preview.blocks.length > 0 && (
+          <div style={{ marginTop: 16 }}>
+            <div style={sectionTitle}>Timeline</div>
+            <div style={{ display: 'grid', gap: 10 }}>
+              {preview.blocks.map((delta) => (
+                <div key={delta.blockId} style={{ fontSize: 12.5, lineHeight: 1.55 }}>
+                  <div style={{ color: 'var(--color-text-tertiary)', textDecoration: delta.labelAfter === null ? 'line-through' : 'none' }}>
+                    {delta.labelBefore}
+                    <span style={{ marginLeft: 8, fontVariantNumeric: 'tabular-nums' }}>
+                      {timeOf(delta.startMsBefore)} – {timeOf(delta.endMsBefore)}
+                    </span>
+                  </div>
+                  {delta.labelAfter === null ? (
+                    <div style={{ color: 'var(--color-text-secondary)', fontWeight: 600 }}>Removed from the day</div>
+                  ) : (
+                    <div style={{ color: 'var(--color-text-primary)', fontWeight: 600 }}>
+                      {delta.labelAfter}
+                      {delta.startMsAfter != null && delta.endMsAfter != null && (
+                        <span style={{ marginLeft: 8, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--color-text-secondary)' }}>
+                          {timeOf(delta.startMsAfter)} – {timeOf(delta.endMsAfter)}
+                        </span>
+                      )}
+                      {delta.categoryAfter && delta.categoryAfter !== delta.categoryBefore && (
+                        <span style={{ marginLeft: 8, fontWeight: 500, color: 'var(--color-text-secondary)' }}>
+                          {activityCategoryLabel(delta.categoryBefore)} → {activityCategoryLabel(delta.categoryAfter)}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {preview.apps.length > 0 && (
+          <div style={{ marginTop: 16 }}>
+            <div style={sectionTitle}>Apps</div>
+            <div style={{ display: 'grid', gap: 4 }}>
+              {preview.apps.map((delta) => (
+                <div key={delta.appName} style={{ display: 'flex', alignItems: 'baseline', gap: 10, fontSize: 12.5 }}>
+                  <span style={{ flex: 1, minWidth: 0, color: 'var(--color-text-primary)', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {formatDisplayAppName(delta.appName)}
+                  </span>
+                  <span style={{ color: 'var(--color-text-secondary)', fontVariantNumeric: 'tabular-nums', flexShrink: 0 }}>
+                    {formatDuration(delta.secondsBefore)} → {formatDuration(delta.secondsAfter)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {preview.surfaces.length > 0 && (
+          <div style={{ marginTop: 16, fontSize: 12, color: 'var(--color-text-tertiary)', lineHeight: 1.6 }}>
+            {preview.surfaces.map((sentence) => (
+              <div key={sentence}>{sentence}</div>
+            ))}
+          </div>
+        )}
+
+        {error && (
+          <div style={{ fontSize: 11.5, lineHeight: 1.5, color: '#f87171', marginTop: 14 }}>{error}</div>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 18 }}>
+          <button
+            type="button"
+            disabled={applying}
+            onClick={onCancel}
+            style={{ border: '1px solid var(--color-border-ghost)', background: 'transparent', color: 'var(--color-text-secondary)', fontSize: 12.5, fontWeight: 650, cursor: applying ? 'default' : 'pointer', padding: '7px 14px', borderRadius: 9 }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={applying}
+            onClick={onApply}
+            style={{ border: 'none', background: 'var(--gradient-primary)', color: 'var(--color-primary-contrast)', fontSize: 12.5, fontWeight: 700, cursor: applying ? 'default' : 'pointer', padding: '7px 16px', borderRadius: 9, opacity: applying ? 0.6 : 1 }}
+          >
+            {applying ? 'Applying…' : 'Apply'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Undo toast ──────────────────────────────────────────────────────────────
+// Stays up until dismissed or replaced by the next correction — only the
+// newest un-undone correction of a date can be undone, so one slot is enough.
+
+function CorrectionUndoToast({
+  description,
+  busy,
+  error,
+  onUndo,
+  onDismiss,
+}: {
+  description: string
+  busy: boolean
+  error: string | null
+  onUndo: () => void
+  onDismiss: () => void
+}) {
+  return (
+    <div
+      data-timeline-inspector="true"
+      role="status"
+      style={{
+        position: 'fixed',
+        left: '50%',
+        bottom: 28,
+        transform: 'translateX(-50%)',
+        zIndex: 85,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        maxWidth: 'min(560px, calc(100vw - 48px))',
+        borderRadius: 12,
+        border: '1px solid var(--color-border-ghost)',
+        background: 'var(--color-surface)',
+        boxShadow: '0 12px 36px rgba(0,0,0,0.28)',
+        padding: '10px 14px',
+      }}
+    >
+      <span style={{ fontSize: 12.5, color: 'var(--color-text-primary)', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {error ?? description}
+      </span>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={onUndo}
+        style={{ border: 'none', background: 'transparent', color: 'var(--color-primary)', fontSize: 12.5, fontWeight: 700, cursor: busy ? 'default' : 'pointer', padding: 0, flexShrink: 0 }}
+      >
+        {busy ? 'Undoing…' : 'Undo'}
+      </button>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={onDismiss}
+        style={{ border: 'none', background: 'transparent', color: 'var(--color-text-tertiary)', fontSize: 14, fontWeight: 700, cursor: 'pointer', padding: 0, lineHeight: 1, flexShrink: 0 }}
+      >
+        ×
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/views/Timeline.tsx
+++ b/src/renderer/views/Timeline.tsx
@@ -2,7 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type CSSPr
 import { useSearchParams } from 'react-router-dom'
 import { EyeOff, Trash2, X } from 'lucide-react'
 import { ANALYTICS_EVENT, blockCountBucket, trackedTimeBucket } from '@shared/analytics'
-import type { AIDaySummaryResult, AISurfaceSummary, AppCategory, CalendarRangeBlock, CalendarRangeDay, ClientRecord, CorrectionCommand, DayTimelinePayload, TimelineGapSegment, WorkContextBlock } from '@shared/types'
+import type { AIDaySummaryResult, AISurfaceSummary, AppCategory, AttributionProject, CalendarRangeBlock, CalendarRangeDay, ClientRecord, CorrectionCommand, DayTimelinePayload, TimelineGapSegment, WorkContextBlock } from '@shared/types'
 import { activityColorForCategory, leisureBlocksDimmed } from '@shared/activityColors'
 import { calendarCardHeights } from '../lib/timelineBlockLayout'
 import { blockActiveSeconds } from '@shared/blockDuration'
@@ -712,15 +712,23 @@ function BlockEditModal({
   const [hidingKey, setHidingKey] = useState<string | null>(null)
   const [assigningClient, setAssigningClient] = useState(false)
   const [clients, setClients] = useState<ClientRecord[]>([])
+  const [projects, setProjects] = useState<AttributionProject[]>([])
   const [error, setError] = useState<string | null>(null)
   const busy = saving || deleting || purgingKey !== null || hidingKey !== null || assigningClient
 
-  // Clients for the attribution select — loaded once; an empty list simply
-  // hides the control (nothing to assign to yet).
+  // Clients and projects for the attribution select — loaded once; an empty
+  // client list simply hides the control (nothing to assign to yet).
   useEffect(() => {
     let cancelled = false
-    ipc.attribution.listClientsDetailed()
-      .then((list) => { if (!cancelled) setClients(list.filter((client) => client.status === 'active')) })
+    Promise.all([
+      ipc.attribution.listClientsDetailed(),
+      ipc.attribution.listProjects().catch(() => [] as AttributionProject[]),
+    ])
+      .then(([clientList, projectList]) => {
+        if (cancelled) return
+        setClients(clientList.filter((client) => client.status === 'active'))
+        setProjects(projectList)
+      })
       .catch(() => { /* the select just stays hidden */ })
     return () => { cancelled = true }
   }, [])
@@ -818,15 +826,21 @@ function BlockEditModal({
     }
   }
 
-  // Assign the block's time to a client (or clear the assignment). Runs
+  // Assign the block's time to a client and optional project (or clear). Runs
   // through the same preview flow; the modal closes once applied because the
   // day's attribution facts re-form underneath it.
-  const assignClient = async (clientId: string | null) => {
+  const assignClient = async (clientId: string | null, projectId: string | null = null) => {
     if (busy) return
     setAssigningClient(true)
     setError(null)
     try {
-      const applied = await onCorrection({ kind: 'assign-client', date: payload.date, blockId: block.id, clientId })
+      const applied = await onCorrection({
+        kind: 'assign-client',
+        date: payload.date,
+        blockId: block.id,
+        clientId,
+        projectId: clientId == null ? null : projectId,
+      })
       if (applied) {
         track(ANALYTICS_EVENT.BLOCK_EDITED, { block_id: block.id, what_changed: 'client' })
         onClose()
@@ -1080,26 +1094,46 @@ function BlockEditModal({
             )}
           </div>
 
-          {/* Client attribution: assign this block's time to a client. Shown
-              only when clients exist; runs through the preview flow like every
-              other correction. */}
+          {/* Attribution: assign this block's time to a client, or a project
+              under that client. Shown only when clients exist; runs through
+              the preview flow like every other correction. */}
           {clients.length > 0 && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
               <select
-                aria-label="Assign to client"
+                aria-label="Assign to client or project"
                 value=""
                 disabled={busy}
                 onChange={(event) => {
                   const value = event.target.value
                   if (!value) return
-                  void assignClient(value === '__none__' ? null : value)
+                  if (value === '__none__') {
+                    void assignClient(null, null)
+                    return
+                  }
+                  if (value.startsWith('project:')) {
+                    const projectId = value.slice('project:'.length)
+                    const project = projects.find((row) => row.id === projectId)
+                    if (!project) return
+                    void assignClient(project.client_id, project.id)
+                    return
+                  }
+                  void assignClient(value, null)
                 }}
                 style={{ ...inputBase, height: 32, padding: '0 8px', cursor: busy ? 'default' : 'pointer' }}
               >
-                <option value="">{assigningClient ? 'Assigning…' : 'Assign to client…'}</option>
+                <option value="">{assigningClient ? 'Assigning…' : 'Assign to client or project…'}</option>
                 {clients.map((client) => (
                   <option key={client.id} value={client.id}>{client.name}</option>
                 ))}
+                {projects.length > 0 && (
+                  <optgroup label="Projects">
+                    {projects.map((project) => (
+                      <option key={project.id} value={`project:${project.id}`}>
+                        {project.client_name} · {project.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                )}
                 <option value="__none__">No client (clear assignment)</option>
               </select>
             </div>

--- a/src/renderer/views/Timeline.tsx
+++ b/src/renderer/views/Timeline.tsx
@@ -1,8 +1,8 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { Trash2, X } from 'lucide-react'
+import { EyeOff, Trash2, X } from 'lucide-react'
 import { ANALYTICS_EVENT, blockCountBucket, trackedTimeBucket } from '@shared/analytics'
-import type { AIDaySummaryResult, AISurfaceSummary, AppCategory, CalendarRangeBlock, CalendarRangeDay, DayTimelinePayload, TimelineGapSegment, WorkContextBlock } from '@shared/types'
+import type { AIDaySummaryResult, AISurfaceSummary, AppCategory, CalendarRangeBlock, CalendarRangeDay, ClientRecord, CorrectionCommand, DayTimelinePayload, TimelineGapSegment, WorkContextBlock } from '@shared/types'
 import { activityColorForCategory, leisureBlocksDimmed } from '@shared/activityColors'
 import { calendarCardHeights } from '../lib/timelineBlockLayout'
 import { blockActiveSeconds } from '@shared/blockDuration'
@@ -21,8 +21,10 @@ import {
   clampEndTimeDraft,
   clampStartTimeDraft,
   draftTimeInputChange,
+  fromTimeInputValue,
   toTimeInputValue,
 } from '../lib/blockTimeEdit'
+import { useCorrectionFlow } from '../components/CorrectionFlow'
 import { mergeSelectionSpan, spanMergeState } from '../lib/timelineMergeSelection'
 import { ipc } from '../lib/ipc'
 import { sanitizeIpcError } from '../lib/ipcError'
@@ -539,6 +541,7 @@ function BlockContextMenu({
   y,
   busy,
   onEdit,
+  onSplit,
   onRegenerate,
   onDelete,
   onClose,
@@ -550,6 +553,9 @@ function BlockContextMenu({
   y: number
   busy: boolean
   onEdit: () => void
+  // Split at a chosen time — opens the small time-picker dialog. Hidden for
+  // provisional blocks (the day hasn't settled enough to cut).
+  onSplit: (() => void) | null
   onRegenerate: () => void
   onDelete: () => void
   onClose: () => void
@@ -572,7 +578,7 @@ function BlockContextMenu({
 
   const MENU_WIDTH = 200
   const ITEM_HEIGHT = 36
-  const itemCount = 3 + (mergeSpan ? 1 : (mergeAbove ? 1 : 0) + (mergeBelow ? 1 : 0))
+  const itemCount = 3 + (onSplit ? 1 : 0) + (mergeSpan ? 1 : (mergeAbove ? 1 : 0) + (mergeBelow ? 1 : 0))
   const MENU_HEIGHT = itemCount * ITEM_HEIGHT + 10
   const left = Math.min(x, window.innerWidth - MENU_WIDTH - 8)
   const top = Math.min(y, window.innerHeight - MENU_HEIGHT - 8)
@@ -647,6 +653,13 @@ function BlockContextMenu({
             )}
           </>
         )}
+        {onSplit && (
+          <button type="button" role="menuitem" disabled={busy} onClick={onSplit} style={itemStyle()}
+            onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--color-surface-high)' }}
+            onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}>
+            Split block…
+          </button>
+        )}
         <button type="button" role="menuitem" disabled={busy} onClick={onRegenerate} style={itemStyle()}
           onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--color-surface-high)' }}
           onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}>
@@ -655,7 +668,7 @@ function BlockContextMenu({
         <button type="button" role="menuitem" disabled={busy} onClick={onDelete} style={itemStyle(true)}
           onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--color-surface-high)' }}
           onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent' }}>
-          Delete
+          Remove from day
         </button>
       </div>
     </div>
@@ -676,6 +689,7 @@ function BlockEditModal({
   onClose,
   onDeleted,
   onRefresh,
+  onCorrection,
 }: {
   block: WorkContextBlock
   payload: DayTimelinePayload
@@ -684,6 +698,9 @@ function BlockEditModal({
   // (now dangling) selection before the refreshed day lands.
   onDeleted: () => void
   onRefresh: () => Promise<void>
+  // Runs a correction command through the shared preview → apply → undo flow
+  // (DEV-172). Resolves true once applied, false if the preview was cancelled.
+  onCorrection: (command: CorrectionCommand) => Promise<boolean>
 }) {
   const [titleDraft, setTitleDraft] = useState(() => userVisibleBlockLabel(block))
   const [categoryDraft, setCategoryDraft] = useState<AppCategory>(block.dominantCategory)
@@ -692,8 +709,21 @@ function BlockEditModal({
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [purgingKey, setPurgingKey] = useState<string | null>(null)
+  const [hidingKey, setHidingKey] = useState<string | null>(null)
+  const [assigningClient, setAssigningClient] = useState(false)
+  const [clients, setClients] = useState<ClientRecord[]>([])
   const [error, setError] = useState<string | null>(null)
-  const busy = saving || deleting || purgingKey !== null
+  const busy = saving || deleting || purgingKey !== null || hidingKey !== null || assigningClient
+
+  // Clients for the attribution select — loaded once; an empty list simply
+  // hides the control (nothing to assign to yet).
+  useEffect(() => {
+    let cancelled = false
+    ipc.attribution.listClientsDetailed()
+      .then((list) => { if (!cancelled) setClients(list.filter((client) => client.status === 'active')) })
+      .catch(() => { /* the select just stays hidden */ })
+    return () => { cancelled = true }
+  }, [])
 
   // Escape = Discard, like closing GCal's editor without saving.
   useEffect(() => {
@@ -760,31 +790,75 @@ function BlockEditModal({
       setStartDraft(clampedStart)
       setEndDraft(clampedEnd)
       const spanDraft = blockSpanDraftChanged(clampedStart, clampedEnd, block)
-      const result = await ipc.db.updateTimelineBlock({
-        blockId: block.id,
-        date: payload.date,
-        label: title && title !== block.label.current ? title : undefined,
-        category: categoryDraft !== block.dominantCategory ? categoryDraft : undefined,
-        startMs: spanDraft?.changed ? spanDraft.startMs : undefined,
-        endMs: spanDraft?.changed ? spanDraft.endMs : undefined,
-      })
+      const label = title && title !== block.label.current ? title : undefined
+      const category = categoryDraft !== block.dominantCategory ? categoryDraft : undefined
+      const startMs = spanDraft?.changed ? spanDraft.startMs : undefined
+      const endMs = spanDraft?.changed ? spanDraft.endMs : undefined
+      if (label === undefined && category === undefined && startMs === undefined && endMs === undefined) {
+        onClose()
+        return
+      }
+      // The shared preview → apply flow: the dialog opens over this modal,
+      // and the modal only closes once the correction actually applied.
+      const applied = await onCorrection({ kind: 'edit', date: payload.date, blockId: block.id, label, category, startMs, endMs })
+      if (!applied) {
+        setSaving(false)
+        return
+      }
       // One event per save; when several fields changed, report the most
       // structural one (time > category > label).
-      const whatChanged = result.changedFields.includes('time')
+      const whatChanged = startMs !== undefined || endMs !== undefined
         ? 'time'
-        : result.changedFields.includes('category')
-          ? 'category'
-          : result.changedFields.includes('label') ? 'label' : null
-      if (whatChanged) {
-        track(ANALYTICS_EVENT.BLOCK_EDITED, { block_id: block.id, what_changed: whatChanged })
-      }
-      daySummaryRecapCache.delete(payload.date)
-      await onRefresh()
+        : category !== undefined ? 'category' : 'label'
+      track(ANALYTICS_EVENT.BLOCK_EDITED, { block_id: block.id, what_changed: whatChanged })
       onClose()
     } catch (err) {
       setError(sanitizeIpcError(err, "Couldn't save the changes. Try again in a moment.").message)
       setSaving(false)
     }
+  }
+
+  // Assign the block's time to a client (or clear the assignment). Runs
+  // through the same preview flow; the modal closes once applied because the
+  // day's attribution facts re-form underneath it.
+  const assignClient = async (clientId: string | null) => {
+    if (busy) return
+    setAssigningClient(true)
+    setError(null)
+    try {
+      const applied = await onCorrection({ kind: 'assign-client', date: payload.date, blockId: block.id, clientId })
+      if (applied) {
+        track(ANALYTICS_EVENT.BLOCK_EDITED, { block_id: block.id, what_changed: 'client' })
+        onClose()
+        return
+      }
+    } catch (err) {
+      setError(sanitizeIpcError(err, "Couldn't assign the client. Try again in a moment.").message)
+    }
+    setAssigningClient(false)
+  }
+
+  // Hide a tracked record from the corrected facts without destroying it —
+  // the undoable counterpart to purgeRow's permanent erase.
+  const hideRow = async (row: { key: string; kind: 'app' | 'site'; bundleId?: string; appName?: string; domain?: string }) => {
+    if (busy) return
+    setHidingKey(row.key)
+    setError(null)
+    try {
+      const applied = await onCorrection({
+        kind: 'exclude-evidence',
+        date: payload.date,
+        blockId: block.id,
+        evidence: { kind: row.kind, bundleId: row.bundleId ?? null, appName: row.appName ?? null, domain: row.domain ?? null },
+      })
+      if (applied) {
+        onClose()
+        return
+      }
+    } catch (err) {
+      setError(sanitizeIpcError(err, "Couldn't hide the record. Try again in a moment.").message)
+    }
+    setHidingKey(null)
   }
 
   // Permanently remove a sensitive tracked record. The main process shows the
@@ -1006,6 +1080,31 @@ function BlockEditModal({
             )}
           </div>
 
+          {/* Client attribution: assign this block's time to a client. Shown
+              only when clients exist; runs through the preview flow like every
+              other correction. */}
+          {clients.length > 0 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <select
+                aria-label="Assign to client"
+                value=""
+                disabled={busy}
+                onChange={(event) => {
+                  const value = event.target.value
+                  if (!value) return
+                  void assignClient(value === '__none__' ? null : value)
+                }}
+                style={{ ...inputBase, height: 32, padding: '0 8px', cursor: busy ? 'default' : 'pointer' }}
+              >
+                <option value="">{assigningClient ? 'Assigning…' : 'Assign to client…'}</option>
+                {clients.map((client) => (
+                  <option key={client.id} value={client.id}>{client.name}</option>
+                ))}
+                <option value="__none__">No client (clear assignment)</option>
+              </select>
+            </div>
+          )}
+
           {/* Tracked records, each permanently removable — real deletion of
               the underlying data, for anything the user doesn't want Daylens
               to hold (native confirm before anything is touched). */}
@@ -1027,6 +1126,16 @@ function BlockEditModal({
                     <span style={{ fontSize: 12, color: 'var(--color-text-secondary)', fontVariantNumeric: 'tabular-nums', flexShrink: 0 }}>{formatDuration(row.seconds)}</span>
                     <button
                       type="button"
+                      aria-label={`Hide ${row.name} from this block`}
+                      title="Hide from timeline (undoable — the record itself is kept)"
+                      disabled={busy}
+                      onClick={() => { void hideRow(row) }}
+                      style={{ width: 26, height: 26, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', borderRadius: 7, border: 'none', background: 'transparent', color: 'var(--color-text-secondary)', cursor: busy ? 'default' : 'pointer', opacity: hidingKey && hidingKey !== row.key ? 0.4 : 1, flexShrink: 0 }}
+                    >
+                      <EyeOff size={14} strokeWidth={2} aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
                       aria-label={`Permanently remove ${row.name} from Daylens`}
                       title="Remove permanently"
                       disabled={purgingKey !== null}
@@ -1039,7 +1148,7 @@ function BlockEditModal({
                 ))}
               </div>
               <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 8, lineHeight: 1.5 }}>
-                Removing deletes the record from Daylens entirely — timeline, apps, and AI — not just from this view.
+                Hide keeps the record but drops it from timeline, apps, and AI (undoable). Remove deletes it from Daylens entirely.
               </div>
             </div>
           )}
@@ -1077,6 +1186,118 @@ function BlockEditModal({
             style={{ border: 'none', background: 'var(--gradient-primary)', color: 'var(--color-primary-contrast)', fontSize: 12.5, fontWeight: 700, cursor: busy ? 'default' : 'pointer', padding: '7px 16px', borderRadius: 9, opacity: saving ? 0.6 : 1 }}
           >
             {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Split dialog ────────────────────────────────────────────────────────────
+// Right-click → Split block…: pick the cut time (defaults to the midpoint),
+// then the shared preview flow shows exactly what the two halves will be
+// before anything applies. The service enforces a one-minute minimum on each
+// side of the cut.
+
+function SplitBlockDialog({
+  block,
+  onClose,
+  onSubmit,
+}: {
+  block: WorkContextBlock
+  onClose: () => void
+  // Runs the split through the preview flow; resolves true once applied.
+  onSubmit: (cutMs: number) => Promise<boolean>
+}) {
+  const midpointMs = block.startTime + Math.floor((block.endTime - block.startTime) / 2)
+  const [draft, setDraft] = useState(() => toTimeInputValue(midpointMs))
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => { if (event.key === 'Escape' && !busy) onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose, busy])
+
+  const submit = async () => {
+    if (busy) return
+    const cutMs = fromTimeInputValue(draft, block.startTime)
+    if (cutMs == null || cutMs <= block.startTime || cutMs >= block.endTime) {
+      setError('Pick a time inside the block.')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      const applied = await onSubmit(cutMs)
+      if (!applied) setBusy(false)
+    } catch (err) {
+      setError(sanitizeIpcError(err, "Couldn't preview the split. Try again in a moment.").message)
+      setBusy(false)
+    }
+  }
+
+  const rangeHint = `${new Date(block.startTime).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })} – ${new Date(block.endTime).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
+
+  return (
+    <div
+      data-timeline-inspector="true"
+      style={{ position: 'fixed', inset: 0, zIndex: 70, background: 'rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}
+      onClick={() => { if (!busy) onClose() }}
+    >
+      <div
+        role="dialog"
+        aria-label="Split block"
+        style={{
+          width: 380,
+          maxWidth: '100%',
+          borderRadius: 16,
+          border: '1px solid var(--color-border-ghost)',
+          background: 'var(--color-surface)',
+          boxShadow: '0 24px 64px rgba(0,0,0,0.35)',
+          padding: '18px 22px',
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--color-text-primary)', lineHeight: 1.4 }}>
+          Split “{userVisibleBlockLabel(block)}”
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', marginTop: 4 }}>
+          {rangeHint} · each half needs at least a minute
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 14 }}>
+          <span style={{ fontSize: 12.5, color: 'var(--color-text-secondary)', fontWeight: 600 }}>Split at</span>
+          <input
+            type="time"
+            aria-label="Split time"
+            value={draft}
+            autoFocus
+            disabled={busy}
+            onChange={(event) => setDraft(draftTimeInputChange(event.target.value))}
+            onKeyDown={(event) => { if (event.key === 'Enter') void submit() }}
+            style={{ borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface-low)', color: 'var(--color-text-primary)', fontSize: 13, outline: 'none', padding: '5px 8px' }}
+          />
+        </div>
+        {error && (
+          <div style={{ fontSize: 11.5, lineHeight: 1.5, color: '#f87171', marginTop: 10 }}>{error}</div>
+        )}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 }}>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onClose}
+            style={{ border: '1px solid var(--color-border-ghost)', background: 'transparent', color: 'var(--color-text-secondary)', fontSize: 12.5, fontWeight: 650, cursor: busy ? 'default' : 'pointer', padding: '7px 14px', borderRadius: 9 }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => { void submit() }}
+            style={{ border: 'none', background: 'var(--gradient-primary)', color: 'var(--color-primary-contrast)', fontSize: 12.5, fontWeight: 700, cursor: busy ? 'default' : 'pointer', padding: '7px 16px', borderRadius: 9, opacity: busy ? 0.6 : 1 }}
+          >
+            {busy ? 'Previewing…' : 'Preview split'}
           </button>
         </div>
       </div>
@@ -2116,6 +2337,16 @@ export default function Timeline() {
   // read-only detail panel never hosts edit controls.
   const [editBlockId, setEditBlockId] = useState<string | null>(null)
   const [menuBusy, setMenuBusy] = useState(false)
+  // The block a split is being picked for (right-click → Split block…).
+  const [splitBlockId, setSplitBlockId] = useState<string | null>(null)
+
+  // The shared preview → apply → undo flow every non-destructive correction
+  // runs through (DEV-172). Applying or undoing re-forms the day, so the
+  // hook's callback owns the cache drop + refresh.
+  const correction = useCorrectionFlow(async () => {
+    daySummaryRecapCache.delete(date)
+    await timelineResource.refresh()
+  })
 
   // Filter the day by block type ("Focused work", "Meeting", "Leisure"…).
   // Filtering dims the other blocks in place — the day's shape stays honest.
@@ -2273,60 +2504,37 @@ export default function Timeline() {
   // neighbour items — the second merge gesture, sharing the same menu.
   const menuMergeSpanActive = !!menuBlock && spanMerge.isSpan && selectedSpanIds.has(menuBlock.id)
 
+  // Merges run through the shared preview flow: the menu closes, the preview
+  // dialog opens, and selection collapses onto the merged span only after the
+  // correction actually applied. A cancelled preview leaves the grid as-is.
+  const runMerge = async (blockIds: string[], selectAt: number | null) => {
+    setContextMenu(null)
+    try {
+      const applied = await correction.request({ kind: 'merge', date, blockIds })
+      if (applied) {
+        if (selectAt != null) pendingSelectAtRef.current = selectAt
+        setMergeRangeEndId(null)
+        setSelectedBlockId(null)
+      }
+    } catch {
+      // Preview failed (e.g. the day just rebuilt) — the grid stays honest.
+    }
+  }
+
   const menuMergeSpan = async () => {
     if (!contextMenu || menuBusy || !menuMergeSpanActive || !spanMerge.canMerge || !spanMerge.endpointIds) return
     const [startId] = spanMerge.endpointIds
-    const spanStartTime = blockMap.get(startId)?.startTime ?? null
-    setMenuBusy(true)
-    try {
-      await ipc.db.mergeTimelineEpisodes({ blockIds: spanMerge.endpointIds, date })
-      daySummaryRecapCache.delete(date)
-      if (spanStartTime != null) pendingSelectAtRef.current = spanStartTime
-      setMergeRangeEndId(null)
-      setSelectedBlockId(null)
-      await timelineResource.refresh()
-    } catch {
-      // Menu just closes; the merged/unmerged state is visible on the grid.
-    } finally {
-      setMenuBusy(false)
-      setContextMenu(null)
-    }
+    await runMerge(spanMerge.endpointIds, blockMap.get(startId)?.startTime ?? null)
   }
 
   const menuMergeAbove = async () => {
     if (!contextMenu || menuBusy || !menuBlock || !menuAboveBlock || menuMergeAboveDisabled) return
-    setMenuBusy(true)
-    try {
-      await ipc.db.mergeTimelineEpisodes({ blockIds: [menuAboveBlock.id, menuBlock.id], date })
-      daySummaryRecapCache.delete(date)
-      pendingSelectAtRef.current = menuAboveBlock.startTime
-      setMergeRangeEndId(null)
-      setSelectedBlockId(null)
-      await timelineResource.refresh()
-    } catch {
-      // Menu just closes; the merged/unmerged state is visible on the grid.
-    } finally {
-      setMenuBusy(false)
-      setContextMenu(null)
-    }
+    await runMerge([menuAboveBlock.id, menuBlock.id], menuAboveBlock.startTime)
   }
 
   const menuMergeBelow = async () => {
     if (!contextMenu || menuBusy || !menuBlock || !menuBelowBlock || menuMergeBelowDisabled) return
-    setMenuBusy(true)
-    try {
-      await ipc.db.mergeTimelineEpisodes({ blockIds: [menuBlock.id, menuBelowBlock.id], date })
-      daySummaryRecapCache.delete(date)
-      pendingSelectAtRef.current = menuBlock.startTime
-      setMergeRangeEndId(null)
-      setSelectedBlockId(null)
-      await timelineResource.refresh()
-    } catch {
-      // Menu just closes; the merged/unmerged state is visible on the grid.
-    } finally {
-      setMenuBusy(false)
-      setContextMenu(null)
-    }
+    await runMerge([menuBlock.id, menuBelowBlock.id], menuBlock.startTime)
   }
 
   const menuRegenerate = async () => {
@@ -2344,21 +2552,21 @@ export default function Timeline() {
     }
   }
 
+  // "Remove from day" hides the block from every corrected surface — an
+  // undoable exclude-block correction, not a purge. Raw activity survives;
+  // the permanent-erase path lives in the editor modal with its own confirm.
   const menuDelete = async () => {
     if (!contextMenu || menuBusy) return
-    setMenuBusy(true)
+    const blockId = contextMenu.blockId
+    setContextMenu(null)
     try {
-      const { deleted } = await ipc.db.deleteTimelineBlock({ blockId: contextMenu.blockId, date })
-      if (deleted) {
-        daySummaryRecapCache.delete(date)
+      const applied = await correction.request({ kind: 'exclude-block', date, blockId })
+      if (applied) {
         setSelectedBlockId(null)
-        await timelineResource.refresh()
+        setMergeRangeEndId(null)
       }
     } catch {
-      // Native dialog cancelled or delete failed — nothing to clean up.
-    } finally {
-      setMenuBusy(false)
-      setContextMenu(null)
+      // Preview failed — nothing changed on the grid.
     }
   }
 
@@ -2632,6 +2840,10 @@ export default function Timeline() {
                           setEditBlockId(contextMenu.blockId)
                           setContextMenu(null)
                         }}
+                        onSplit={menuBlock && !menuBlock.provisional ? () => {
+                          setSplitBlockId(contextMenu.blockId)
+                          setContextMenu(null)
+                        } : null}
                         mergeSpan={menuMergeSpanActive ? { count: spanMerge.count, disabled: !spanMerge.canMerge, onClick: () => { void menuMergeSpan() } } : null}
                         mergeAbove={menuAboveBlock ? { disabled: menuMergeAboveDisabled, onClick: () => { void menuMergeAbove() } } : null}
                         mergeBelow={menuBelowBlock ? { disabled: menuMergeBelowDisabled, onClick: () => { void menuMergeBelow() } } : null}
@@ -2650,6 +2862,22 @@ export default function Timeline() {
                           setMergeRangeEndId(null)
                         }}
                         onRefresh={timelineResource.refresh}
+                        onCorrection={correction.request}
+                      />
+                    )}
+                    {splitBlockId && blockMap.get(splitBlockId) && (
+                      <SplitBlockDialog
+                        block={blockMap.get(splitBlockId)!}
+                        onClose={() => setSplitBlockId(null)}
+                        onSubmit={async (cutMs) => {
+                          const applied = await correction.request({ kind: 'split', date, blockId: splitBlockId, cutMs })
+                          if (applied) {
+                            setSplitBlockId(null)
+                            setSelectedBlockId(null)
+                            setMergeRangeEndId(null)
+                          }
+                          return applied
+                        }}
                       />
                     )}
                     {/* The right column is one panel with two mutually
@@ -2698,6 +2926,9 @@ export default function Timeline() {
                     )}
                   </div>
                 )}
+                {/* The correction preview dialog + undo toast — outside the
+                    blocks gate so the toast survives excluding the last block. */}
+                {correction.overlay}
               </>
             )}
           </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2072,6 +2072,14 @@ export interface ProjectSummary {
   color: string | null
 }
 
+/** Active project row for attribution pickers (client + project). */
+export interface AttributionProject {
+  id: string
+  client_id: string
+  name: string
+  client_name: string
+}
+
 export interface WorkSessionApp {
   app_name: string
   duration_ms: number
@@ -2320,6 +2328,7 @@ export const IPC = {
     FIND_CLIENT: 'attribution:find-client',
     LIST_CLIENTS: 'attribution:list-clients',
     LIST_CLIENTS_DETAILED: 'attribution:list-clients-detailed',
+    LIST_PROJECTS: 'attribution:list-projects',
     CREATE_CLIENT: 'attribution:create-client',
     ENSURE_CLIENTS: 'attribution:ensure-clients',
     UPDATE_CLIENT: 'attribution:update-client',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -58,6 +58,71 @@ export interface TimelineBlockEditResult {
   changedFields: Array<'label' | 'category' | 'time'>
 }
 
+// ─── Correction commands (timeline spec, Corrections) ────────────────────────
+// One typed command per correction a person can make. Every command previews
+// its effect on time, entities, Timeline, Apps, and search before applying,
+// applies atomically, and can be undone. Permanent purges are NOT commands —
+// they stay on their own destructive, confirmed, no-undo path.
+
+export interface ExcludedEvidenceRef {
+  kind: 'app' | 'site'
+  bundleId?: string | null
+  appName?: string | null
+  domain?: string | null
+}
+
+export type CorrectionCommand =
+  | { kind: 'edit'; date: string; blockId: string; label?: string; category?: AppCategory; startMs?: number; endMs?: number }
+  | { kind: 'merge'; date: string; blockIds: string[] }
+  | { kind: 'split'; date: string; blockId: string; cutMs: number }
+  | { kind: 'exclude-block'; date: string; blockId: string }
+  | { kind: 'exclude-evidence'; date: string; blockId: string; evidence: ExcludedEvidenceRef }
+  | { kind: 'assign-client'; date: string; blockId: string; clientId: string | null; projectId?: string | null }
+
+export interface CorrectionBlockDelta {
+  blockId: string
+  labelBefore: string
+  /** null = the block is gone after the correction (merged away or excluded). */
+  labelAfter: string | null
+  startMsBefore: number
+  endMsBefore: number
+  startMsAfter: number | null
+  endMsAfter: number | null
+  categoryBefore: AppCategory
+  categoryAfter: AppCategory | null
+}
+
+export interface CorrectionAppDelta {
+  appName: string
+  secondsBefore: number
+  secondsAfter: number
+}
+
+export interface CorrectionPreview {
+  /** One human sentence naming the correction, e.g. `Rename "A" to "B"`. */
+  description: string
+  totalSecondsBefore: number
+  totalSecondsAfter: number
+  blockCountBefore: number
+  blockCountAfter: number
+  /** Blocks whose label, span, or category the correction changes. */
+  blocks: CorrectionBlockDelta[]
+  /** Apps whose day total the correction changes (Apps view delta). */
+  apps: CorrectionAppDelta[]
+  /** Plain sentences on how consuming surfaces change (search, AI, client rollups). */
+  surfaces: string[]
+}
+
+export interface CorrectionApplyResult {
+  correctionId: string
+  description: string
+}
+
+export interface CorrectionUndoResult {
+  undone: boolean
+  description: string
+}
+
 // Each Apps row leads with what was accomplished, not how long.
 // This compact digest provides the headline activity per app over a range —
 // the top work block the app participated in and the top artifact it touched.
@@ -2138,6 +2203,9 @@ export const IPC = {
     UPDATE_TIMELINE_BLOCK: 'db:update-timeline-block',
     PURGE_TRACKED_EVIDENCE: 'db:purge-tracked-evidence',
     PURGE_TIMELINE_BLOCK: 'db:purge-timeline-block',
+    PREVIEW_CORRECTION: 'db:preview-correction',
+    APPLY_CORRECTION: 'db:apply-correction',
+    UNDO_CORRECTION: 'db:undo-correction',
     GET_DISTRACTION_COST: 'db:get-distraction-cost',
     GET_RECAP_RANGE: 'db:get-recap-range',
     GET_TIMELINE_RANGE_BLOCKS: 'db:get-timeline-range-blocks',

--- a/tests/correctionCommands.test.ts
+++ b/tests/correctionCommands.test.ts
@@ -1,0 +1,389 @@
+// Correction commands (timeline spec, Corrections; DEV-172): every
+// non-destructive correction previews its exact cross-surface effect without
+// persisting, applies atomically, and can be undone — and the corrected facts
+// reach Timeline, Apps, and search immediately and survive a rebuild.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type Database from 'better-sqlite3'
+import type { AppCategory, CorrectionCommand } from '../src/shared/types.ts'
+import { createProductionTestDatabase } from './support/testDatabase.ts'
+import {
+  applyCorrection,
+  previewCorrection,
+  undoCorrection,
+} from '../src/main/services/correctionCommands.ts'
+import { getTimelineDayPayload } from '../src/main/services/workBlocks.ts'
+import {
+  getCorrectedAppSummariesForRange,
+  getCorrectedSessionsForRange,
+  getCorrectedWebsiteSummariesForRange,
+} from '../src/main/services/activityFacts.ts'
+import { searchAll, searchBrowser, searchSessions } from '../src/main/db/queries.ts'
+import { localDayBounds } from '../src/main/lib/localDate.ts'
+
+const TEST_DATE = '2026-04-22'
+
+function localMs(hour: number, minute = 0): number {
+  return new Date(2026, 3, 22, hour, minute, 0, 0).getTime()
+}
+
+function insertSession(
+  db: Database.Database,
+  payload: {
+    bundleId?: string
+    appName?: string
+    title: string
+    startMinute: number
+    durationMinutes: number
+    category?: AppCategory
+  },
+): void {
+  const startTime = localMs(9, payload.startMinute)
+  const endTime = startTime + payload.durationMinutes * 60_000
+  const bundleId = payload.bundleId ?? 'com.google.Chrome'
+  const appName = payload.appName ?? 'Google Chrome'
+  db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec,
+      category, is_focused, window_title, raw_app_name, capture_source, capture_version
+    ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 'test', 1)
+  `).run(
+    bundleId, appName, startTime, endTime, payload.durationMinutes * 60,
+    payload.category ?? 'browsing', payload.title, appName,
+  )
+}
+
+function insertVisit(
+  db: Database.Database,
+  payload: { domain: string; pageTitle: string; startMinute: number; durationSeconds: number },
+): void {
+  const startTime = localMs(9, payload.startMinute)
+  db.prepare(`
+    INSERT INTO website_visits (
+      browser_bundle_id, canonical_browser_id, visit_time, visit_time_us,
+      duration_sec, url, normalized_url, domain, page_title
+    ) VALUES ('com.google.Chrome', 'com.google.Chrome', ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    startTime, startTime * 1000, payload.durationSeconds,
+    `https://${payload.domain}/`, `https://${payload.domain}/`,
+    payload.domain, payload.pageTitle,
+  )
+}
+
+function seedTwoTopicDay(db: Database.Database): void {
+  insertSession(db, { title: 'Camera comparison research - DPReview - Google Chrome', startMinute: 0, durationMinutes: 25 })
+  insertSession(db, { title: 'City council election results - Local News - Google Chrome', startMinute: 25, durationMinutes: 25 })
+}
+
+function correctionLedgerCounts(db: Database.Database): { reviews: number; boundary: number; exclusions: number; undoLog: number } {
+  const count = (table: string): number =>
+    (db.prepare(`SELECT COUNT(*) AS c FROM ${table}`).get() as { c: number }).c
+  return {
+    reviews: count('timeline_block_reviews'),
+    boundary: count('timeline_boundary_corrections'),
+    exclusions: count('evidence_exclusions'),
+    undoLog: count('correction_undo_log'),
+  }
+}
+
+test('preview reports the rename delta without persisting anything', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const payload = getTimelineDayPayload(db, TEST_DATE)
+  const target = payload.blocks[0]
+  const before = correctionLedgerCounts(db)
+
+  const preview = previewCorrection(db, {
+    kind: 'edit', date: TEST_DATE, blockId: target.id, label: 'Acme camera research',
+  }, null)
+
+  assert.match(preview.description, /Rename/)
+  assert.equal(preview.blocks[0].labelAfter, 'Acme camera research')
+  assert.equal(preview.totalSecondsBefore, preview.totalSecondsAfter)
+  assert.ok(preview.surfaces.some((note) => note.includes('Acme camera research')))
+
+  // Nothing persisted: the ledger row counts and the rendered label are unchanged.
+  const after = getTimelineDayPayload(db, TEST_DATE)
+  assert.equal(after.blocks[0].label.current, target.label.current)
+  assert.deepEqual(correctionLedgerCounts(db), before)
+  db.close()
+})
+
+test('a rename applies atomically, reaches search immediately, and undo restores it', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const target = getTimelineDayPayload(db, TEST_DATE).blocks[0]
+
+  const { correctionId } = applyCorrection(db, {
+    kind: 'edit', date: TEST_DATE, blockId: target.id, label: 'Acme camera research',
+  }, null)
+
+  const renamed = getTimelineDayPayload(db, TEST_DATE)
+  assert.ok(renamed.blocks.some((block) => block.label.current === 'Acme camera research'))
+  const hits = searchAll(db, 'Acme camera', { startDate: TEST_DATE, endDate: TEST_DATE })
+  assert.ok(hits.length > 0, 'the corrected label is searchable with no rebuild')
+
+  const undo = undoCorrection(db, correctionId)
+  assert.equal(undo.undone, true)
+  const restored = getTimelineDayPayload(db, TEST_DATE)
+  assert.ok(!restored.blocks.some((block) => block.label.current === 'Acme camera research'))
+  assert.equal(restored.blocks[0].label.current, target.label.current)
+  db.close()
+})
+
+test('a category correction reaches Timeline and Apps and undo restores both', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const [dayFromMs, dayToMs] = localDayBounds(TEST_DATE)
+  const target = getTimelineDayPayload(db, TEST_DATE).blocks[0]
+  assert.notEqual(target.dominantCategory, 'research')
+
+  const { correctionId } = applyCorrection(db, {
+    kind: 'edit', date: TEST_DATE, blockId: target.id, category: 'research',
+  }, null)
+
+  const corrected = getTimelineDayPayload(db, TEST_DATE)
+  const correctedBlock = corrected.blocks.find((block) =>
+    block.startTime <= target.startTime && block.endTime >= target.endTime)
+  assert.equal(correctedBlock?.dominantCategory, 'research')
+  const apps = getCorrectedAppSummariesForRange(db, dayFromMs, dayToMs)
+  assert.ok(apps.some((app) => app.category === 'research'), 'Apps reads the corrected category')
+
+  undoCorrection(db, correctionId)
+  const restored = getTimelineDayPayload(db, TEST_DATE)
+  assert.equal(restored.blocks[0].dominantCategory, target.dominantCategory)
+  db.close()
+})
+
+test('merge previews the block-count change, applies, survives a rebuild, and undoes', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const before = getTimelineDayPayload(db, TEST_DATE).blocks
+  assert.equal(before.length, 2)
+
+  const command: CorrectionCommand = {
+    kind: 'merge', date: TEST_DATE, blockIds: [before[0].id, before[1].id],
+  }
+  const preview = previewCorrection(db, command, null)
+  assert.equal(preview.blockCountBefore, 2)
+  assert.equal(preview.blockCountAfter, 1)
+  assert.equal(getTimelineDayPayload(db, TEST_DATE).blocks.length, 2, 'preview persisted nothing')
+
+  const { correctionId } = applyCorrection(db, command, null)
+  assert.equal(getTimelineDayPayload(db, TEST_DATE).blocks.length, 1)
+
+  // The merge survives a forced rebuild (correction durability).
+  db.prepare(`UPDATE timeline_blocks SET heuristic_version = 'timeline-v3'`).run()
+  assert.equal(getTimelineDayPayload(db, TEST_DATE).blocks.length, 1)
+
+  undoCorrection(db, correctionId)
+  assert.equal(getTimelineDayPayload(db, TEST_DATE).blocks.length, 2)
+  db.close()
+})
+
+test('split at a chosen time cuts the block in two and undo rejoins it', () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, { title: 'Camera comparison research - DPReview - Google Chrome', startMinute: 0, durationMinutes: 50 })
+  const before = getTimelineDayPayload(db, TEST_DATE).blocks
+  assert.equal(before.length, 1)
+
+  const cutMs = localMs(9, 25)
+  const command: CorrectionCommand = {
+    kind: 'split', date: TEST_DATE, blockId: before[0].id, cutMs,
+  }
+  const preview = previewCorrection(db, command, null)
+  assert.equal(preview.blockCountAfter, 2)
+  assert.equal(getTimelineDayPayload(db, TEST_DATE).blocks.length, 1, 'preview persisted nothing')
+
+  const { correctionId } = applyCorrection(db, command, null)
+  const split = getTimelineDayPayload(db, TEST_DATE).blocks
+  assert.equal(split.length, 2)
+  assert.equal(split[0].endTime, cutMs)
+  assert.equal(split[1].startTime, cutMs)
+
+  undoCorrection(db, correctionId)
+  assert.equal(getTimelineDayPayload(db, TEST_DATE).blocks.length, 1)
+  db.close()
+})
+
+test('excluding a block removes it from Timeline, Apps, and search; undo brings it back', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const [dayFromMs, dayToMs] = localDayBounds(TEST_DATE)
+  const before = getTimelineDayPayload(db, TEST_DATE)
+  const target = before.blocks[1]
+
+  const command: CorrectionCommand = { kind: 'exclude-block', date: TEST_DATE, blockId: target.id }
+  const preview = previewCorrection(db, command, null)
+  assert.ok(preview.totalSecondsAfter < preview.totalSecondsBefore)
+  assert.equal(preview.blocks[0].labelAfter, null, 'the excluded block is gone in the preview')
+
+  const { correctionId } = applyCorrection(db, command, null)
+  const excluded = getTimelineDayPayload(db, TEST_DATE)
+  assert.ok(excluded.totalSeconds < before.totalSeconds)
+  const appsSeconds = getCorrectedAppSummariesForRange(db, dayFromMs, dayToMs)
+    .reduce((sum, app) => sum + app.totalSeconds, 0)
+  assert.equal(appsSeconds, Math.round(excluded.totalSeconds), 'Apps and Timeline agree after the exclusion')
+  assert.equal(
+    searchSessions(db, 'election', { startDate: TEST_DATE, endDate: TEST_DATE }).length,
+    0,
+    'the excluded stretch is gone from search',
+  )
+
+  undoCorrection(db, correctionId)
+  const restored = getTimelineDayPayload(db, TEST_DATE)
+  assert.equal(Math.round(restored.totalSeconds), Math.round(before.totalSeconds))
+  assert.ok(searchSessions(db, 'election', { startDate: TEST_DATE, endDate: TEST_DATE }).length > 0)
+  db.close()
+})
+
+test('excluding one site hides it from the block, Apps, and search without touching raw rows', () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, { title: 'Camera comparison research - DPReview - Google Chrome', startMinute: 0, durationMinutes: 50 })
+  insertVisit(db, { domain: 'dpreview.com', pageTitle: 'Camera comparison', startMinute: 5, durationSeconds: 600 })
+  insertVisit(db, { domain: 'secretsite.example', pageTitle: 'Private reading', startMinute: 20, durationSeconds: 600 })
+  const [dayFromMs, dayToMs] = localDayBounds(TEST_DATE)
+  const block = getTimelineDayPayload(db, TEST_DATE).blocks[0]
+
+  const command: CorrectionCommand = {
+    kind: 'exclude-evidence', date: TEST_DATE, blockId: block.id,
+    evidence: { kind: 'site', domain: 'secretsite.example' },
+  }
+  const { correctionId } = applyCorrection(db, command, null)
+
+  const blockAfter = getTimelineDayPayload(db, TEST_DATE).blocks[0]
+  assert.ok(!blockAfter.websites.some((site) => site.domain === 'secretsite.example'))
+  assert.ok(!getCorrectedWebsiteSummariesForRange(db, dayFromMs, dayToMs)
+    .some((site) => site.domain === 'secretsite.example'))
+  assert.equal(searchBrowser(db, 'Private reading', { startDate: TEST_DATE, endDate: TEST_DATE }).length, 0)
+  const rawRows = (db.prepare(`SELECT COUNT(*) AS c FROM website_visits WHERE domain = 'secretsite.example'`).get() as { c: number }).c
+  assert.equal(rawRows, 1, 'raw capture is untouched — the exclusion is reversible')
+
+  undoCorrection(db, correctionId)
+  assert.ok(getCorrectedWebsiteSummariesForRange(db, dayFromMs, dayToMs)
+    .some((site) => site.domain === 'secretsite.example'))
+  assert.ok(searchBrowser(db, 'Private reading', { startDate: TEST_DATE, endDate: TEST_DATE }).length > 0)
+  db.close()
+})
+
+test('excluding one app removes its minutes from the day and undo restores them', () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, { title: 'Camera comparison research - DPReview - Google Chrome', startMinute: 0, durationMinutes: 25 })
+  insertSession(db, {
+    bundleId: 'com.spotify.client', appName: 'Spotify', title: 'Lo-fi beats',
+    startMinute: 5, durationMinutes: 10, category: 'entertainment',
+  })
+  const [dayFromMs, dayToMs] = localDayBounds(TEST_DATE)
+  const block = getTimelineDayPayload(db, TEST_DATE).blocks[0]
+  const appsBefore = getCorrectedAppSummariesForRange(db, dayFromMs, dayToMs)
+  assert.ok(appsBefore.some((app) => app.appName === 'Spotify'))
+
+  const { correctionId } = applyCorrection(db, {
+    kind: 'exclude-evidence', date: TEST_DATE, blockId: block.id,
+    evidence: { kind: 'app', bundleId: 'com.spotify.client', appName: 'Spotify' },
+  }, null)
+
+  const appsAfter = getCorrectedAppSummariesForRange(db, dayFromMs, dayToMs)
+  assert.ok(!appsAfter.some((app) => app.appName === 'Spotify'))
+
+  undoCorrection(db, correctionId)
+  assert.ok(getCorrectedAppSummariesForRange(db, dayFromMs, dayToMs)
+    .some((app) => app.appName === 'Spotify'))
+  db.close()
+})
+
+test('assigning a client updates work sessions atomically and undo restores the prior owner', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const block = getTimelineDayPayload(db, TEST_DATE).blocks[0]
+  const now = Date.now()
+  db.prepare(`
+    INSERT INTO clients (id, name, created_at, updated_at) VALUES ('client_acme', 'Acme', ?, ?)
+  `).run(now, now)
+  db.prepare(`
+    INSERT INTO work_sessions (
+      id, device_id, started_at, ended_at, duration_ms, active_ms, idle_ms,
+      client_id, project_id, attribution_status, app_bundle_ids_json, created_at, updated_at
+    ) VALUES ('ws_1', 'device', ?, ?, ?, ?, 0, NULL, NULL, 'unattributed', '[]', ?, ?)
+  `).run(block.startTime, block.endTime, block.endTime - block.startTime, block.endTime - block.startTime, now, now)
+
+  const command: CorrectionCommand = {
+    kind: 'assign-client', date: TEST_DATE, blockId: block.id, clientId: 'client_acme',
+  }
+  const preview = previewCorrection(db, command, null)
+  assert.ok(preview.surfaces.some((note) => note.includes('Acme')))
+  const unassigned = db.prepare(`SELECT client_id FROM work_sessions WHERE id = 'ws_1'`).get() as { client_id: string | null }
+  assert.equal(unassigned.client_id, null, 'preview persisted nothing')
+
+  const { correctionId } = applyCorrection(db, command, null)
+  const assigned = db.prepare(`SELECT client_id, attribution_status FROM work_sessions WHERE id = 'ws_1'`).get() as { client_id: string | null; attribution_status: string }
+  assert.equal(assigned.client_id, 'client_acme')
+  assert.equal(assigned.attribution_status, 'attributed')
+
+  undoCorrection(db, correctionId)
+  const restored = db.prepare(`SELECT client_id, attribution_status FROM work_sessions WHERE id = 'ws_1'`).get() as { client_id: string | null; attribution_status: string }
+  assert.equal(restored.client_id, null)
+  assert.equal(restored.attribution_status, 'unattributed')
+  db.close()
+})
+
+test('a conflicting merge fails atomically and leaves the ledger untouched', () => {
+  const db = createProductionTestDatabase()
+  // 25 minutes of real absence between the blocks — the absence guard vetoes.
+  insertSession(db, { title: 'Camera comparison research - DPReview - Google Chrome', startMinute: 0, durationMinutes: 20 })
+  insertSession(db, { title: 'City council election results - Local News - Google Chrome', startMinute: 45, durationMinutes: 20 })
+  const blocks = getTimelineDayPayload(db, TEST_DATE).blocks
+  assert.equal(blocks.length, 2)
+  const before = correctionLedgerCounts(db)
+
+  assert.throws(() => applyCorrection(db, {
+    kind: 'merge', date: TEST_DATE, blockIds: [blocks[0].id, blocks[1].id],
+  }, null), /absence/i)
+
+  assert.deepEqual(correctionLedgerCounts(db), before, 'nothing applied partially')
+  db.close()
+})
+
+test('only the newest correction of a day can be undone', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const blocks = getTimelineDayPayload(db, TEST_DATE).blocks
+  const first = applyCorrection(db, {
+    kind: 'edit', date: TEST_DATE, blockId: blocks[0].id, label: 'First rename',
+  }, null)
+  applyCorrection(db, {
+    kind: 'edit', date: TEST_DATE, blockId: blocks[1].id, label: 'Second rename',
+  }, null)
+
+  assert.throws(() => undoCorrection(db, first.correctionId), /newer correction/i)
+  db.close()
+})
+
+test('corrections survive restart and reprojection', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const target = getTimelineDayPayload(db, TEST_DATE).blocks[0]
+  // A rename is anchored to the block's evidence set: with unchanged facts,
+  // reprojection re-forms the same block and the rename must hold.
+  applyCorrection(db, {
+    kind: 'edit', date: TEST_DATE, blockId: target.id, label: 'Durable rename',
+  }, null)
+  db.prepare(`UPDATE timeline_blocks SET invalidated_at = ?`).run(Date.now())
+  const rebuilt = getTimelineDayPayload(db, TEST_DATE)
+  const renamed = rebuilt.blocks.find((candidate) => candidate.label.current === 'Durable rename')
+  assert.ok(renamed, 'the rename survives reprojection')
+
+  // A category correction is anchored to the block's wall-clock span, so it
+  // survives even when the corrected facts re-segment the day.
+  applyCorrection(db, {
+    kind: 'edit', date: TEST_DATE, blockId: renamed!.id, category: 'research',
+  }, null)
+  db.prepare(`UPDATE timeline_blocks SET invalidated_at = ?`).run(Date.now())
+  const sessionsInSpan = getCorrectedSessionsForRange(db, renamed!.startTime, renamed!.endTime)
+  assert.ok(sessionsInSpan.length > 0)
+  assert.ok(
+    sessionsInSpan.every((session) => session.category === 'research'),
+    'the category correction survives reprojection in the corrected session facts',
+  )
+  db.close()
+})

--- a/tests/correctionCommands.test.ts
+++ b/tests/correctionCommands.test.ts
@@ -327,6 +327,80 @@ test('assigning a client updates work sessions atomically and undo restores the 
   db.close()
 })
 
+test('assigning a project updates work sessions and undo restores the prior owner', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const block = getTimelineDayPayload(db, TEST_DATE).blocks[0]
+  const now = Date.now()
+  db.prepare(`
+    INSERT INTO clients (id, name, created_at, updated_at) VALUES ('client_acme', 'Acme', ?, ?)
+  `).run(now, now)
+  db.prepare(`
+    INSERT INTO projects (id, client_id, name, status, created_at, updated_at)
+    VALUES ('proj_launch', 'client_acme', 'Launch', 'active', ?, ?)
+  `).run(now, now)
+  db.prepare(`
+    INSERT INTO work_sessions (
+      id, device_id, started_at, ended_at, duration_ms, active_ms, idle_ms,
+      client_id, project_id, attribution_status, app_bundle_ids_json, created_at, updated_at
+    ) VALUES ('ws_1', 'device', ?, ?, ?, ?, 0, NULL, NULL, 'unattributed', '[]', ?, ?)
+  `).run(block.startTime, block.endTime, block.endTime - block.startTime, block.endTime - block.startTime, now, now)
+
+  const command: CorrectionCommand = {
+    kind: 'assign-client',
+    date: TEST_DATE,
+    blockId: block.id,
+    clientId: 'client_acme',
+    projectId: 'proj_launch',
+  }
+  const preview = previewCorrection(db, command, null)
+  assert.match(preview.description, /Acme · Launch/)
+  assert.ok(preview.surfaces.some((note) => note.includes('Launch')))
+
+  const { correctionId, description } = applyCorrection(db, command, null)
+  assert.match(description, /Acme · Launch/)
+  const assigned = db.prepare(`
+    SELECT client_id, project_id, attribution_status FROM work_sessions WHERE id = 'ws_1'
+  `).get() as { client_id: string | null; project_id: string | null; attribution_status: string }
+  assert.equal(assigned.client_id, 'client_acme')
+  assert.equal(assigned.project_id, 'proj_launch')
+  assert.equal(assigned.attribution_status, 'attributed')
+
+  undoCorrection(db, correctionId)
+  const restored = db.prepare(`
+    SELECT client_id, project_id, attribution_status FROM work_sessions WHERE id = 'ws_1'
+  `).get() as { client_id: string | null; project_id: string | null; attribution_status: string }
+  assert.equal(restored.client_id, null)
+  assert.equal(restored.project_id, null)
+  assert.equal(restored.attribution_status, 'unattributed')
+  db.close()
+})
+
+test('assigning a client with no overlapping work sessions throws and leaves the undo ledger untouched', () => {
+  const db = createProductionTestDatabase()
+  seedTwoTopicDay(db)
+  const block = getTimelineDayPayload(db, TEST_DATE).blocks[0]
+  const now = Date.now()
+  db.prepare(`
+    INSERT INTO clients (id, name, created_at, updated_at) VALUES ('client_acme', 'Acme', ?, ?)
+  `).run(now, now)
+  const before = correctionLedgerCounts(db)
+
+  const command: CorrectionCommand = {
+    kind: 'assign-client', date: TEST_DATE, blockId: block.id, clientId: 'client_acme',
+  }
+  assert.throws(
+    () => previewCorrection(db, command, null),
+    /Nothing to attribute in this block yet/,
+  )
+  assert.throws(
+    () => applyCorrection(db, command, null),
+    /Nothing to attribute in this block yet/,
+  )
+  assert.deepEqual(correctionLedgerCounts(db), before, 'undo ledger untouched')
+  db.close()
+})
+
 test('a conflicting merge fails atomically and leaves the ledger untouched', () => {
   const db = createProductionTestDatabase()
   // 25 minutes of real absence between the blocks — the absence guard vetoes.


### PR DESCRIPTION
Closes DEV-172.

## What this does

The full correction set from the Timeline spec — rename, category change, time trim, merge, split at time, exclude block, exclude evidence, client assignment — now runs through one typed `CorrectionCommand` service with three verbs:

- **`previewCorrection`** applies the command inside a SQLite savepoint, reads the corrected Timeline + Apps facts, rolls back, and returns the exact cross-surface delta. The preview *is* the apply, dry-run — it can never drift from what apply will do.
- **`applyCorrection`** runs in one transaction: snapshot the correction-ledger rows the command may touch, apply, record the undo entry. A conflicting correction throws and nothing lands.
- **`undoCorrection`** restores the snapshot in one transaction; only the newest un-undone correction of a date can be undone.

Permanent purges are **not** commands — they keep their native confirm and no undo, clearly separated per the spec.

## Renderer

- Shared preview dialog (day total, block before → after, per-app deltas, consuming-surface sentences) + persistent undo toast.
- Context menu: merges and "Remove from day" (exclude-block) go through the preview flow; new "Split block…" opens a time-picker dialog.
- Block editor: save routes through the `edit` command; each tracked record gains an undoable Hide (exclude-evidence) beside permanent remove; a client select assigns the block's time through the same flow.

## Tests

12 service regression tests: accurate previews per command type, savepoint rollback leaves no trace, atomic conflict failure, undo restores the ledger, corrections survive reprojection. Full suite: 1443 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aTJYg361XTizVwCUTmqWD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeline correction previews with confirmation before applying changes.
  * Added undo support for recent corrections.
  * Added split-block editing, merge, category changes, client assignment, and reversible evidence hiding.
  * Added correction details showing affected blocks, apps, time, and other surfaces.
* **Bug Fixes**
  * Hidden apps and websites are now removed consistently from timeline and search results while preserving underlying activity data.
* **Tests**
  * Added coverage for correction, undo, search, timeline, attribution, and restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->