### PR TITLE
Nothing raw can ever sync (DEV-187)

### DIFF
--- a/src/shared/aiSanitize.ts
+++ b/src/shared/aiSanitize.ts
@@ -6,49 +6,7 @@
 // the user knows something was filtered. Both are last-line defenses; capture-
 // side hygiene strips most leak vectors before they reach either layer.
 
-interface Pattern {
-  name: string
-  regex: RegExp
-}
-
-// Order matters. Specific provider shapes run first so they take credit for
-// the redaction in the analytics counter; the generic backstops mop up the
-// rest. Each regex is /g so we replace every occurrence in a string.
-const PATTERNS: Pattern[] = [
-  // 1. URL query strings (and fragments) on http(s) URLs. Also any bare
-  // ?code=… style query when it follows a path-looking prefix.
-  { name: 'url_query', regex: /(https?:\/\/[^\s?#]+)[?#][^\s)\]"'<>]*/gi },
-
-  // 2. JWT — three base64url segments separated by dots, starting with eyJ
-  // (a base64 of "{"...). Must run before generic base64 backstop.
-  { name: 'jwt', regex: /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g },
-
-  // 3. Provider-specific token shapes.
-  { name: 'openai_key', regex: /sk-[A-Za-z0-9_-]{20,}/g },
-  { name: 'slack_token', regex: /xox[abprs]-[A-Za-z0-9-]{10,}/g },
-  { name: 'google_oauth', regex: /ya29\.[A-Za-z0-9_.-]+/g },
-  { name: 'github_pat', regex: /gh[pousr]_[A-Za-z0-9]{30,}/g },
-  { name: 'aws_access_key', regex: /\bAKIA[0-9A-Z]{16}\b/g },
-
-  // 4. OAuth callback "code=…" / "state=…" / "access_token=…" parameters
-  // even when they appear bare (e.g. captured into a window title without
-  // the leading URL). Catches the reproduced leak shape.
-  { name: 'oauth_param', regex: /\b(?:code|state|access_token|id_token|refresh_token|token|client_secret|api_key)=[A-Za-z0-9_.\-+/=%]{8,}/gi },
-
-  // 5. Hex blobs ≥32 chars (sha-256 hashes, AWS secrets without the prefix,
-  // long capture cookies). Word-boundary anchored to avoid clipping into
-  // surrounding text.
-  { name: 'hex_blob', regex: /\b[0-9a-fA-F]{32,}\b/g },
-
-  // 6. Base64-ish ≥24 chars with mixed case+digits and no whitespace.
-  // Requires at least one digit and one of each case to avoid hitting plain
-  // English words. The character class includes the URL-safe variants.
-  { name: 'base64_blob', regex: /\b(?=[A-Za-z0-9+/=_-]*\d)(?=[A-Za-z0-9+/=_-]*[A-Z])(?=[A-Za-z0-9+/=_-]*[a-z])[A-Za-z0-9+/=_-]{24,}\b/g },
-
-  // 7. Generic high-entropy backstop: ≥32 chars of [A-Za-z0-9_-] with no
-  // whitespace. Runs last so the more-specific patterns claim the match.
-  { name: 'generic_token', regex: /\b[A-Za-z0-9_-]{32,}\b/g },
-]
+import { CREDENTIAL_PATTERNS } from './credentialPatterns'
 
 export interface SanitizeReport {
   redactionCount: number
@@ -60,7 +18,7 @@ function applyPatterns(input: string, replacement: string | ((name: string) => s
   let redactionCount = 0
   const patternsHit: string[] = []
 
-  for (const { name, regex } of PATTERNS) {
+  for (const { name, regex } of CREDENTIAL_PATTERNS) {
     // Reset in case any caller passed a stateful regex by accident; ours are
     // module-local so this is defensive.
     regex.lastIndex = 0

--- a/src/shared/credentialPatterns.ts
+++ b/src/shared/credentialPatterns.ts
@@ -1,0 +1,60 @@
+// Shared credential / secret regex corpus. Used by aiSanitize (model + render
+// redaction) and by the sync allowlist value guards. Order matters: specific
+// provider shapes run first so they take credit; generic backstops mop up.
+
+export interface CredentialPattern {
+  name: string
+  regex: RegExp
+}
+
+export const CREDENTIAL_PATTERNS: CredentialPattern[] = [
+  // 1. URL query strings (and fragments) on http(s) URLs. Also any bare
+  // ?code=… style query when it follows a path-looking prefix.
+  { name: 'url_query', regex: /(https?:\/\/[^\s?#]+)[?#][^\s)\]"'<>]*/gi },
+
+  // 2. JWT — three base64url segments separated by dots, starting with eyJ
+  // (a base64 of "{"...). Must run before generic base64 backstop.
+  { name: 'jwt', regex: /eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g },
+
+  // 3. Provider-specific token shapes.
+  { name: 'openai_key', regex: /sk-[A-Za-z0-9_-]{20,}/g },
+  { name: 'slack_token', regex: /xox[abprs]-[A-Za-z0-9-]{10,}/g },
+  { name: 'google_oauth', regex: /ya29\.[A-Za-z0-9_.-]+/g },
+  { name: 'github_pat', regex: /gh[pousr]_[A-Za-z0-9]{30,}/g },
+  { name: 'aws_access_key', regex: /\bAKIA[0-9A-Z]{16}\b/g },
+
+  // 4. OAuth callback "code=…" / "state=…" / "access_token=…" parameters
+  // even when they appear bare (e.g. captured into a window title without
+  // the leading URL). Catches the reproduced leak shape.
+  { name: 'oauth_param', regex: /\b(?:code|state|access_token|id_token|refresh_token|token|client_secret|api_key)=[A-Za-z0-9_.\-+/=%]{8,}/gi },
+
+  // 5. Hex blobs ≥32 chars (sha-256 hashes, AWS secrets without the prefix,
+  // long capture cookies). Word-boundary anchored to avoid clipping into
+  // surrounding text.
+  { name: 'hex_blob', regex: /\b[0-9a-fA-F]{32,}\b/g },
+
+  // 6. Base64-ish ≥24 chars with mixed case+digits and no whitespace.
+  // Requires at least one digit and one of each case to avoid hitting plain
+  // English words. The character class includes the URL-safe variants.
+  { name: 'base64_blob', regex: /\b(?=[A-Za-z0-9+/=_-]*\d)(?=[A-Za-z0-9+/=_-]*[A-Z])(?=[A-Za-z0-9+/=_-]*[a-z])[A-Za-z0-9+/=_-]{24,}\b/g },
+
+  // 7. Generic high-entropy backstop: ≥32 chars of [A-Za-z0-9_-] with no
+  // whitespace. Runs last so the more-specific patterns claim the match.
+  { name: 'generic_token', regex: /\b[A-Za-z0-9_-]{32,}\b/g },
+]
+
+export function findCredentialPattern(value: string): string | null {
+  if (!value) return null
+  for (const { name, regex } of CREDENTIAL_PATTERNS) {
+    regex.lastIndex = 0
+    if (regex.test(value)) {
+      regex.lastIndex = 0
+      return name
+    }
+  }
+  return null
+}
+
+export function containsCredential(value: string): boolean {
+  return findCredentialPattern(value) !== null
+}

--- a/src/shared/syncAllowlist/index.ts
+++ b/src/shared/syncAllowlist/index.ts
@@ -1,0 +1,201 @@
+import type { RemoteSyncPayload, WorkspaceLivePresence } from '@daylens/remote-contract'
+import { ZodError } from 'zod'
+import {
+  ARTIFACT_ROLLUP_KEYS,
+  ENTITY_ROLLUP_KEYS,
+  FOCUS_SCORE_V2_KEYS,
+  RECAP_CHAPTER_KEYS,
+  RECAP_COVERAGE_KEYS,
+  RECAP_METRIC_KEYS,
+  RECAP_SUMMARY_LITE_KEYS,
+  REMOTE_SYNC_PAYLOAD_KEYS,
+  SYNCED_DAY_SUMMARY_KEYS,
+  SYNCED_RECAP_KEYS,
+  WORK_BLOCK_SUMMARY_KEYS,
+  WORK_BLOCK_TOP_APP_KEYS,
+  WORK_BLOCK_TOP_PAGE_KEYS,
+  WORKSPACE_LIVE_PRESENCE_KEYS,
+  WORKSTREAM_ROLLUP_KEYS,
+  OPAQUE_SOURCE_REFERENCE_KEYS,
+} from './keys'
+import { opaqueSourceReferenceSchema, type OpaqueSourceReference } from './opaqueSource'
+import {
+  artifactRollupSchema,
+  entityRollupSchema,
+  focusScoreV2Schema,
+  recapChapterSchema,
+  recapCoverageSchema,
+  recapMetricSchema,
+  recapSummaryLiteSchema,
+  remoteSyncPayloadSchema,
+  syncedDaySummarySchema,
+  syncedRecapSchema,
+  workBlockSummarySchema,
+  workBlockTopAppSchema,
+  workBlockTopPageSchema,
+  workspaceLivePresenceSchema,
+  workstreamRollupSchema,
+} from './schemas'
+import {
+  collectForbiddenKeys,
+  collectPresenceValueViolations,
+  collectRemoteSyncValueViolations,
+  type SyncAllowlistViolationDetail,
+} from './valueGuards'
+
+export type { ExactKeys } from './keys'
+export {
+  ARTIFACT_ROLLUP_KEYS,
+  ENTITY_ROLLUP_KEYS,
+  FOCUS_SCORE_V2_KEYS,
+  OPAQUE_SOURCE_REFERENCE_KEYS,
+  RECAP_CHAPTER_KEYS,
+  RECAP_COVERAGE_KEYS,
+  RECAP_METRIC_KEYS,
+  RECAP_SUMMARY_LITE_KEYS,
+  REMOTE_SYNC_PAYLOAD_KEYS,
+  SYNCED_DAY_SUMMARY_KEYS,
+  SYNCED_RECAP_KEYS,
+  WORK_BLOCK_SUMMARY_KEYS,
+  WORK_BLOCK_TOP_APP_KEYS,
+  WORK_BLOCK_TOP_PAGE_KEYS,
+  WORKSPACE_LIVE_PRESENCE_KEYS,
+  WORKSTREAM_ROLLUP_KEYS,
+} from './keys'
+export { opaqueSourceReferenceSchema, type OpaqueSourceReference } from './opaqueSource'
+export {
+  artifactRollupSchema,
+  entityRollupSchema,
+  focusScoreV2Schema,
+  recapChapterSchema,
+  recapCoverageSchema,
+  recapMetricSchema,
+  recapSummaryLiteSchema,
+  remoteSyncPayloadSchema,
+  syncedDaySummarySchema,
+  syncedRecapSchema,
+  workBlockSummarySchema,
+  workBlockTopAppSchema,
+  workBlockTopPageSchema,
+  workspaceLivePresenceSchema,
+  workstreamRollupSchema,
+} from './schemas'
+export type { SyncAllowlistViolationClass, SyncAllowlistViolationDetail } from './valueGuards'
+
+export class SyncAllowlistViolation extends Error {
+  readonly violations: SyncAllowlistViolationDetail[]
+
+  constructor(violations: SyncAllowlistViolationDetail[]) {
+    const summary = violations
+      .slice(0, 5)
+      .map((item) => `${item.class}@${item.path}`)
+      .join('; ')
+    super(
+      violations.length === 1
+        ? `Sync allowlist violation: ${summary}`
+        : `Sync allowlist violations (${violations.length}): ${summary}`,
+    )
+    this.name = 'SyncAllowlistViolation'
+    this.violations = violations
+  }
+}
+
+function zodToViolations(error: ZodError): SyncAllowlistViolationDetail[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+    if (issue.code === 'unrecognized_keys') {
+      return {
+        class: 'extra_field' as const,
+        path,
+        detail: issue.message,
+      }
+    }
+    return {
+      class: 'schema' as const,
+      path,
+      detail: issue.message,
+    }
+  })
+}
+
+function throwIfAny(violations: SyncAllowlistViolationDetail[]): void {
+  if (violations.length > 0) throw new SyncAllowlistViolation(violations)
+}
+
+/** Structural + value-class gate for organized-fact day sync payloads. */
+export function assertSyncPayloadAllowed(payload: unknown): RemoteSyncPayload {
+  const parsed = remoteSyncPayloadSchema.safeParse(payload)
+  if (!parsed.success) {
+    throw new SyncAllowlistViolation(zodToViolations(parsed.error))
+  }
+
+  const violations = [
+    ...collectForbiddenKeys(parsed.data),
+    ...collectRemoteSyncValueViolations(parsed.data),
+  ]
+  throwIfAny(violations)
+  return parsed.data
+}
+
+/** Structural + value-class gate for workspace heartbeat presence. */
+export function assertWorkspaceLivePresenceAllowed(payload: unknown): WorkspaceLivePresence {
+  const parsed = workspaceLivePresenceSchema.safeParse(payload)
+  if (!parsed.success) {
+    throw new SyncAllowlistViolation(zodToViolations(parsed.error))
+  }
+
+  const violations = [
+    ...collectForbiddenKeys(parsed.data),
+    ...collectPresenceValueViolations(parsed.data),
+  ]
+  throwIfAny(violations)
+  return parsed.data
+}
+
+/** Spec opaque source reference: exactly three fields, no titles/URLs/excerpts. */
+export function assertOpaqueSourceAllowed(payload: unknown): OpaqueSourceReference {
+  const parsed = opaqueSourceReferenceSchema.safeParse(payload)
+  if (!parsed.success) {
+    const violations = zodToViolations(parsed.error).map((item) =>
+      item.class === 'extra_field'
+        ? { ...item, class: 'opaque_source_shape' as const }
+        : item.class === 'schema'
+          ? { ...item, class: 'opaque_source_shape' as const }
+          : item,
+    )
+    throw new SyncAllowlistViolation(violations)
+  }
+  return parsed.data
+}
+
+/** Key-map ↔ zod-shape parity for structural “new field fails” coverage. */
+export const SYNC_ALLOWLIST_KEY_SCHEMA_PAIRS: Array<{
+  name: string
+  keys: Record<string, true>
+  shape: Record<string, unknown>
+}> = [
+  { name: 'RemoteSyncPayload', keys: REMOTE_SYNC_PAYLOAD_KEYS, shape: remoteSyncPayloadSchema.shape },
+  { name: 'SyncedDaySummary', keys: SYNCED_DAY_SUMMARY_KEYS, shape: syncedDaySummarySchema.shape },
+  { name: 'FocusScoreV2Snapshot', keys: FOCUS_SCORE_V2_KEYS, shape: focusScoreV2Schema.shape },
+  { name: 'SyncedRecap', keys: SYNCED_RECAP_KEYS, shape: syncedRecapSchema.shape },
+  { name: 'RecapSummaryLite', keys: RECAP_SUMMARY_LITE_KEYS, shape: recapSummaryLiteSchema.shape },
+  { name: 'RecapChapter', keys: RECAP_CHAPTER_KEYS, shape: recapChapterSchema.shape },
+  { name: 'RecapMetric', keys: RECAP_METRIC_KEYS, shape: recapMetricSchema.shape },
+  { name: 'RecapCoverage', keys: RECAP_COVERAGE_KEYS, shape: recapCoverageSchema.shape },
+  { name: 'WorkstreamRollup', keys: WORKSTREAM_ROLLUP_KEYS, shape: workstreamRollupSchema.shape },
+  { name: 'WorkBlockSummary', keys: WORK_BLOCK_SUMMARY_KEYS, shape: workBlockSummarySchema.shape },
+  { name: 'WorkBlockTopApp', keys: WORK_BLOCK_TOP_APP_KEYS, shape: workBlockTopAppSchema.shape },
+  { name: 'WorkBlockTopPage', keys: WORK_BLOCK_TOP_PAGE_KEYS, shape: workBlockTopPageSchema.shape },
+  { name: 'EntityRollup', keys: ENTITY_ROLLUP_KEYS, shape: entityRollupSchema.shape },
+  { name: 'ArtifactRollup', keys: ARTIFACT_ROLLUP_KEYS, shape: artifactRollupSchema.shape },
+  {
+    name: 'WorkspaceLivePresence',
+    keys: WORKSPACE_LIVE_PRESENCE_KEYS,
+    shape: workspaceLivePresenceSchema.shape,
+  },
+  {
+    name: 'OpaqueSourceReference',
+    keys: OPAQUE_SOURCE_REFERENCE_KEYS,
+    shape: opaqueSourceReferenceSchema.shape,
+  },
+]

--- a/src/shared/syncAllowlist/keys.ts
+++ b/src/shared/syncAllowlist/keys.ts
@@ -1,0 +1,214 @@
+import type {
+  ArtifactRollup,
+  EntityRollup,
+  FocusScoreV2Snapshot,
+  RecapCoverage,
+  RecapSummaryLite,
+  RemoteSyncPayload,
+  SyncedDaySummary,
+  WorkBlockSummary,
+  WorkspaceLivePresence,
+  WorkstreamRollup,
+} from '@daylens/remote-contract'
+
+// Bidirectional exactness: fails typecheck if the map has extras OR the
+// mirrored type gains a field that is not listed.
+export type ExactKeys<T, M extends Record<keyof T, true>> =
+  Exclude<keyof M, keyof T> extends never
+    ? Exclude<keyof T, keyof M> extends never
+      ? M
+      : never
+    : never
+
+type RecapChapter = RecapSummaryLite['chapters'][number]
+type RecapMetric = RecapSummaryLite['metrics'][number]
+type WorkBlockTopApp = WorkBlockSummary['topApps'][number]
+type WorkBlockTopPage = WorkBlockSummary['topPages'][number]
+type SyncedRecap = SyncedDaySummary['recap']
+
+export const REMOTE_SYNC_PAYLOAD_KEYS = {
+  contractVersion: true,
+  deviceId: true,
+  localDate: true,
+  generatedAt: true,
+  daySummary: true,
+  workBlocks: true,
+  entities: true,
+  artifacts: true,
+} as const satisfies Record<keyof RemoteSyncPayload, true>
+const _exactRemoteSyncPayloadKeys: ExactKeys<RemoteSyncPayload, typeof REMOTE_SYNC_PAYLOAD_KEYS> =
+  REMOTE_SYNC_PAYLOAD_KEYS
+void _exactRemoteSyncPayloadKeys
+
+export const SYNCED_DAY_SUMMARY_KEYS = {
+  contractVersion: true,
+  deviceId: true,
+  localDate: true,
+  generatedAt: true,
+  isPartialDay: true,
+  focusScore: true,
+  focusSeconds: true,
+  focusScoreV2: true,
+  recap: true,
+  coverage: true,
+  topWorkstreams: true,
+  latestWorkBlockId: true,
+  workBlockCount: true,
+  entityCount: true,
+  artifactCount: true,
+  privacyFiltered: true,
+} as const satisfies Record<keyof SyncedDaySummary, true>
+const _exactSyncedDaySummaryKeys: ExactKeys<SyncedDaySummary, typeof SYNCED_DAY_SUMMARY_KEYS> =
+  SYNCED_DAY_SUMMARY_KEYS
+void _exactSyncedDaySummaryKeys
+
+export const FOCUS_SCORE_V2_KEYS = {
+  deepWorkPct: true,
+  longestStreakSeconds: true,
+  switchCount: true,
+  deepWorkSessionCount: true,
+} as const satisfies Record<keyof FocusScoreV2Snapshot, true>
+const _exactFocusScoreV2Keys: ExactKeys<FocusScoreV2Snapshot, typeof FOCUS_SCORE_V2_KEYS> =
+  FOCUS_SCORE_V2_KEYS
+void _exactFocusScoreV2Keys
+
+export const SYNCED_RECAP_KEYS = {
+  day: true,
+  week: true,
+  month: true,
+} as const satisfies Record<keyof SyncedRecap, true>
+const _exactSyncedRecapKeys: ExactKeys<SyncedRecap, typeof SYNCED_RECAP_KEYS> = SYNCED_RECAP_KEYS
+void _exactSyncedRecapKeys
+
+export const RECAP_SUMMARY_LITE_KEYS = {
+  headline: true,
+  chapters: true,
+  metrics: true,
+  changeSummary: true,
+  promptChips: true,
+  hasData: true,
+} as const satisfies Record<keyof RecapSummaryLite, true>
+const _exactRecapSummaryLiteKeys: ExactKeys<RecapSummaryLite, typeof RECAP_SUMMARY_LITE_KEYS> =
+  RECAP_SUMMARY_LITE_KEYS
+void _exactRecapSummaryLiteKeys
+
+export const RECAP_CHAPTER_KEYS = {
+  id: true,
+  eyebrow: true,
+  title: true,
+  body: true,
+} as const satisfies Record<keyof RecapChapter, true>
+const _exactRecapChapterKeys: ExactKeys<RecapChapter, typeof RECAP_CHAPTER_KEYS> = RECAP_CHAPTER_KEYS
+void _exactRecapChapterKeys
+
+export const RECAP_METRIC_KEYS = {
+  label: true,
+  value: true,
+  detail: true,
+} as const satisfies Record<keyof RecapMetric, true>
+const _exactRecapMetricKeys: ExactKeys<RecapMetric, typeof RECAP_METRIC_KEYS> = RECAP_METRIC_KEYS
+void _exactRecapMetricKeys
+
+export const RECAP_COVERAGE_KEYS = {
+  attributedPct: true,
+  untitledPct: true,
+  activeDayCount: true,
+  quietDayCount: true,
+  hasComparison: true,
+  coverageNote: true,
+} as const satisfies Record<keyof RecapCoverage, true>
+const _exactRecapCoverageKeys: ExactKeys<RecapCoverage, typeof RECAP_COVERAGE_KEYS> =
+  RECAP_COVERAGE_KEYS
+void _exactRecapCoverageKeys
+
+export const WORKSTREAM_ROLLUP_KEYS = {
+  label: true,
+  seconds: true,
+  blockCount: true,
+  isUntitled: true,
+} as const satisfies Record<keyof WorkstreamRollup, true>
+const _exactWorkstreamRollupKeys: ExactKeys<WorkstreamRollup, typeof WORKSTREAM_ROLLUP_KEYS> =
+  WORKSTREAM_ROLLUP_KEYS
+void _exactWorkstreamRollupKeys
+
+export const WORK_BLOCK_SUMMARY_KEYS = {
+  id: true,
+  startAt: true,
+  endAt: true,
+  label: true,
+  labelSource: true,
+  dominantCategory: true,
+  focusSeconds: true,
+  switchCount: true,
+  confidence: true,
+  topApps: true,
+  topPages: true,
+  artifactIds: true,
+} as const satisfies Record<keyof WorkBlockSummary, true>
+const _exactWorkBlockSummaryKeys: ExactKeys<WorkBlockSummary, typeof WORK_BLOCK_SUMMARY_KEYS> =
+  WORK_BLOCK_SUMMARY_KEYS
+void _exactWorkBlockSummaryKeys
+
+export const WORK_BLOCK_TOP_APP_KEYS = {
+  appKey: true,
+  seconds: true,
+} as const satisfies Record<keyof WorkBlockTopApp, true>
+const _exactWorkBlockTopAppKeys: ExactKeys<WorkBlockTopApp, typeof WORK_BLOCK_TOP_APP_KEYS> =
+  WORK_BLOCK_TOP_APP_KEYS
+void _exactWorkBlockTopAppKeys
+
+export const WORK_BLOCK_TOP_PAGE_KEYS = {
+  domain: true,
+  label: true,
+  seconds: true,
+} as const satisfies Record<keyof WorkBlockTopPage, true>
+const _exactWorkBlockTopPageKeys: ExactKeys<WorkBlockTopPage, typeof WORK_BLOCK_TOP_PAGE_KEYS> =
+  WORK_BLOCK_TOP_PAGE_KEYS
+void _exactWorkBlockTopPageKeys
+
+export const ENTITY_ROLLUP_KEYS = {
+  id: true,
+  label: true,
+  kind: true,
+  secondsToday: true,
+  blockCount: true,
+} as const satisfies Record<keyof EntityRollup, true>
+const _exactEntityRollupKeys: ExactKeys<EntityRollup, typeof ENTITY_ROLLUP_KEYS> = ENTITY_ROLLUP_KEYS
+void _exactEntityRollupKeys
+
+export const ARTIFACT_ROLLUP_KEYS = {
+  id: true,
+  kind: true,
+  title: true,
+  byteSize: true,
+  generatedAt: true,
+  threadId: true,
+} as const satisfies Record<keyof ArtifactRollup, true>
+const _exactArtifactRollupKeys: ExactKeys<ArtifactRollup, typeof ARTIFACT_ROLLUP_KEYS> =
+  ARTIFACT_ROLLUP_KEYS
+void _exactArtifactRollupKeys
+
+export const WORKSPACE_LIVE_PRESENCE_KEYS = {
+  contractVersion: true,
+  deviceId: true,
+  localDate: true,
+  state: true,
+  heartbeatAt: true,
+  capturedAt: true,
+  lastMeaningfulCaptureAt: true,
+  currentBlockLabel: true,
+  currentCategory: true,
+  currentAppKey: true,
+  currentFocusSeconds: true,
+} as const satisfies Record<keyof WorkspaceLivePresence, true>
+const _exactWorkspaceLivePresenceKeys: ExactKeys<
+  WorkspaceLivePresence,
+  typeof WORKSPACE_LIVE_PRESENCE_KEYS
+> = WORKSPACE_LIVE_PRESENCE_KEYS
+void _exactWorkspaceLivePresenceKeys
+
+export const OPAQUE_SOURCE_REFERENCE_KEYS = {
+  evidenceId: true,
+  evidenceKind: true,
+  originatingDevice: true,
+} as const

--- a/src/shared/syncAllowlist/opaqueSource.ts
+++ b/src/shared/syncAllowlist/opaqueSource.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod'
+import { ExactKeys, OPAQUE_SOURCE_REFERENCE_KEYS } from './keys'
+
+// Spec shape for synced source references: evidence identifier, kind, and
+// originating device only. Titles, URLs, and excerpts are never allowed.
+export interface OpaqueSourceReference {
+  evidenceId: string
+  evidenceKind: string
+  originatingDevice: string
+}
+
+const _exactOpaqueSourceKeys: ExactKeys<
+  OpaqueSourceReference,
+  typeof OPAQUE_SOURCE_REFERENCE_KEYS
+> = OPAQUE_SOURCE_REFERENCE_KEYS
+void _exactOpaqueSourceKeys
+
+export const opaqueSourceReferenceSchema = z
+  .object({
+    evidenceId: z.string().min(1),
+    evidenceKind: z.string().min(1),
+    originatingDevice: z.string().min(1),
+  })
+  .strict()

--- a/src/shared/syncAllowlist/schemas.ts
+++ b/src/shared/syncAllowlist/schemas.ts
@@ -1,0 +1,197 @@
+import { z } from 'zod'
+
+const categorySchema = z.enum([
+  'development',
+  'communication',
+  'research',
+  'writing',
+  'aiTools',
+  'design',
+  'browsing',
+  'meetings',
+  'entertainment',
+  'email',
+  'productivity',
+  'social',
+  'system',
+  'uncategorized',
+])
+
+const recapChapterIdSchema = z.enum(['headline', 'focus', 'artifacts', 'rhythm', 'change'])
+
+const workspacePresenceStateSchema = z.enum([
+  'active',
+  'idle',
+  'meeting',
+  'sleeping',
+  'offline',
+  'stale',
+])
+
+export const focusScoreV2Schema = z
+  .object({
+    deepWorkPct: z.number().nullable(),
+    longestStreakSeconds: z.number(),
+    switchCount: z.number(),
+    deepWorkSessionCount: z.number(),
+  })
+  .strict()
+
+export const recapChapterSchema = z
+  .object({
+    id: recapChapterIdSchema,
+    eyebrow: z.string(),
+    title: z.string(),
+    body: z.string(),
+  })
+  .strict()
+
+export const recapMetricSchema = z
+  .object({
+    label: z.string(),
+    value: z.string(),
+    detail: z.string(),
+  })
+  .strict()
+
+export const recapSummaryLiteSchema = z
+  .object({
+    headline: z.string(),
+    chapters: z.array(recapChapterSchema),
+    metrics: z.array(recapMetricSchema),
+    changeSummary: z.string(),
+    promptChips: z.array(z.string()),
+    hasData: z.boolean(),
+  })
+  .strict()
+
+export const syncedRecapSchema = z
+  .object({
+    day: recapSummaryLiteSchema,
+    week: recapSummaryLiteSchema.nullable(),
+    month: recapSummaryLiteSchema.nullable(),
+  })
+  .strict()
+
+export const recapCoverageSchema = z
+  .object({
+    attributedPct: z.number(),
+    untitledPct: z.number(),
+    activeDayCount: z.number(),
+    quietDayCount: z.number(),
+    hasComparison: z.boolean(),
+    coverageNote: z.string().nullable(),
+  })
+  .strict()
+
+export const workstreamRollupSchema = z
+  .object({
+    label: z.string(),
+    seconds: z.number(),
+    blockCount: z.number(),
+    isUntitled: z.boolean(),
+  })
+  .strict()
+
+export const workBlockTopAppSchema = z
+  .object({
+    appKey: z.string(),
+    seconds: z.number(),
+  })
+  .strict()
+
+export const workBlockTopPageSchema = z
+  .object({
+    domain: z.string(),
+    label: z.string().nullable(),
+    seconds: z.number(),
+  })
+  .strict()
+
+export const workBlockSummarySchema = z
+  .object({
+    id: z.string(),
+    startAt: z.string(),
+    endAt: z.string(),
+    label: z.string(),
+    labelSource: z.enum(['user', 'ai', 'rule']),
+    dominantCategory: categorySchema,
+    focusSeconds: z.number(),
+    switchCount: z.number(),
+    confidence: z.enum(['high', 'medium', 'low']),
+    topApps: z.array(workBlockTopAppSchema),
+    topPages: z.array(workBlockTopPageSchema),
+    artifactIds: z.array(z.string()),
+  })
+  .strict()
+
+export const entityRollupSchema = z
+  .object({
+    id: z.string(),
+    label: z.string(),
+    kind: z.enum(['client', 'project', 'repo', 'topic']),
+    secondsToday: z.number(),
+    blockCount: z.number(),
+  })
+  .strict()
+
+export const artifactRollupSchema = z
+  .object({
+    id: z.string(),
+    kind: z.enum(['markdown', 'csv', 'json_table', 'html_chart', 'report']),
+    title: z.string(),
+    byteSize: z.number(),
+    generatedAt: z.string(),
+    threadId: z.string().nullable(),
+  })
+  .strict()
+
+export const syncedDaySummarySchema = z
+  .object({
+    contractVersion: z.string(),
+    deviceId: z.string(),
+    localDate: z.string(),
+    generatedAt: z.string(),
+    isPartialDay: z.boolean(),
+    focusScore: z.number(),
+    focusSeconds: z.number(),
+    focusScoreV2: focusScoreV2Schema.nullable(),
+    recap: syncedRecapSchema,
+    coverage: recapCoverageSchema,
+    topWorkstreams: z.array(workstreamRollupSchema),
+    latestWorkBlockId: z.string().nullable(),
+    workBlockCount: z.number(),
+    entityCount: z.number(),
+    artifactCount: z.number(),
+    privacyFiltered: z.boolean(),
+  })
+  .strict()
+
+export const remoteSyncPayloadSchema = z
+  .object({
+    contractVersion: z.string(),
+    deviceId: z.string(),
+    localDate: z.string(),
+    generatedAt: z.string(),
+    daySummary: syncedDaySummarySchema,
+    workBlocks: z.array(workBlockSummarySchema),
+    entities: z.array(entityRollupSchema),
+    artifacts: z.array(artifactRollupSchema),
+  })
+  .strict()
+
+export const workspaceLivePresenceSchema = z
+  .object({
+    contractVersion: z.string(),
+    deviceId: z.string(),
+    localDate: z.string(),
+    state: workspacePresenceStateSchema,
+    heartbeatAt: z.number(),
+    capturedAt: z.number(),
+    lastMeaningfulCaptureAt: z.number(),
+    currentBlockLabel: z.string().nullable(),
+    currentCategory: categorySchema.nullable(),
+    currentAppKey: z.string().nullable(),
+    currentFocusSeconds: z.number().nullable(),
+  })
+  .strict()

--- a/src/shared/syncAllowlist/valueGuards.ts
+++ b/src/shared/syncAllowlist/valueGuards.ts
@@ -1,0 +1,198 @@
+import { containsCredential, findCredentialPattern } from '../credentialPatterns'
+
+export type SyncAllowlistViolationClass =
+  | 'schema'
+  | 'extra_field'
+  | 'credential'
+  | 'path'
+  | 'raw_url'
+  | 'unrestricted_filename'
+  | 'opaque_source_shape'
+  | 'excluded_class'
+
+export interface SyncAllowlistViolationDetail {
+  class: SyncAllowlistViolationClass
+  path: string
+  detail: string
+}
+
+// Absolute / home / drive paths and nested filesystem-looking segments.
+const PATH_LIKE_RE =
+  /(?:[A-Za-z]:\\|\/Users\/|\/home\/|\/var\/|\/tmp\/|~\/|\\{2}|local-file:|\/[^/\s]+\/[^/\s]+)/i
+
+const RAW_URL_RE = /\bhttps?:\/\/[^\s)\]'"<>]+/i
+
+// Keys that must never appear on a sync object (raw evidence / indexes).
+const FORBIDDEN_KEY_RE =
+  /^(imageBase64|framePath|ocrText|transcript|audioPath|windowTitle|embedding|embeddingVector|rawUrl|visitCount)$/i
+
+export function looksLikePath(value: string): boolean {
+  return PATH_LIKE_RE.test(value)
+}
+
+export function looksLikeRawUrl(value: string): boolean {
+  return RAW_URL_RE.test(value)
+}
+
+export function looksLikeUnrestrictedFilename(value: string): boolean {
+  if (/^local-file:/i.test(value)) return true
+  // Unrestricted filenames with extensions that look like local file evidence.
+  return /(?:^|[/\\])[^/\\]+\.(md|txt|pdf|docx?|png|jpe?g|gif|mov|mp4|wav|m4a)$/i.test(value)
+}
+
+export function classifyHumanField(value: string, path: string): SyncAllowlistViolationDetail | null {
+  if (!value) return null
+
+  const credential = findCredentialPattern(value)
+  if (credential) {
+    return { class: 'credential', path, detail: `credential pattern ${credential}` }
+  }
+  if (looksLikeRawUrl(value)) {
+    return { class: 'raw_url', path, detail: 'raw URL' }
+  }
+  if (looksLikePath(value)) {
+    return { class: 'path', path, detail: 'path-like value' }
+  }
+  if (looksLikeUnrestrictedFilename(value)) {
+    return { class: 'unrestricted_filename', path, detail: 'unrestricted filename' }
+  }
+  return null
+}
+
+export function classifyArtifactId(value: string, path: string): SyncAllowlistViolationDetail | null {
+  if (!value) return null
+  if (/^local-file:/i.test(value) || looksLikePath(value) || looksLikeRawUrl(value)) {
+    return { class: 'path', path, detail: 'artifact id looks like a local path or URL' }
+  }
+  // IDs are not human prose; skip broad credential entropy patterns.
+  if (containsCredential(value) && /(?:sk-|xox|gh[pousr]_|AKIA|ya29\.|eyJ)/.test(value)) {
+    return { class: 'credential', path, detail: 'credential-shaped artifact id' }
+  }
+  return null
+}
+
+export function collectForbiddenKeys(
+  value: unknown,
+  path = '',
+  out: SyncAllowlistViolationDetail[] = [],
+): SyncAllowlistViolationDetail[] {
+  if (value == null) return out
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectForbiddenKeys(item, `${path}[${index}]`, out))
+    return out
+  }
+  if (typeof value !== 'object') return out
+
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    const childPath = path ? `${path}.${key}` : key
+    if (FORBIDDEN_KEY_RE.test(key)) {
+      out.push({
+        class: 'excluded_class',
+        path: childPath,
+        detail: `forbidden key ${key}`,
+      })
+    }
+    collectForbiddenKeys(child, childPath, out)
+  }
+  return out
+}
+
+type HumanFieldWalker = (value: string, path: string) => void
+
+function walkRecapSummary(
+  recap: {
+    headline: string
+    chapters: Array<{ eyebrow: string; title: string; body: string }>
+    metrics: Array<{ label: string; value: string; detail: string }>
+    changeSummary: string
+    promptChips: string[]
+  },
+  base: string,
+  visit: HumanFieldWalker,
+) {
+  visit(recap.headline, `${base}.headline`)
+  visit(recap.changeSummary, `${base}.changeSummary`)
+  recap.promptChips.forEach((chip, index) => visit(chip, `${base}.promptChips[${index}]`))
+  recap.chapters.forEach((chapter, index) => {
+    visit(chapter.eyebrow, `${base}.chapters[${index}].eyebrow`)
+    visit(chapter.title, `${base}.chapters[${index}].title`)
+    visit(chapter.body, `${base}.chapters[${index}].body`)
+  })
+  recap.metrics.forEach((metric, index) => {
+    visit(metric.label, `${base}.metrics[${index}].label`)
+    visit(metric.value, `${base}.metrics[${index}].value`)
+    visit(metric.detail, `${base}.metrics[${index}].detail`)
+  })
+}
+
+export function collectRemoteSyncValueViolations(payload: {
+  daySummary: {
+    recap: {
+      day: Parameters<typeof walkRecapSummary>[0]
+      week: Parameters<typeof walkRecapSummary>[0] | null
+      month: Parameters<typeof walkRecapSummary>[0] | null
+    }
+    coverage: { coverageNote: string | null }
+    topWorkstreams: Array<{ label: string }>
+  }
+  workBlocks: Array<{
+    label: string
+    topPages: Array<{ domain: string; label: string | null }>
+    artifactIds: string[]
+  }>
+  entities: Array<{ label: string }>
+  artifacts: Array<{ title: string }>
+}): SyncAllowlistViolationDetail[] {
+  const violations: SyncAllowlistViolationDetail[] = []
+  const visitHuman: HumanFieldWalker = (value, path) => {
+    const hit = classifyHumanField(value, path)
+    if (hit) violations.push(hit)
+  }
+
+  walkRecapSummary(payload.daySummary.recap.day, 'daySummary.recap.day', visitHuman)
+  if (payload.daySummary.recap.week) {
+    walkRecapSummary(payload.daySummary.recap.week, 'daySummary.recap.week', visitHuman)
+  }
+  if (payload.daySummary.recap.month) {
+    walkRecapSummary(payload.daySummary.recap.month, 'daySummary.recap.month', visitHuman)
+  }
+  if (payload.daySummary.coverage.coverageNote) {
+    visitHuman(payload.daySummary.coverage.coverageNote, 'daySummary.coverage.coverageNote')
+  }
+  payload.daySummary.topWorkstreams.forEach((stream, index) => {
+    visitHuman(stream.label, `daySummary.topWorkstreams[${index}].label`)
+  })
+
+  payload.workBlocks.forEach((block, index) => {
+    visitHuman(block.label, `workBlocks[${index}].label`)
+    block.topPages.forEach((page, pageIndex) => {
+      // Domains are hostnames; still reject path/URL/credential-shaped values.
+      const domainHit = classifyHumanField(page.domain, `workBlocks[${index}].topPages[${pageIndex}].domain`)
+      if (domainHit) violations.push(domainHit)
+      if (page.label != null) {
+        visitHuman(page.label, `workBlocks[${index}].topPages[${pageIndex}].label`)
+      }
+    })
+    block.artifactIds.forEach((id, idIndex) => {
+      const hit = classifyArtifactId(id, `workBlocks[${index}].artifactIds[${idIndex}]`)
+      if (hit) violations.push(hit)
+    })
+  })
+
+  payload.entities.forEach((entity, index) => {
+    visitHuman(entity.label, `entities[${index}].label`)
+  })
+  payload.artifacts.forEach((artifact, index) => {
+    visitHuman(artifact.title, `artifacts[${index}].title`)
+  })
+
+  return violations
+}
+
+export function collectPresenceValueViolations(presence: {
+  currentBlockLabel: string | null
+}): SyncAllowlistViolationDetail[] {
+  if (presence.currentBlockLabel == null) return []
+  const hit = classifyHumanField(presence.currentBlockLabel, 'currentBlockLabel')
+  return hit ? [hit] : []
+}

--- a/tests/support/remoteSyncPayloadFixture.ts
+++ b/tests/support/remoteSyncPayloadFixture.ts
@@ -1,0 +1,233 @@
+import type { RemoteSyncPayload, WorkspaceLivePresence } from '@daylens/remote-contract'
+
+export const FIXTURE_WORKSPACE_ID = 'workspaces:test'
+export const FIXTURE_DEVICE_ID = 'desktop:test'
+export const FIXTURE_LOCAL_DATE = '2026-07-14'
+export const FIXTURE_GENERATED_AT = '2026-07-14T16:00:00.000Z'
+
+/**
+ * Intentionally dirty day-sync payload used by server sanitizer roundtrip tests.
+ * Paths, unrestricted page titles, and local-file artifact ids must fail the
+ * client sync allowlist; the Convex sanitizer strips them after receipt.
+ */
+export function makeDirtyRemoteSyncPayload(
+  overrides: Partial<RemoteSyncPayload> = {},
+): RemoteSyncPayload {
+  const payload: RemoteSyncPayload = {
+    contractVersion: '2026-04-20-r2',
+    deviceId: FIXTURE_DEVICE_ID,
+    localDate: FIXTURE_LOCAL_DATE,
+    generatedAt: FIXTURE_GENERATED_AT,
+    daySummary: {
+      contractVersion: '2026-04-20-r2',
+      deviceId: FIXTURE_DEVICE_ID,
+      localDate: FIXTURE_LOCAL_DATE,
+      generatedAt: FIXTURE_GENERATED_AT,
+      isPartialDay: false,
+      focusScore: 82,
+      focusSeconds: 3600,
+      focusScoreV2: {
+        deepWorkPct: 82,
+        longestStreakSeconds: 3600,
+        switchCount: 2,
+        deepWorkSessionCount: 1,
+      },
+      recap: {
+        day: {
+          headline: 'A deliberately untrusted desktop recap',
+          chapters: [],
+          metrics: [],
+          changeSummary: '',
+          promptChips: [],
+          hasData: true,
+        },
+        week: null,
+        month: null,
+      },
+      coverage: {
+        attributedPct: 100,
+        untitledPct: 0,
+        activeDayCount: 1,
+        quietDayCount: 0,
+        hasComparison: false,
+        coverageNote: null,
+      },
+      topWorkstreams: [],
+      latestWorkBlockId: 'block:1',
+      workBlockCount: 1,
+      entityCount: 1,
+      artifactCount: 1,
+      privacyFiltered: true,
+    },
+    workBlocks: [
+      {
+        id: 'block:1',
+        startAt: '2026-07-14T14:00:00.000Z',
+        endAt: '2026-07-14T15:00:00.000Z',
+        label: '/Users/person/private/client-plan.md',
+        labelSource: 'rule',
+        dominantCategory: 'development',
+        focusSeconds: 3600,
+        switchCount: 2,
+        confidence: 'high',
+        topApps: [
+          { appKey: 'com.microsoft.VSCode', seconds: 3300 },
+          { appKey: 'unknown-123', seconds: 300 },
+        ],
+        topPages: [{ domain: 'github.com', label: 'Secret Client · GitHub', seconds: 900 }],
+        artifactIds: ['local-file:/Users/person/private/client-plan.md'],
+      },
+    ],
+    entities: [
+      {
+        id: 'project:daylens',
+        label: 'Daylens',
+        kind: 'project',
+        secondsToday: 3600,
+        blockCount: 1,
+      },
+    ],
+    artifacts: [
+      {
+        id: 'artifact:1',
+        kind: 'report',
+        title: 'Daily report',
+        byteSize: 1024,
+        generatedAt: FIXTURE_GENERATED_AT,
+        threadId: null,
+      },
+    ],
+  }
+  return { ...payload, ...overrides }
+}
+
+/**
+ * Post-boundary clean shape: what remains after privacy sanitization.
+ * Must pass the sync allowlist unchanged.
+ */
+export function makeCleanRemoteSyncPayload(
+  overrides: Partial<RemoteSyncPayload> = {},
+): RemoteSyncPayload {
+  const payload: RemoteSyncPayload = {
+    contractVersion: '2026-04-20-r2',
+    deviceId: FIXTURE_DEVICE_ID,
+    localDate: FIXTURE_LOCAL_DATE,
+    generatedAt: FIXTURE_GENERATED_AT,
+    daySummary: {
+      contractVersion: '2026-04-20-r2',
+      deviceId: FIXTURE_DEVICE_ID,
+      localDate: FIXTURE_LOCAL_DATE,
+      generatedAt: FIXTURE_GENERATED_AT,
+      isPartialDay: false,
+      focusScore: 82,
+      focusSeconds: 3600,
+      focusScoreV2: {
+        deepWorkPct: 82,
+        longestStreakSeconds: 3600,
+        switchCount: 2,
+        deepWorkSessionCount: 1,
+      },
+      recap: {
+        day: {
+          headline: 'Tracked 1h 0m across 1 synced work blocks. Main thread: VSCode.',
+          chapters: [
+            {
+              id: 'headline',
+              eyebrow: 'Timeline',
+              title: 'What the synced day shows',
+              body: 'Tracked 1h 0m across 1 synced work blocks. Main thread: VSCode.',
+            },
+          ],
+          metrics: [
+            {
+              label: 'Focus time',
+              value: '1h 0m',
+              detail: '1 synced work blocks',
+            },
+          ],
+          changeSummary: '',
+          promptChips: ['What was I working on most today?'],
+          hasData: true,
+        },
+        week: null,
+        month: null,
+      },
+      coverage: {
+        attributedPct: 100,
+        untitledPct: 0,
+        activeDayCount: 1,
+        quietDayCount: 0,
+        hasComparison: false,
+        coverageNote: null,
+      },
+      topWorkstreams: [
+        {
+          label: 'VSCode',
+          seconds: 3600,
+          blockCount: 1,
+          isUntitled: false,
+        },
+      ],
+      latestWorkBlockId: 'block:1',
+      workBlockCount: 1,
+      entityCount: 1,
+      artifactCount: 1,
+      privacyFiltered: true,
+    },
+    workBlocks: [
+      {
+        id: 'block:1',
+        startAt: '2026-07-14T14:00:00.000Z',
+        endAt: '2026-07-14T15:00:00.000Z',
+        label: 'VSCode',
+        labelSource: 'rule',
+        dominantCategory: 'development',
+        focusSeconds: 3600,
+        switchCount: 2,
+        confidence: 'high',
+        topApps: [{ appKey: 'VSCode', seconds: 3300 }],
+        topPages: [{ domain: 'github.com', label: 'github.com', seconds: 900 }],
+        artifactIds: [],
+      },
+    ],
+    entities: [
+      {
+        id: 'project:daylens',
+        label: 'Daylens',
+        kind: 'project',
+        secondsToday: 3600,
+        blockCount: 1,
+      },
+    ],
+    artifacts: [
+      {
+        id: 'artifact:1',
+        kind: 'report',
+        title: 'Daily report',
+        byteSize: 1024,
+        generatedAt: FIXTURE_GENERATED_AT,
+        threadId: null,
+      },
+    ],
+  }
+  return { ...payload, ...overrides }
+}
+
+export function makeCleanWorkspaceLivePresence(
+  overrides: Partial<WorkspaceLivePresence> = {},
+): WorkspaceLivePresence {
+  return {
+    contractVersion: '2026-04-20-r2',
+    deviceId: FIXTURE_DEVICE_ID,
+    localDate: FIXTURE_LOCAL_DATE,
+    state: 'active',
+    heartbeatAt: Date.parse(FIXTURE_GENERATED_AT),
+    capturedAt: Date.parse(FIXTURE_GENERATED_AT),
+    lastMeaningfulCaptureAt: Date.parse(FIXTURE_GENERATED_AT),
+    currentBlockLabel: 'VSCode',
+    currentCategory: 'development',
+    currentAppKey: 'VSCode',
+    currentFocusSeconds: 1200,
+    ...overrides,
+  }
+}

--- a/tests/syncAllowlist.test.ts
+++ b/tests/syncAllowlist.test.ts
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  SYNC_ALLOWLIST_KEY_SCHEMA_PAIRS,
+  SyncAllowlistViolation,
+  assertOpaqueSourceAllowed,
+  assertSyncPayloadAllowed,
+  assertWorkspaceLivePresenceAllowed,
+} from '../src/shared/syncAllowlist/index'
+import {
+  makeCleanRemoteSyncPayload,
+  makeCleanWorkspaceLivePresence,
+  makeDirtyRemoteSyncPayload,
+} from './support/remoteSyncPayloadFixture'
+
+test('clean post-boundary remote sync payload passes the allowlist unchanged', () => {
+  const clean = makeCleanRemoteSyncPayload()
+  const allowed = assertSyncPayloadAllowed(clean)
+  assert.deepEqual(allowed, clean)
+})
+
+test('dirty remote sync fixture fails with classified path violations', () => {
+  const dirty = makeDirtyRemoteSyncPayload()
+  assert.throws(
+    () => assertSyncPayloadAllowed(dirty),
+    (error: unknown) => {
+      assert.ok(error instanceof SyncAllowlistViolation)
+      const classes = new Set(error.violations.map((item) => item.class))
+      assert.ok(classes.has('path'), `expected path violation, got ${[...classes].join(',')}`)
+      assert.ok(
+        error.violations.some((item) => item.path.includes('workBlocks[0].label')),
+        'expected label path violation',
+      )
+      assert.ok(
+        error.violations.some((item) => item.path.includes('artifactIds')),
+        'expected artifact id path violation',
+      )
+      return true
+    },
+  )
+})
+
+test('extra root field on sync payload fails strict schema', () => {
+  const dirty = {
+    ...makeCleanRemoteSyncPayload(),
+    rawForegroundEvents: [{ windowTitle: 'leak' }],
+  }
+  assert.throws(
+    () => assertSyncPayloadAllowed(dirty),
+    (error: unknown) => {
+      assert.ok(error instanceof SyncAllowlistViolation)
+      assert.ok(error.violations.some((item) => item.class === 'extra_field'))
+      return true
+    },
+  )
+})
+
+test('credential in a work block label fails the allowlist', () => {
+  const payload = makeCleanRemoteSyncPayload()
+  payload.workBlocks[0]!.label = 'Draft with sk-abcdefghijklmnopqrstuvwxyz012345'
+  assert.throws(
+    () => assertSyncPayloadAllowed(payload),
+    (error: unknown) => {
+      assert.ok(error instanceof SyncAllowlistViolation)
+      assert.ok(error.violations.some((item) => item.class === 'credential'))
+      assert.ok(error.violations.some((item) => item.path.includes('label')))
+      return true
+    },
+  )
+})
+
+test('opaque source reference rejects title and url extras', () => {
+  const valid = assertOpaqueSourceAllowed({
+    evidenceId: 'ev_123',
+    evidenceKind: 'application_interval',
+    originatingDevice: 'desktop:test',
+  })
+  assert.equal(valid.evidenceId, 'ev_123')
+
+  assert.throws(
+    () =>
+      assertOpaqueSourceAllowed({
+        evidenceId: 'ev_123',
+        evidenceKind: 'application_interval',
+        originatingDevice: 'desktop:test',
+        title: 'Secret Client Plan',
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof SyncAllowlistViolation)
+      assert.ok(error.violations.some((item) => item.class === 'opaque_source_shape'))
+      return true
+    },
+  )
+
+  assert.throws(
+    () =>
+      assertOpaqueSourceAllowed({
+        evidenceId: 'ev_123',
+        evidenceKind: 'application_interval',
+        originatingDevice: 'desktop:test',
+        url: 'https://example.com/private',
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof SyncAllowlistViolation)
+      assert.ok(error.violations.some((item) => item.class === 'opaque_source_shape'))
+      return true
+    },
+  )
+})
+
+test('key maps match zod .strict() shapes for every synced type', () => {
+  for (const pair of SYNC_ALLOWLIST_KEY_SCHEMA_PAIRS) {
+    const fromKeys = Object.keys(pair.keys).sort()
+    const fromShape = Object.keys(pair.shape).sort()
+    assert.deepEqual(
+      fromKeys,
+      fromShape,
+      `${pair.name}: key map and zod shape drifted`,
+    )
+  }
+})
+
+test('WorkspaceLivePresence is allowlisted and rejects credential labels', () => {
+  const clean = makeCleanWorkspaceLivePresence()
+  assert.deepEqual(assertWorkspaceLivePresenceAllowed(clean), clean)
+
+  assert.throws(
+    () =>
+      assertWorkspaceLivePresenceAllowed({
+        ...clean,
+        currentBlockLabel: 'token=supersecretvalue123',
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof SyncAllowlistViolation)
+      assert.ok(error.violations.some((item) => item.class === 'credential'))
+      return true
+    },
+  )
+
+  assert.throws(
+    () =>
+      assertWorkspaceLivePresenceAllowed({
+        ...clean,
+        ocrText: 'screen derived',
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof SyncAllowlistViolation)
+      assert.ok(error.violations.some((item) => item.class === 'extra_field'))
+      return true
+    },
+  )
+})
+
+test('excluded raw evidence classes cannot serialize into an allowed payload', () => {
+  const cases: Array<{ name: string; mutate: (payload: ReturnType<typeof makeCleanRemoteSyncPayload>) => unknown }> = [
+    {
+      name: 'raw URL in label',
+      mutate: (payload) => {
+        payload.workBlocks[0]!.label = 'https://intranet.example/secret?token=abc'
+        return payload
+      },
+    },
+    {
+      name: 'path in entity label',
+      mutate: (payload) => {
+        payload.entities[0]!.label = '/home/person/notes.md'
+        return payload
+      },
+    },
+    {
+      name: 'forbidden screen key nested via override object',
+      mutate: (payload) => ({
+        ...payload,
+        workBlocks: [
+          {
+            ...payload.workBlocks[0]!,
+            ocrText: 'captured screen text',
+          },
+        ],
+      }),
+    },
+  ]
+
+  for (const item of cases) {
+    assert.throws(
+      () => assertSyncPayloadAllowed(item.mutate(makeCleanRemoteSyncPayload())),
+      (error: unknown) => {
+        assert.ok(error instanceof SyncAllowlistViolation, item.name)
+        return true
+      },
+      item.name,
+    )
+  }
+})

--- a/tests/webRemoteRoundtrip.test.ts
+++ b/tests/webRemoteRoundtrip.test.ts
@@ -8,107 +8,18 @@ import * as devices from '../apps/web/convex/devices.ts'
 import * as remoteSync from '../apps/web/convex/remoteSync.ts'
 import { buildAppDetail } from '../apps/web/app/lib/presentation.ts'
 import { InMemoryConvexDatabase } from './support/inMemoryConvex.ts'
+import {
+  FIXTURE_DEVICE_ID as deviceId,
+  FIXTURE_WORKSPACE_ID as workspaceId,
+  makeDirtyRemoteSyncPayload as makePayload,
+} from './support/remoteSyncPayloadFixture'
 
 type RegisteredHandler = {
   _handler: (ctx: unknown, args: unknown) => Promise<unknown>
 }
 
-const workspaceId = 'workspaces:test'
-const deviceId = 'desktop:test'
-
 function handler(value: unknown): RegisteredHandler['_handler'] {
   return (value as RegisteredHandler)._handler
-}
-
-function makePayload(overrides: Partial<RemoteSyncPayload> = {}): RemoteSyncPayload {
-  const localDate = '2026-07-14'
-  const generatedAt = '2026-07-14T16:00:00.000Z'
-  const payload: RemoteSyncPayload = {
-    contractVersion: '2026-04-20-r2',
-    deviceId,
-    localDate,
-    generatedAt,
-    daySummary: {
-      contractVersion: '2026-04-20-r2',
-      deviceId,
-      localDate,
-      generatedAt,
-      isPartialDay: false,
-      focusScore: 82,
-      focusSeconds: 3600,
-      focusScoreV2: {
-        deepWorkPct: 82,
-        longestStreakSeconds: 3600,
-        switchCount: 2,
-        deepWorkSessionCount: 1,
-      },
-      recap: {
-        day: {
-          headline: 'A deliberately untrusted desktop recap',
-          chapters: [],
-          metrics: [],
-          changeSummary: '',
-          promptChips: [],
-          hasData: true,
-        },
-        week: null,
-        month: null,
-      },
-      coverage: {
-        attributedPct: 100,
-        untitledPct: 0,
-        activeDayCount: 1,
-        quietDayCount: 0,
-        hasComparison: false,
-        coverageNote: null,
-      },
-      topWorkstreams: [],
-      latestWorkBlockId: 'block:1',
-      workBlockCount: 1,
-      entityCount: 1,
-      artifactCount: 1,
-      privacyFiltered: true,
-    },
-    workBlocks: [
-      {
-        id: 'block:1',
-        startAt: '2026-07-14T14:00:00.000Z',
-        endAt: '2026-07-14T15:00:00.000Z',
-        label: '/Users/person/private/client-plan.md',
-        labelSource: 'rule',
-        dominantCategory: 'development',
-        focusSeconds: 3600,
-        switchCount: 2,
-        confidence: 'high',
-        topApps: [
-          { appKey: 'com.microsoft.VSCode', seconds: 3300 },
-          { appKey: 'unknown-123', seconds: 300 },
-        ],
-        topPages: [{ domain: 'github.com', label: 'Secret Client · GitHub', seconds: 900 }],
-        artifactIds: ['local-file:/Users/person/private/client-plan.md'],
-      },
-    ],
-    entities: [
-      {
-        id: 'project:daylens',
-        label: 'Daylens',
-        kind: 'project',
-        secondsToday: 3600,
-        blockCount: 1,
-      },
-    ],
-    artifacts: [
-      {
-        id: 'artifact:1',
-        kind: 'report',
-        title: 'Daily report',
-        byteSize: 1024,
-        generatedAt,
-        threadId: null,
-      },
-    ],
-  }
-  return { ...payload, ...overrides }
 }
 
 async function setupRemote() {


### PR DESCRIPTION
## Summary
- Adds a typed sync allowlist (`src/shared/syncAllowlist`) with zod `.strict()` mirrors and `ExactKeys` maps for `RemoteSyncPayload`, nested day-sync types, `WorkspaceLivePresence`, and the spec’s opaque source reference shape.
- Value-class guards reject credentials (shared `credentialPatterns` corpus), paths, raw URLs, unrestricted filenames, and forbidden raw-evidence keys before a payload can be considered sync-safe.
- Contract tests prove clean post-boundary fixtures pass unchanged, dirty roundtrip fixtures fail with classified violations, and key-map ↔ schema parity catches unlisted fields.

Closes DEV-187

## Test plan
- [x] `node scripts/run-tests.mjs syncAllowlist aiSanitize webRemoteRoundtrip` (16 pass)
- [x] `npm test` (1433 pass; capture-helper binary linked in worktree for that one env-dependent file)
- [x] `npm run contract:check` (remote-contract untouched / hash ok)
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)