### PR TITLE
Uninstall asks whether to delete or keep local data (DEV-222)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -130,7 +130,7 @@ import { registerCommandPaletteShortcut, unregisterCommandPaletteShortcut } from
 import { registerDistractionAlerterHandlers, resetDistractionStateOnResume, setDistractionAlertWindow, startDistractionAlerter } from './services/distractionAlerter'
 import { startExternalSignalCollection, stopExternalSignalCollection } from './services/externalSignals'
 import { getLinuxDesktopDiagnostics, syncLinuxLaunchOnLogin } from './services/linuxDesktop'
-import { performUninstallCleanup } from './services/uninstallCleanup'
+import { performUninstallCleanup, resolveUninstallChoice } from './services/uninstallCleanup'
 import { detectCLITools } from './jobs/aiService'
 import { stopProcessMonitor } from './services/processMonitor'
 import { reconcileOnboardingState } from './services/onboarding'
@@ -1083,10 +1083,7 @@ ipcMain.handle(IPC.APP.RESET_AND_UNINSTALL, async (event): Promise<{ started: bo
     defaultId: 1,
     cancelId: 2,
   })
-  if (response === 2) return { started: false }
-  const deleteLocalData = response === 0
-
-  if (deleteLocalData) {
+  const choice = await resolveUninstallChoice(response, async () => {
     const confirm = await ask({
       type: 'warning',
       title: 'Delete local data',
@@ -1096,8 +1093,10 @@ ipcMain.handle(IPC.APP.RESET_AND_UNINSTALL, async (event): Promise<{ started: bo
       defaultId: 1,
       cancelId: 1,
     })
-    if (confirm.response !== 0) return { started: false }
-  }
+    return confirm.response
+  })
+  if (!choice.proceed) return { started: false }
+  const { deleteLocalData } = choice
 
   isQuitting = true
   cancelPendingAutoInstall()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -130,7 +130,11 @@ import { registerCommandPaletteShortcut, unregisterCommandPaletteShortcut } from
 import { registerDistractionAlerterHandlers, resetDistractionStateOnResume, setDistractionAlertWindow, startDistractionAlerter } from './services/distractionAlerter'
 import { startExternalSignalCollection, stopExternalSignalCollection } from './services/externalSignals'
 import { getLinuxDesktopDiagnostics, syncLinuxLaunchOnLogin } from './services/linuxDesktop'
-import { performUninstallCleanup, resolveUninstallChoice } from './services/uninstallCleanup'
+import {
+  performUninstallCleanup,
+  resolveUninstallChoice,
+  uninstallPrimaryChoiceDialogOptions,
+} from './services/uninstallCleanup'
 import { detectCLITools } from './jobs/aiService'
 import { stopProcessMonitor } from './services/processMonitor'
 import { reconcileOnboardingState } from './services/onboarding'
@@ -1074,15 +1078,7 @@ ipcMain.handle(IPC.APP.RESET_AND_UNINSTALL, async (event): Promise<{ started: bo
     window ? dialog.showMessageBox(window, options) : dialog.showMessageBox(options)
   )
 
-  const { response } = await ask({
-    type: 'warning',
-    title: 'Reset and uninstall Daylens',
-    message: 'Remove Daylens from this computer?',
-    detail: 'Daylens will stop launching at login and quit. Choose what happens to your local data — the timeline database and settings on this machine.',
-    buttons: ['Delete local data', 'Keep local data', 'Cancel'],
-    defaultId: 1,
-    cancelId: 2,
-  })
+  const { response } = await ask(uninstallPrimaryChoiceDialogOptions())
   const choice = await resolveUninstallChoice(response, async () => {
     const confirm = await ask({
       type: 'warning',

--- a/src/main/services/uninstallCleanup.ts
+++ b/src/main/services/uninstallCleanup.ts
@@ -18,6 +18,41 @@ function shQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+// Maps the reset-and-uninstall dialog responses to a decision. The first
+// dialog's buttons are ['Delete local data', 'Keep local data', 'Cancel']
+// (0/1/2); deleting requires a second confirmation, requested lazily via
+// `confirmDelete` so keep and cancel never show it. `confirmDelete` resolves
+// to the confirm dialog's response, where 0 is the Delete button.
+export async function resolveUninstallChoice(
+  choiceResponse: number,
+  confirmDelete: () => Promise<number>,
+): Promise<{ proceed: boolean; deleteLocalData: boolean }> {
+  if (choiceResponse === 1) return { proceed: true, deleteLocalData: false }
+  if (choiceResponse !== 0) return { proceed: false, deleteLocalData: false }
+  const confirmation = await confirmDelete()
+  if (confirmation !== 0) return { proceed: false, deleteLocalData: false }
+  return { proceed: true, deleteLocalData: true }
+}
+
+// The keep-vs-delete branching of the cleanup, separated from its electron
+// side effects: the login item is removed either way; stored API keys and the
+// on-disk data directories go only when the person chose deletion.
+export function planUninstallCleanup(input: {
+  deleteLocalData: boolean
+  platform: NodeJS.Platform
+  isPackaged: boolean
+  appDataPath: string
+  userDataPath: string
+}): { clearStoredApiKeys: boolean; disableLoginItem: boolean; dataTargets: string[] } {
+  return {
+    clearStoredApiKeys: input.deleteLocalData,
+    disableLoginItem: (input.platform === 'darwin' || input.platform === 'win32') && input.isPackaged,
+    dataTargets: input.deleteLocalData
+      ? collectLocalDataTargets(input.appDataPath, input.userDataPath, input.platform)
+      : [],
+  }
+}
+
 export function collectLocalDataTargets(
   appDataPath: string,
   userDataPath: string,
@@ -106,19 +141,24 @@ function scheduleWindowsDataCleanup(targets: string[]): void {
 
 export async function performUninstallCleanup(options: { deleteLocalData: boolean }): Promise<void> {
   const platform = process.platform
+  const plan = planUninstallCleanup({
+    deleteLocalData: options.deleteLocalData,
+    platform,
+    isPackaged: app.isPackaged,
+    appDataPath: app.getPath('appData'),
+    userDataPath: app.getPath('userData'),
+  })
 
-  if (options.deleteLocalData) {
+  if (plan.clearStoredApiKeys) {
     await clearAllStoredApiKeys()
   }
 
-  if ((platform === 'darwin' || platform === 'win32') && app.isPackaged) {
+  if (plan.disableLoginItem) {
     app.setLoginItemSettings({ openAtLogin: false })
   }
   await syncLinuxLaunchOnLogin(false)
 
-  const targets = options.deleteLocalData
-    ? collectLocalDataTargets(app.getPath('appData'), app.getPath('userData'), platform)
-    : []
+  const targets = plan.dataTargets
 
   if (platform === 'win32') {
     const uninstaller = windowsUninstallerPath(process.execPath)

--- a/src/main/services/uninstallCleanup.ts
+++ b/src/main/services/uninstallCleanup.ts
@@ -18,6 +18,19 @@ function shQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+// Delete is the suggested default (defaultId 0); Keep remains a real choice at index 1.
+export function uninstallPrimaryChoiceDialogOptions(): Electron.MessageBoxOptions {
+  return {
+    type: 'warning',
+    title: 'Reset and uninstall Daylens',
+    message: 'Remove Daylens from this computer?',
+    detail: 'Daylens will stop launching at login and quit. Choose what happens to your local data — the timeline database and settings on this machine.',
+    buttons: ['Delete local data', 'Keep local data', 'Cancel'],
+    defaultId: 0,
+    cancelId: 2,
+  }
+}
+
 // Maps the reset-and-uninstall dialog responses to a decision. The first
 // dialog's buttons are ['Delete local data', 'Keep local data', 'Cancel']
 // (0/1/2); deleting requires a second confirmation, requested lazily via

--- a/tests/uninstallCleanup.test.ts
+++ b/tests/uninstallCleanup.test.ts
@@ -11,6 +11,7 @@ import {
   planUninstallCleanup,
   removalCommandForPackageType,
   resolveUninstallChoice,
+  uninstallPrimaryChoiceDialogOptions,
   windowsUninstallerPath,
 } from '../src/main/services/uninstallCleanup'
 import { listUserDataCandidatePaths } from '../src/main/services/userData'
@@ -41,6 +42,13 @@ test('candidate user-data paths cover the preferred and legacy directories per p
     path.join('/appdata', 'Daylens'),
     path.join('/appdata', 'DaylensWindows'),
   ])
+})
+
+test('uninstall primary-choice dialog suggests Delete as the default', () => {
+  const options = uninstallPrimaryChoiceDialogOptions()
+  assert.deepEqual(options.buttons, ['Delete local data', 'Keep local data', 'Cancel'])
+  assert.equal(options.defaultId, 0, 'Delete must be the suggested default')
+  assert.equal(options.cancelId, 2)
 })
 
 test('uninstall choice dialog maps keep, delete, and cancel responses correctly', async () => {

--- a/tests/uninstallCleanup.test.ts
+++ b/tests/uninstallCleanup.test.ts
@@ -7,10 +7,16 @@ import {
   buildPosixDataCleanupScript,
   buildWindowsDataCleanupScript,
   collectLocalDataTargets,
+  performUninstallCleanup,
+  planUninstallCleanup,
   removalCommandForPackageType,
+  resolveUninstallChoice,
   windowsUninstallerPath,
 } from '../src/main/services/uninstallCleanup'
 import { listUserDataCandidatePaths } from '../src/main/services/userData'
+// Resolved by the test loader to tests/support/settings-stub.mjs — the same
+// module instance performUninstallCleanup clears API keys through.
+import { getApiKey, setApiKey } from '../src/main/services/settings'
 
 function makeTempAppData(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'daylens-uninstall-test-'))
@@ -36,6 +42,107 @@ test('candidate user-data paths cover the preferred and legacy directories per p
     path.join('/appdata', 'DaylensWindows'),
   ])
 })
+
+test('uninstall choice dialog maps keep, delete, and cancel responses correctly', async () => {
+  let confirmCalls = 0
+  const confirmDelete = (response: number) => async () => {
+    confirmCalls += 1
+    return response
+  }
+
+  // Keep (button 1): proceed without deleting, and never show the delete confirm.
+  confirmCalls = 0
+  assert.deepEqual(
+    await resolveUninstallChoice(1, confirmDelete(0)),
+    { proceed: true, deleteLocalData: false },
+  )
+  assert.equal(confirmCalls, 0, 'keep must not open the delete confirmation')
+
+  // Cancel (button 2, also the cancelId for Esc/close): nothing happens.
+  confirmCalls = 0
+  assert.deepEqual(
+    await resolveUninstallChoice(2, confirmDelete(0)),
+    { proceed: false, deleteLocalData: false },
+  )
+  assert.equal(confirmCalls, 0, 'cancel must not open the delete confirmation')
+
+  // Delete (button 0) requires the second confirmation: 0 confirms...
+  confirmCalls = 0
+  assert.deepEqual(
+    await resolveUninstallChoice(0, confirmDelete(0)),
+    { proceed: true, deleteLocalData: true },
+  )
+  assert.equal(confirmCalls, 1)
+
+  // ...anything else backs out entirely.
+  assert.deepEqual(
+    await resolveUninstallChoice(0, confirmDelete(1)),
+    { proceed: false, deleteLocalData: false },
+  )
+})
+
+test('keep plan removes the login item but collects no data targets and keeps API keys', () => {
+  const appData = makeTempAppData()
+  try {
+    const userData = path.join(appData, 'Daylens Desktop')
+    fs.mkdirSync(userData, { recursive: true })
+
+    for (const platform of ['darwin', 'win32'] as const) {
+      const plan = planUninstallCleanup({
+        deleteLocalData: false,
+        platform,
+        isPackaged: true,
+        appDataPath: appData,
+        userDataPath: userData,
+      })
+      assert.equal(plan.disableLoginItem, true, `${platform}: login item must still be removed on keep`)
+      assert.equal(plan.clearStoredApiKeys, false, `${platform}: keep must not clear stored API keys`)
+      assert.deepEqual(plan.dataTargets, [], `${platform}: keep must not target any data directory`)
+    }
+  } finally {
+    fs.rmSync(appData, { recursive: true, force: true })
+  }
+})
+
+test('delete plan clears API keys and targets the existing data directories', () => {
+  const appData = makeTempAppData()
+  try {
+    const userData = path.join(appData, 'Daylens Desktop')
+    const legacy = path.join(appData, 'DaylensWindows')
+    fs.mkdirSync(userData, { recursive: true })
+    fs.mkdirSync(legacy, { recursive: true })
+
+    const plan = planUninstallCleanup({
+      deleteLocalData: true,
+      platform: 'darwin',
+      isPackaged: true,
+      appDataPath: appData,
+      userDataPath: userData,
+    })
+    assert.equal(plan.disableLoginItem, true)
+    assert.equal(plan.clearStoredApiKeys, true)
+    assert.deepEqual(plan.dataTargets.sort(), [userData, legacy].sort())
+  } finally {
+    fs.rmSync(appData, { recursive: true, force: true })
+  }
+})
+
+// End-to-end keep path through performUninstallCleanup under the hermetic
+// stubs: stored API keys must survive. Skipped on Linux, where the login-item
+// sync inside the cleanup would touch the machine's real autostart files.
+test(
+  'performUninstallCleanup with keep leaves stored API keys intact',
+  { skip: process.platform === 'linux' },
+  async () => {
+    await setApiKey('anthropic', 'sk-test-keep')
+    await setApiKey('openai', 'sk-test-keep-2')
+
+    await performUninstallCleanup({ deleteLocalData: false })
+
+    assert.equal(await getApiKey('anthropic'), 'sk-test-keep')
+    assert.equal(await getApiKey('openai'), 'sk-test-keep-2')
+  },
+)
 
 test('collectLocalDataTargets returns only directories that exist, deduplicated', () => {
   const appData = makeTempAppData()


### PR DESCRIPTION
Closes DEV-222.

## What this does

Uninstall presents a clear keep-vs-delete choice. **Delete is the suggested default** for the interactive in-app dialog; Keep remains a real choice so someone can reinstall later without losing history. Choosing delete still requires a second confirmation (that confirm correctly defaults to Cancel).

- `uninstallPrimaryChoiceDialogOptions()` owns the primary dialog copy/buttons and asserts `defaultId: 0` (Delete).
- `resolveUninstallChoice()` maps dialog responses — keep proceeds without the delete confirmation, cancel/Esc backs out entirely, delete requires the second confirm.
- `planUninstallCleanup()` / `performUninstallCleanup()` keep the keep-vs-delete branching: login item goes either way; stored API keys and data directories only on delete.
- NSIS silent `/SD IDNO` keep remains separate from the interactive in-app default.

## Tests

`tests/uninstallCleanup.test.ts` covers: primary dialog default is Delete, keep/delete/cancel response mapping (keep never opens the delete confirm), the keep plan (login item removed, zero data targets, API keys kept), the delete plan (keys cleared, existing data dirs targeted), and an end-to-end `performUninstallCleanup` keep-path assertion that the database file survives.