### PR TITLE
Phase 1: an analyzed day stays analyzed; merges never add time (DEV-277/279/282/283)

### DIFF
--- a/src/main/jobs/aiService.ts
+++ b/src/main/jobs/aiService.ts
@@ -2050,7 +2050,7 @@ export async function generateDaySummary(dateStr: string): Promise<AIDaySummaryR
     // reason through instead of burying it in the log (DEV-279).
     console.warn(`[ai] day_summary failed for ${dateStr}:`, error)
     const message = error instanceof Error ? error.message.trim() : ''
-    const reason = message ? (/[.!?]$/.test(message) ? message : `${message}.`) : undefined
+    const reason = message ? (/[.!?…]$/.test(message) ? message : `${message}.`) : undefined
     return { ...fallback, degraded: true, degradedReason: reason }
   }
 }

--- a/src/main/jobs/aiService.ts
+++ b/src/main/jobs/aiService.ts
@@ -2043,10 +2043,15 @@ export async function generateDaySummary(dateStr: string): Promise<AIDaySummaryR
     }
     // The model answered but its output was unusable. Surface the factual
     // fallback marked degraded, and do NOT cache it, so a later open retries AI.
-    return { ...fallback, degraded: true }
+    return { ...fallback, degraded: true, degradedReason: 'The model replied in a shape Daylens could not read.' }
   } catch (error) {
+    // The orchestration layer already shapes provider failures into messages a
+    // person can act on ("AI access is paused…", "…timed out"); pass that
+    // reason through instead of burying it in the log (DEV-279).
     console.warn(`[ai] day_summary failed for ${dateStr}:`, error)
-    return { ...fallback, degraded: true }
+    const message = error instanceof Error ? error.message.trim() : ''
+    const reason = message ? (/[.!?]$/.test(message) ? message : `${message}.`) : undefined
+    return { ...fallback, degraded: true, degradedReason: reason }
   }
 }
 

--- a/src/main/lib/daySummarySuggestions.ts
+++ b/src/main/lib/daySummarySuggestions.ts
@@ -128,7 +128,23 @@ export function parseDaySummaryResultText(
       ),
     }
   } catch {
-    if (/^\s*[{[]/.test(normalized) || /"summary"\s*:/.test(normalized)) return null
+    if (/^\s*[{[]/.test(normalized) || /"summary"\s*:/.test(normalized)) {
+      // Truncated or malformed JSON. A complete "summary" string field is
+      // still a usable recap — salvage it rather than degrading to facts.
+      const summaryField = normalized.match(/"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/)
+      if (summaryField) {
+        try {
+          const summary = (JSON.parse(`"${summaryField[1]}"`) as string).trim()
+          if (summary) {
+            return {
+              summary,
+              questionSuggestions: fillDaySummaryQuestionSuggestions([], fallbackQuestions),
+            }
+          }
+        } catch { /* fall through to null */ }
+      }
+      return null
+    }
     return {
       summary: normalized,
       questionSuggestions: fillDaySummaryQuestionSuggestions([], fallbackQuestions),

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -4582,18 +4582,25 @@ export function snapshotCarryForwardAiLabels(
   dateStr: string,
 ): Map<string, CarriedAiLabel> {
   const out = new Map<string, CarriedAiLabel>()
+  // Only blocks whose CURRENT label is the AI's (a user rename must never be
+  // shadowed by a stale ai row), and only the freshest ai row per block — a
+  // block re-labeled twice keeps both rows in timeline_block_labels (the
+  // insert key hashes the label text), and treating the superseded row as a
+  // second claimant would falsely trip the ambiguity guard below.
   const rows = db.prepare(`
     SELECT l.block_id AS blockId, l.label AS label, l.narrative AS narrative, l.confidence AS confidence,
            tb.start_time AS startMs, tb.end_time AS endMs
     FROM timeline_block_labels l
     JOIN timeline_blocks tb ON tb.id = l.block_id
-    WHERE tb.date = ? AND tb.invalidated_at IS NULL AND tb.is_live = 0 AND l.source = 'ai'
+    WHERE tb.date = ? AND tb.invalidated_at IS NULL AND tb.is_live = 0
+      AND l.source = 'ai' AND tb.label_source = 'ai'
     ORDER BY l.created_at DESC
   `).all(dateStr) as Array<{
     blockId: string; label: string; narrative: string | null; confidence: number
     startMs: number; endMs: number
   }>
   if (rows.length === 0) return out
+  const seenBlocks = new Set<string>()
 
   const memberStmt = db.prepare(`
     SELECT member_id AS memberId
@@ -4614,6 +4621,9 @@ export function snapshotCarryForwardAiLabels(
     }
   }
   for (const row of rows) {
+    // created_at DESC — the first row seen for a block is its freshest label.
+    if (seenBlocks.has(row.blockId)) continue
+    seenBlocks.add(row.blockId)
     const label = row.label?.trim()
     if (!label) continue
     const entry: CarriedAiLabel = {
@@ -4627,7 +4637,6 @@ export function snapshotCarryForwardAiLabels(
       .map((m) => Number(m.memberId))
       .filter((id) => Number.isFinite(id) && id >= 0)
       .sort((a, b) => a - b)
-    // created_at DESC — the first row seen for a key is the freshest; keep it.
     if (ids.length > 0) put(`sessions:${ids.join(',')}`, entry)
     if (row.endMs > row.startMs) put(`span:${row.startMs}:${row.endMs}`, entry)
   }

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -4557,29 +4557,42 @@ export function invalidateTimelineDayBlocks(db: Database.Database, dateStr: stri
   deleteWrappedNarrativesForDate(db, dateStr, 'evidence-change')
 }
 
-type CarriedAiLabel = { label: string; narrative: string | null; confidence: number }
+type CarriedAiLabel = {
+  label: string
+  narrative: string | null
+  confidence: number
+  startMs: number
+  endMs: number
+}
 
 // Re-attach AI block names across a re-segmentation. A block's id is derived from
 // its exact session set + boundaries (`blockIdFor`), so a day that grows or
 // re-segments on the next open mints brand-new ids and strands the AI labels
 // keyed to the old ones — the rebuilt block silently drops back to a raw artifact
-// title ("Jamie Duffy", "Labrinth"). That is the "timeline didn't save after a
-// restart" bug. Snapshot the day's current AI labels by the same stable,
-// session-set evidence key the review layer uses (`reviewEvidenceKeyForBlock`)
-// so a freshly rebuilt block whose evidence is unchanged inherits the name it
-// already earned, and re-persists it under its new id (stopping the orphan churn).
+// title ("Jamie Duffy", "Labrinth") or, once every labeled block is superseded,
+// the whole analyzed day reads as un-analyzed again (DEV-277). Snapshot the
+// day's current AI labels under two keys: the session-set evidence key the
+// review layer uses (`reviewEvidenceKeyForBlock`), and the block's exact
+// wall-clock span. The span key matters because a past day's rebuild feeds
+// *derived* sessions whose ids live in a different namespace than the ids the
+// day was analyzed with — the session-set key can never match across that
+// boundary, but the same stretch of work re-derives the same span.
 export function snapshotCarryForwardAiLabels(
   db: Database.Database,
   dateStr: string,
 ): Map<string, CarriedAiLabel> {
   const out = new Map<string, CarriedAiLabel>()
   const rows = db.prepare(`
-    SELECT l.block_id AS blockId, l.label AS label, l.narrative AS narrative, l.confidence AS confidence
+    SELECT l.block_id AS blockId, l.label AS label, l.narrative AS narrative, l.confidence AS confidence,
+           tb.start_time AS startMs, tb.end_time AS endMs
     FROM timeline_block_labels l
     JOIN timeline_blocks tb ON tb.id = l.block_id
     WHERE tb.date = ? AND tb.invalidated_at IS NULL AND tb.is_live = 0 AND l.source = 'ai'
     ORDER BY l.created_at DESC
-  `).all(dateStr) as Array<{ blockId: string; label: string; narrative: string | null; confidence: number }>
+  `).all(dateStr) as Array<{
+    blockId: string; label: string; narrative: string | null; confidence: number
+    startMs: number; endMs: number
+  }>
   if (rows.length === 0) return out
 
   const memberStmt = db.prepare(`
@@ -4587,26 +4600,47 @@ export function snapshotCarryForwardAiLabels(
     FROM timeline_block_members
     WHERE block_id = ? AND member_type = 'app_session'
   `)
+  const ambiguous = new Set<string>()
+  const put = (key: string, entry: CarriedAiLabel): void => {
+    if (ambiguous.has(key)) return
+    const existing = out.get(key)
+    if (!existing) {
+      out.set(key, entry)
+    } else if (existing.label !== entry.label) {
+      // Two differently-named blocks claim the same key (only possible with
+      // corrupt data): re-attaching either would be a guess, so neither wins.
+      out.delete(key)
+      ambiguous.add(key)
+    }
+  }
   for (const row of rows) {
     const label = row.label?.trim()
     if (!label) continue
+    const entry: CarriedAiLabel = {
+      label,
+      narrative: row.narrative ?? null,
+      confidence: row.confidence,
+      startMs: row.startMs,
+      endMs: row.endMs,
+    }
     const ids = (memberStmt.all(row.blockId) as Array<{ memberId: string }>)
       .map((m) => Number(m.memberId))
       .filter((id) => Number.isFinite(id) && id >= 0)
       .sort((a, b) => a - b)
-    if (ids.length === 0) continue
-    const key = `sessions:${ids.join(',')}`
     // created_at DESC — the first row seen for a key is the freshest; keep it.
-    if (!out.has(key)) out.set(key, { label, narrative: row.narrative ?? null, confidence: row.confidence })
+    if (ids.length > 0) put(`sessions:${ids.join(',')}`, entry)
+    if (row.endMs > row.startMs) put(`span:${row.startMs}:${row.endMs}`, entry)
   }
   return out
 }
 
 // A freshly rebuilt block with no AI label and no user override inherits a
-// carried-forward AI name when its evidence (the exact session set) is identical
-// to a block that already had one. Strict equality means we only re-attach to the
-// same stretch of work — a merge/split that changes the evidence gets re-named by
-// AI on the next pass instead, never mislabeled.
+// carried-forward AI name when it is the same stretch of work: an identical
+// session set, an identical wall-clock span, or — when session ids changed
+// namespace and boundaries drifted — an unambiguous mutual-midpoint match
+// (each span contains the other's midpoint, so they overlap by more than half
+// of both). A merge/split that genuinely changes the evidence matches nothing
+// and gets re-named by AI on the next pass instead — never mislabeled.
 function inheritCarriedAiLabel(
   db: Database.Database,
   block: WorkContextBlock,
@@ -4615,6 +4649,8 @@ function inheritCarriedAiLabel(
   if (!carried || carried.size === 0) return block
   if (block.aiLabel?.trim() || block.label.override?.trim()) return block
   const match = carried.get(reviewEvidenceKeyForBlock(block))
+    ?? carried.get(`span:${block.startTime}:${block.endTime}`)
+    ?? mutualMidpointMatch(block, carried)
   if (!match) return block
   if (getBlockLabelOverride(db, block.id)?.label?.trim()) return block
   const nextLabel = block.label.narrative?.trim()
@@ -4623,16 +4659,29 @@ function inheritCarriedAiLabel(
   return { ...block, aiLabel: match.label, label: nextLabel }
 }
 
+function mutualMidpointMatch(
+  block: WorkContextBlock,
+  carried: Map<string, CarriedAiLabel>,
+): CarriedAiLabel | null {
+  const blockMid = block.startTime + (block.endTime - block.startTime) / 2
+  const candidates = new Set<CarriedAiLabel>()
+  for (const entry of carried.values()) {
+    const entryMid = entry.startMs + (entry.endMs - entry.startMs) / 2
+    if (entryMid >= block.startTime && entryMid < block.endTime
+      && blockMid >= entry.startMs && blockMid < entry.endMs) {
+      candidates.add(entry)
+    }
+  }
+  if (candidates.size !== 1) return null
+  return candidates.values().next().value ?? null
+}
+
 function persistTimelineDay(
   db: Database.Database,
   dateStr: string,
   blocks: WorkContextBlock[],
-  options: { finalized?: boolean } = {},
 ): void {
   const validIds = blocks.filter((block) => !block.isLive).map((block) => block.id)
-  // Carry forward AI names from the day's current blocks before the invalidation
-  // below strands them. Skipped when finalized — those labels are already final.
-  const carriedAiLabels = options.finalized ? null : snapshotCarryForwardAiLabels(db, dateStr)
   const persist = db.transaction(() => {
     if (validIds.length > 0) {
       const placeholders = validIds.map(() => '?').join(', ')
@@ -4671,11 +4720,8 @@ function persistTimelineDay(
       `).run(dayFromMs, dayToMs)
     }
 
-    for (const rawBlock of blocks) {
-      if (rawBlock.isLive) continue
-      const block = options.finalized
-        ? rawBlock
-        : finalizedLabelForBlock(db, inheritCarriedAiLabel(db, rawBlock, carriedAiLabels), dateStr)
+    for (const block of blocks) {
+      if (block.isLive) continue
       db.prepare(`
         INSERT INTO timeline_blocks (
           id,
@@ -4922,7 +4968,7 @@ function persistTimelineDayIfChanged(
     return
   }
 
-  persistTimelineDay(db, dateStr, blocks, { finalized: true })
+  persistTimelineDay(db, dateStr, blocks)
   timelineMaterializationFingerprints.set(cacheKey, fingerprint)
 }
 
@@ -5379,15 +5425,29 @@ export function buildTimelineBlocksForDay(
     if (persisted && persisted.length > 0
       && (persistedDayWasProcessed(db, dateStr) || persistedDayHasCorrections(db, dateStr))) {
       if (persistedDayUnderCovers(persisted, sessions)) {
-        // DEV-267: a day sealed with most of its blocks missing. Drop the
-        // partial seal so the day rebuilds from its sessions — the same repair
-        // the user's own block-invalidation performs by hand. Never fails
-        // silently: the seal/rebuild is logged.
+        // DEV-267: a day sealed with most of its blocks missing (an analyze
+        // that ran mid-day, or a finalize that died between steps). Rebuild
+        // the day from its sessions — but the analysis is work the person
+        // already has: the rebuilt blocks re-inherit the day's AI names for
+        // every unchanged stretch, and only the newly uncovered time comes
+        // back unnamed (DEV-277: an analyzed day must never revert to coarse
+        // sittings). Never fails silently: the seal/rebuild is logged.
         console.warn(
           `[timeline] ${dateStr} was sealed under-covered — its ${persisted.length} `
           + `stored block${persisted.length === 1 ? '' : 's'} leave over `
-          + `${Math.round(PARTIAL_SEAL_MAX_UNCOVERED_MS / 60_000)}m of the day's tracked time uncovered; rebuilding from sessions`,
+          + `${Math.round(PARTIAL_SEAL_MAX_UNCOVERED_MS / 60_000)}m of the day's tracked time uncovered; `
+          + 'rebuilding from sessions and carrying the AI labels forward',
         )
+        const repaired = rebuildDayBlocksWithCarriedLabels(db, dateStr, sessions)
+        const analysisSurvived = repaired.some((block) => !block.isLive
+          && (block.label.source === 'ai' || block.label.source === 'workflow' || block.label.source === 'user'))
+        if (analysisSurvived || persistedDayHasCorrections(db, dateStr)) {
+          persistTimelineDayIfChanged(db, dateStr, sessions, repaired, true)
+          flagSuspiciousUnbrokenBlocks(dateStr, repaired)
+          return repaired
+        }
+        // No label or correction survived the rebuild — the day is effectively
+        // un-analyzed again and falls through to the coarse read (DEV-268).
         invalidateTimelineDay(db, dateStr)
         forceMaterialize = true
       } else {
@@ -5413,12 +5473,28 @@ export function buildTimelineBlocksForDay(
     forceMaterialize = true
   }
 
-  const computed = buildBlocksForSessions(db, sessions, dateStr).map((block) => finalizedLabelForBlock(db, block, dateStr))
+  const computed = rebuildDayBlocksWithCarriedLabels(db, dateStr, sessions)
   flagSuspiciousUnbrokenBlocks(dateStr, computed)
   if (shouldMaterialize) {
     persistTimelineDayIfChanged(db, dateStr, sessions, computed, forceMaterialize)
   }
   return computed
+}
+
+// Every full rebuild goes through here so the day's existing AI labels are
+// snapshotted BEFORE the rebuild supersedes their blocks, and re-attached to
+// the rebuilt blocks that are the same stretch of work. Without this, any
+// rebuild that re-keys block ids (re-segmentation, a heuristic bump, the
+// derived-session id namespace on a past day) strands the labels and the
+// analyzed day silently reverts (DEV-277).
+function rebuildDayBlocksWithCarriedLabels(
+  db: Database.Database,
+  dateStr: string,
+  sessions: AppSession[],
+): WorkContextBlock[] {
+  const carried = snapshotCarryForwardAiLabels(db, dateStr)
+  return buildBlocksForSessions(db, sessions, dateStr)
+    .map((block) => finalizedLabelForBlock(db, inheritCarriedAiLabel(db, block, carried), dateStr))
 }
 
 // A gap becomes visible blank space on the grid at the same threshold that

--- a/src/renderer/components/CorrectionFlow.tsx
+++ b/src/renderer/components/CorrectionFlow.tsx
@@ -6,7 +6,7 @@
 // leaves an Undo toast up until the next correction replaces it. Permanent
 // purges never come through here — they keep their native confirm and no undo.
 import { useCallback, useEffect, useState, type CSSProperties, type ReactNode } from 'react'
-import type { CorrectionCommand, CorrectionPreview } from '@shared/types'
+import type { CorrectionBlockDelta, CorrectionCommand, CorrectionPreview } from '@shared/types'
 import { activityCategoryLabel } from '@shared/activityCategories'
 import { ipc } from '../lib/ipc'
 import { sanitizeIpcError } from '../lib/ipcError'
@@ -147,6 +147,51 @@ export function useCorrectionFlow(onApplied: () => void | Promise<void>): Correc
 const timeOf = (ms: number): string =>
   new Date(ms).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
 
+// A block label can be arbitrarily long (a pasted ticket description); the
+// preview shows at most two lines of it.
+const clampedLabel: CSSProperties = {
+  minWidth: 0,
+  overflow: 'hidden',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+}
+
+// A merge maps several source blocks onto one surviving block; showing the
+// survivor once per source repeats it and reads as noise. Group deltas that
+// resolve to the same successor so the preview reads "A + B → merged".
+interface DeltaGroup {
+  sources: CorrectionBlockDelta[]
+  after: CorrectionBlockDelta | null
+  categoryChanged: boolean
+}
+
+function groupDeltasBySuccessor(deltas: readonly CorrectionBlockDelta[]): DeltaGroup[] {
+  const groups: DeltaGroup[] = []
+  const byKey = new Map<string, DeltaGroup>()
+  for (const delta of deltas) {
+    if (delta.labelAfter === null) {
+      groups.push({ sources: [delta], after: null, categoryChanged: false })
+      continue
+    }
+    const key = `${delta.labelAfter}:${delta.startMsAfter}:${delta.endMsAfter}`
+    const existing = byKey.get(key)
+    if (existing) {
+      existing.sources.push(delta)
+      existing.categoryChanged ||= delta.categoryAfter !== delta.categoryBefore
+    } else {
+      const group: DeltaGroup = {
+        sources: [delta],
+        after: delta,
+        categoryChanged: delta.categoryAfter !== null && delta.categoryAfter !== delta.categoryBefore,
+      }
+      byKey.set(key, group)
+      groups.push(group)
+    }
+  }
+  return groups
+}
+
 function CorrectionPreviewDialog({
   preview,
   applying,
@@ -216,28 +261,31 @@ function CorrectionPreviewDialog({
         {preview.blocks.length > 0 && (
           <div style={{ marginTop: 16 }}>
             <div style={sectionTitle}>Timeline</div>
-            <div style={{ display: 'grid', gap: 10 }}>
-              {preview.blocks.map((delta) => (
-                <div key={delta.blockId} style={{ fontSize: 12.5, lineHeight: 1.55 }}>
-                  <div style={{ color: 'var(--color-text-tertiary)', textDecoration: delta.labelAfter === null ? 'line-through' : 'none' }}>
-                    {delta.labelBefore}
-                    <span style={{ marginLeft: 8, fontVariantNumeric: 'tabular-nums' }}>
-                      {timeOf(delta.startMsBefore)} – {timeOf(delta.endMsBefore)}
-                    </span>
-                  </div>
-                  {delta.labelAfter === null ? (
+            <div style={{ display: 'grid', gap: 12 }}>
+              {groupDeltasBySuccessor(preview.blocks).map((group) => (
+                <div key={group.sources[0].blockId} style={{ fontSize: 12.5, lineHeight: 1.55 }}>
+                  {group.sources.map((delta) => (
+                    <div key={delta.blockId} style={{ display: 'flex', alignItems: 'baseline', gap: 8, color: 'var(--color-text-tertiary)', textDecoration: group.after === null ? 'line-through' : 'none' }}>
+                      <span style={clampedLabel}>{delta.labelBefore}</span>
+                      <span style={{ fontVariantNumeric: 'tabular-nums', flexShrink: 0 }}>
+                        {timeOf(delta.startMsBefore)} – {timeOf(delta.endMsBefore)}
+                      </span>
+                    </div>
+                  ))}
+                  {group.after === null ? (
                     <div style={{ color: 'var(--color-text-secondary)', fontWeight: 600 }}>Removed from the day</div>
                   ) : (
-                    <div style={{ color: 'var(--color-text-primary)', fontWeight: 600 }}>
-                      {delta.labelAfter}
-                      {delta.startMsAfter != null && delta.endMsAfter != null && (
-                        <span style={{ marginLeft: 8, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--color-text-secondary)' }}>
-                          {timeOf(delta.startMsAfter)} – {timeOf(delta.endMsAfter)}
+                    <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, color: 'var(--color-text-primary)', fontWeight: 600 }}>
+                      <span aria-hidden style={{ flexShrink: 0, color: 'var(--color-text-secondary)', fontWeight: 500 }}>→</span>
+                      <span style={clampedLabel}>{group.after.labelAfter}</span>
+                      {group.after.startMsAfter != null && group.after.endMsAfter != null && (
+                        <span style={{ fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--color-text-secondary)', flexShrink: 0 }}>
+                          {timeOf(group.after.startMsAfter)} – {timeOf(group.after.endMsAfter)}
                         </span>
                       )}
-                      {delta.categoryAfter && delta.categoryAfter !== delta.categoryBefore && (
-                        <span style={{ marginLeft: 8, fontWeight: 500, color: 'var(--color-text-secondary)' }}>
-                          {activityCategoryLabel(delta.categoryBefore)} → {activityCategoryLabel(delta.categoryAfter)}
+                      {group.categoryChanged && group.after.categoryAfter && (
+                        <span style={{ fontWeight: 500, color: 'var(--color-text-secondary)', flexShrink: 0 }}>
+                          · {activityCategoryLabel(group.after.categoryAfter)}
                         </span>
                       )}
                     </div>

--- a/src/renderer/views/Timeline.tsx
+++ b/src/renderer/views/Timeline.tsx
@@ -1842,8 +1842,10 @@ function DaySummaryInspector({ payload, analysis }: { payload: DayTimelinePayloa
               {/* Nothing fails silently: when the AI recap couldn't run, the
                   factual fallback says so plainly rather than posing as prose. */}
               {recap.degraded && (
-                <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)' }}>
-                  AI recap unavailable — showing the day's facts. Try again in a moment.
+                <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', lineHeight: 1.5 }}>
+                  {recap.degradedReason
+                    ? `The full recap couldn't be generated — ${recap.degradedReason} Showing the day's facts; Generate recap retries.`
+                    : "The full recap couldn't be generated. Showing the day's facts; Generate recap retries."}
                 </div>
               )}
               <div style={{ fontSize: 14, lineHeight: 1.7, color: 'var(--color-text-primary)' }}>
@@ -3683,7 +3685,10 @@ export default function Timeline() {
                         block shows its detail; no selection shows the day
                         summary. Nothing floats over the timeline. */}
                     {selectedBlock ? (
-                      <>
+                      // One grid item: a fragment here would hand the grid two
+                      // right-column children and wrap the detail panel to a
+                      // full-width second row (DEV-283).
+                      <div style={{ position: 'sticky', top: 24, alignSelf: 'start' }}>
                         {/* Analyze feedback follows you into a block's detail view
                             so the run never looks like it silently stopped (DEV-270). */}
                         {(dayAnalysis.analyzing || dayAnalysis.status) && (
@@ -3697,13 +3702,14 @@ export default function Timeline() {
                         <BlockDetailInspector
                           block={selectedBlock}
                           payload={payload}
+                          sticky={false}
                           onCorrection={correction.request}
                           onClose={() => {
                             setSelectedBlockId(null)
                             setMergeRangeEndId(null)
                           }}
                         />
-                      </>
+                      </div>
                     ) : (
                       <DaySummaryInspector payload={payload} analysis={dayAnalysis} />
                     )}

--- a/src/renderer/views/Timeline.tsx
+++ b/src/renderer/views/Timeline.tsx
@@ -3688,7 +3688,7 @@ export default function Timeline() {
                       // One grid item: a fragment here would hand the grid two
                       // right-column children and wrap the detail panel to a
                       // full-width second row (DEV-283).
-                      <div style={{ position: 'sticky', top: 24, alignSelf: 'start' }}>
+                      <div data-timeline-inspector="true" style={{ position: 'sticky', top: 24, alignSelf: 'start' }}>
                         {/* Analyze feedback follows you into a block's detail view
                             so the run never looks like it silently stopped (DEV-270). */}
                         {(dayAnalysis.analyzing || dayAnalysis.status) && (

--- a/src/shared/blockDuration.ts
+++ b/src/shared/blockDuration.ts
@@ -4,21 +4,34 @@
 // user was actually working: the block builder permits up to 15 minutes of gap
 // between adjacent sessions before splitting (see workBlocks.ts), so a 30 minute
 // block can span 2+ hours of wall clock. Use the sum of session durations as the
-// truth for displayed durations, clamped to the wall-clock span so it never
-// reads larger than the block's visible range.
+// truth for displayed durations.
+//
+// The measure must be additive over sessions: the day total is the sum over
+// blocks, and re-partitioning the same sessions (a merge or split) must not
+// change it. Clamping the summed durations to the block's span breaks that —
+// a merged block spans the gap between its parts, so time clamped away before
+// the merge reappears after it. Inflated per-session durations are clamped to
+// each session's own span instead, which merges and splits cannot alter.
 
 import type { WorkContextBlock, AppSession } from './types'
+
+function sessionActiveSeconds(session: AppSession): number {
+  const duration = Math.max(0, session.durationSeconds || 0)
+  if (session.endTime == null) return duration
+  const span = Math.max(0, Math.round((session.endTime - session.startTime) / 1000))
+  return Math.min(duration, span)
+}
 
 export function blockActiveSeconds(block: Pick<WorkContextBlock, 'startTime' | 'endTime' | 'sessions'>): number {
   const span = Math.max(0, Math.round((block.endTime - block.startTime) / 1000))
   const sessions = block.sessions ?? []
   if (sessions.length === 0) return Math.max(1, span)
   const summed = sessions.reduce(
-    (sum, session: AppSession) => sum + Math.max(0, session.durationSeconds || 0),
+    (sum, session: AppSession) => sum + sessionActiveSeconds(session),
     0,
   )
   if (summed <= 0) return Math.max(1, span)
-  return Math.max(1, span > 0 ? Math.min(summed, span) : summed)
+  return Math.max(1, summed)
 }
 
 // Duration that matches the clock range shown next to it. Clock displays

--- a/src/shared/blockDuration.ts
+++ b/src/shared/blockDuration.ts
@@ -25,12 +25,17 @@ function sessionActiveSeconds(session: AppSession): number {
 export function blockActiveSeconds(block: Pick<WorkContextBlock, 'startTime' | 'endTime' | 'sessions'>): number {
   const span = Math.max(0, Math.round((block.endTime - block.startTime) / 1000))
   const sessions = block.sessions ?? []
+  // No hydrated sessions at all (a provisional or calendar-shaped block):
+  // the span is the only measure that exists. Such blocks never take part in
+  // a merge (merges anchor on sessions), so this exception cannot break the
+  // additivity below.
   if (sessions.length === 0) return Math.max(1, span)
   const summed = sessions.reduce(
     (sum, session: AppSession) => sum + sessionActiveSeconds(session),
     0,
   )
-  if (summed <= 0) return Math.max(1, span)
+  // Sessions exist but carry no time: the additive answer is (almost) zero,
+  // and falling back to the span here would let a merge change the total.
   return Math.max(1, summed)
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -666,6 +666,9 @@ export interface AIDaySummaryResult {
    *  (DEV-270/275: nothing fails silently). Absent on a real AI recap and on the
    *  empty-day line. */
   degraded?: boolean
+  /** Why the AI recap could not be generated, in words the person can act on
+   *  (provider error, timeout, unreadable reply). Only set when degraded. */
+  degradedReason?: string
 }
 
 export type AIAnswerKind =

--- a/tests/aiLabelCarryForward.test.ts
+++ b/tests/aiLabelCarryForward.test.ts
@@ -54,7 +54,7 @@ test('snapshot keys AI names by their session set', () => {
   db.close()
 })
 
-test('snapshot ignores invalidated blocks, rule-only labels, and member-less blocks', () => {
+test('snapshot ignores invalidated blocks and rule-only labels; a member-less block still carries by span', () => {
   const db = createProductionTestDatabase()
 
   // Invalidated AI block — its name is stale, must not be carried forward.
@@ -67,11 +67,32 @@ test('snapshot ignores invalidated blocks, rule-only labels, and member-less blo
   seedBlock(db, 'blk-rule')
   addSessionMembers(db, 'blk-rule', [2])
 
-  // AI block with no session members — no stable key, skip it.
+  // AI block with no session members — no session key, but its span still
+  // identifies the same stretch of work on a rebuild.
   seedBlock(db, 'blk-nomembers')
   writeAIBlockLabel(db, { blockId: 'blk-nomembers', label: 'No evidence' })
 
   const map = snapshotCarryForwardAiLabels(db, DATE)
-  assert.equal(map.size, 0)
+  assert.equal(map.get(`span:${START}:${START + 3_600_000}`)?.label, 'No evidence')
+  assert.equal(map.size, 1)
+  db.close()
+})
+
+test('snapshot keys AI names by span as well, and a contested span carries neither name', () => {
+  const db = createProductionTestDatabase()
+
+  seedBlock(db, 'blk-a')
+  addSessionMembers(db, 'blk-a', [11])
+  writeAIBlockLabel(db, { blockId: 'blk-a', label: 'Refactoring the sync uploader' })
+
+  // Same span as blk-a (corrupt data): the span key must go to neither.
+  seedBlock(db, 'blk-b')
+  addSessionMembers(db, 'blk-b', [30])
+  writeAIBlockLabel(db, { blockId: 'blk-b', label: 'Reviewing pull requests' })
+
+  const map = snapshotCarryForwardAiLabels(db, DATE)
+  assert.equal(map.get('sessions:11')?.label, 'Refactoring the sync uploader')
+  assert.equal(map.get('sessions:30')?.label, 'Reviewing pull requests')
+  assert.equal(map.get(`span:${START}:${START + 3_600_000}`), undefined)
   db.close()
 })

--- a/tests/analyzedDayPersistence.test.ts
+++ b/tests/analyzedDayPersistence.test.ts
@@ -1,0 +1,108 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import Database from 'better-sqlite3'
+import type { AppCategory } from '../src/shared/types.ts'
+import { createProductionTestDatabase } from './support/testDatabase.ts'
+import { writeAIBlockLabel } from '../src/main/db/queries.ts'
+import { getTimelineDayProjection, materializeTimelineDayProjection } from '../src/main/core/query/projections.ts'
+
+// DEV-277: a day analyzed mid-day kept accruing activity; the next open judged
+// the seal under-covered, threw the whole analysis away, and served coarse
+// "Morning / Afternoon / Night" sittings with the Analyze button reset. The
+// repair must extend the day to its real end while re-attaching every AI label
+// the person already earned.
+
+const TEST_DATE = '2026-04-22'
+
+function localMs(hour: number, minute = 0): number {
+  return new Date(2026, 3, 22, hour, minute, 0, 0).getTime()
+}
+
+function insertSession(
+  db: Database.Database,
+  title: string,
+  startHour: number,
+  startMinute: number,
+  durationMinutes: number,
+  category: AppCategory = 'development',
+  app: { bundleId: string; name: string } = { bundleId: 'com.mitchellh.ghostty', name: 'Ghostty' },
+): void {
+  const startTime = localMs(startHour, startMinute)
+  const endTime = startTime + durationMinutes * 60_000
+  db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec,
+      category, is_focused, window_title, raw_app_name, capture_source, capture_version
+    ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 'test', 1)
+  `).run(app.bundleId, app.name, startTime, endTime, durationMinutes * 60, category, title, app.name)
+}
+
+function rendererRead(db: Database.Database) {
+  // The exact options the GET_TIMELINE_DAY handler uses.
+  return getTimelineDayProjection(db, TEST_DATE, null, { materialize: false, analysis: false })
+}
+
+// Analyze the morning, then live through an afternoon: the sealed blocks now
+// under-cover the day by hours.
+function seedAnalyzedMorningThenAfternoon(db: Database.Database): string {
+  for (let hour = 9; hour < 12; hour++) {
+    insertSession(db, 'Week 1 — Coursera', hour, 0, 55, 'research', { bundleId: 'com.google.Chrome', name: 'Google Chrome' })
+  }
+  materializeTimelineDayProjection(db, TEST_DATE, null)
+  const analyzed = db.prepare(`
+    SELECT id FROM timeline_blocks WHERE date = ? AND invalidated_at IS NULL AND is_live = 0
+  `).all(TEST_DATE) as Array<{ id: string }>
+  assert.ok(analyzed.length >= 1, 'the analyze pass sealed the morning')
+  const aiLabel = 'Studying machine learning'
+  for (const block of analyzed) {
+    writeAIBlockLabel(db, { blockId: block.id, label: aiLabel, narrative: 'Coursera week 1' })
+  }
+  for (let hour = 13; hour < 20; hour++) {
+    insertSession(db, 'daylens — Ghostty', hour, 0, 55, 'development')
+  }
+  return aiLabel
+}
+
+test('DEV-277: an analyzed day that kept accruing activity keeps its AI labels on the next open', () => {
+  const db = createProductionTestDatabase()
+  const aiLabel = seedAnalyzedMorningThenAfternoon(db)
+
+  const rendered = rendererRead(db)
+  const blocks = rendered.blocks.filter((block) => !block.isLive)
+
+  assert.ok(
+    blocks.some((block) => block.label.current === aiLabel),
+    `the analyzed morning keeps its AI name; got ${blocks.map((b) => `"${b.label.current}"`).join(', ')}`,
+  )
+  assert.ok(blocks.every((block) => !block.provisional),
+    'the day stays settled — the Analyze button must not reset to a fresh coarse day')
+  const lastEnd = Math.max(...blocks.map((block) => block.endTime))
+  assert.ok(lastEnd >= localMs(19), 'the repaired day reaches its real end, covering the afternoon')
+  const partNames = new Set(['Morning', 'Afternoon', 'Evening', 'Night', 'Late night'])
+  assert.ok(blocks.every((block) => !partNames.has(block.label.current)),
+    'no block reverts to a coarse part-of-day sitting name')
+
+  // The repair is durable: a second read serves the same settled day.
+  const again = rendererRead(db).blocks.filter((block) => !block.isLive)
+  assert.ok(again.some((block) => block.label.current === aiLabel))
+  assert.ok(again.every((block) => !block.provisional))
+  db.close()
+})
+
+test('DEV-277: AI labels survive a rebuild that re-keys every session id', () => {
+  const db = createProductionTestDatabase()
+  const aiLabel = seedAnalyzedMorningThenAfternoon(db)
+
+  // A past day's rebuild feeds derived sessions whose ids live in a different
+  // namespace than the ids the day was analyzed with. Shift every session id
+  // so the session-set carry key can never match — the span must carry instead.
+  db.prepare(`UPDATE app_sessions SET id = id + 100000`).run()
+
+  const blocks = rendererRead(db).blocks.filter((block) => !block.isLive)
+  assert.ok(
+    blocks.some((block) => block.label.current === aiLabel),
+    `the AI name re-attaches by span when session ids changed; got ${blocks.map((b) => `"${b.label.current}"`).join(', ')}`,
+  )
+  assert.ok(blocks.every((block) => !block.provisional))
+  db.close()
+})

--- a/tests/blockDuration.test.ts
+++ b/tests/blockDuration.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { blockDisplayedSpanSeconds } from '../src/shared/blockDuration.ts'
+import { blockActiveSeconds, blockDisplayedSpanSeconds } from '../src/shared/blockDuration.ts'
+import type { AppSession } from '../src/shared/types.ts'
 
 // Synthesize timestamps at known second offsets within a fixed minute.
 function minuteMs(hour: number, minute: number, second = 0): number {
@@ -32,4 +33,57 @@ test('displayed span floors to 1 second when start and end share a minute', () =
   const block = { startTime: minuteMs(9, 0, 10), endTime: minuteMs(9, 0, 50) }
   // Both round to "9:00" on the clock; avoid emitting "0m" next to the range.
   assert.equal(blockDisplayedSpanSeconds(block), 1)
+})
+
+function session(startTime: number, endTime: number, durationSeconds: number): AppSession {
+  return {
+    id: 1,
+    bundleId: 'com.example.app',
+    appName: 'Example',
+    startTime,
+    endTime,
+    durationSeconds,
+    category: 'development',
+    isFocused: true,
+  }
+}
+
+test('active seconds sum the sessions', () => {
+  const block = {
+    startTime: minuteMs(9, 0),
+    endTime: minuteMs(9, 30),
+    sessions: [
+      session(minuteMs(9, 0), minuteMs(9, 10), 10 * 60),
+      session(minuteMs(9, 12), minuteMs(9, 30), 18 * 60),
+    ],
+  }
+  assert.equal(blockActiveSeconds(block), 28 * 60)
+})
+
+test('an inflated session duration is clamped to its own span', () => {
+  const block = {
+    startTime: minuteMs(9, 0),
+    endTime: minuteMs(9, 20),
+    sessions: [session(minuteMs(9, 0), minuteMs(9, 20), 25 * 60)],
+  }
+  assert.equal(blockActiveSeconds(block), 20 * 60)
+})
+
+test('merging two blocks never changes the summed active seconds', () => {
+  // Block A carries an inflated session duration; before the fix the per-block
+  // span clamp hid that inflation, and the wider merged span let it back out.
+  const sessionsA = [
+    session(minuteMs(9, 0), minuteMs(9, 20), 25 * 60),
+    session(minuteMs(9, 21), minuteMs(9, 28), 7 * 60),
+  ]
+  const sessionsB = [session(minuteMs(9, 45), minuteMs(10, 15), 30 * 60)]
+  const separate =
+    blockActiveSeconds({ startTime: minuteMs(9, 0), endTime: minuteMs(9, 28), sessions: sessionsA }) +
+    blockActiveSeconds({ startTime: minuteMs(9, 45), endTime: minuteMs(10, 15), sessions: sessionsB })
+  const merged = blockActiveSeconds({
+    startTime: minuteMs(9, 0),
+    endTime: minuteMs(10, 15),
+    sessions: [...sessionsA, ...sessionsB],
+  })
+  assert.equal(merged, separate)
 })

--- a/tests/blockDuration.test.ts
+++ b/tests/blockDuration.test.ts
@@ -69,6 +69,31 @@ test('an inflated session duration is clamped to its own span', () => {
   assert.equal(blockActiveSeconds(block), 20 * 60)
 })
 
+test('a block whose sessions carry no time reads as the 1-second floor, not its span', () => {
+  const block = {
+    startTime: minuteMs(9, 0),
+    endTime: minuteMs(11, 0),
+    sessions: [session(minuteMs(9, 0), minuteMs(9, 30), 0)],
+  }
+  assert.equal(blockActiveSeconds(block), 1)
+})
+
+test('merging never changes the total even when one side has zero-duration sessions', () => {
+  const zeroSide = [session(minuteMs(9, 0), minuteMs(9, 30), 0)]
+  const realSide = [session(minuteMs(10, 0), minuteMs(10, 45), 45 * 60)]
+  const separate =
+    blockActiveSeconds({ startTime: minuteMs(9, 0), endTime: minuteMs(9, 30), sessions: zeroSide }) +
+    blockActiveSeconds({ startTime: minuteMs(10, 0), endTime: minuteMs(10, 45), sessions: realSide })
+  const merged = blockActiveSeconds({
+    startTime: minuteMs(9, 0),
+    endTime: minuteMs(10, 45),
+    sessions: [...zeroSide, ...realSide],
+  })
+  // Both sides sum their sessions; the only drift allowed is the empty side's
+  // 1-second display floor.
+  assert.ok(Math.abs(merged - separate) <= 1, `merged ${merged} vs separate ${separate}`)
+})
+
 test('merging two blocks never changes the summed active seconds', () => {
   // Block A carries an inflated session duration; before the fix the per-block
   // span clamp hid that inflation, and the wider merged span let it back out.


### PR DESCRIPTION
Fixes the four foundation bugs from the July 22 review session. Linear: DEV-277, DEV-279, DEV-282, DEV-283.

## DEV-277 — An analyzed day reverts to coarse Morning/Afternoon/Night (Urgent)

Two compounding causes:

1. **The AI-label carry-forward was dead code.** It only ran when `persistTimelineDay` was called with `finalized:false`, and its only caller always passed `finalized:true`. Any rebuild that re-keys block ids (re-segmentation, heuristic bump, the derived-session id namespace on a past day) stranded every AI label; `persistedDayWasProcessed` flipped false; the read path served coarse provisional sittings and reset the Analyze button.
2. **The partial-seal repair was destructive on read.** A day analyzed mid-day that kept accruing activity is judged "under-covered" on the next open; the repair invalidated all analyzed blocks during a `materialize:false` renderer read and returned coarse blocks without re-persisting anything.

Now every full rebuild goes through `rebuildDayBlocksWithCarriedLabels`: the day's AI labels are snapshotted before the rebuild supersedes their blocks and re-attached by (a) identical session set, (b) identical wall-clock span — this survives the session-id namespace change on past days — or (c) an unambiguous mutual-midpoint match (each span contains the other's midpoint; threshold-free). The under-covered repair rebuilds the whole day, carries the labels, persists, and returns the settled day; it only falls back to the old coarse behavior when no label or correction survives (preserving DEV-267/268 semantics, and their tests pass unchanged).

**Known remaining vector, flagged for a product decision:** `resetDerivedState` (upgrade-time version bumps) hard-deletes `timeline_blocks` + `timeline_block_labels`, which wipes analysis with nothing left to carry forward. Whether AI analysis should survive a full derived-state reset is asked on DEV-277.

## DEV-282 — Merge inflates the day total; garbled preview

`blockActiveSeconds` clamped the summed session durations to the block's wall-clock span. The clamp ceiling is per block, so merging two blocks (span now includes the gap) let previously clamped time back out — the observed 9h 28m → 9h 32m. The measure is now additive per session (each clamped to its own span), which re-partitioning cannot change. Regression test asserts merge-invariance directly.

The merge preview grouped: source blocks render as compact "label + times" rows above one "→ merged label + times" row instead of repeating the survivor per source; labels clamp to two lines so a pasted-ticket-description label can't flood the dialog.

## DEV-283 — Detail panel renders at the bottom of the page

The analyze-status banner and `BlockDetailInspector` were fragment siblings, handing the two-column day grid a third in-flow child: timeline → (r1c1), banner → (r1c2), inspector → (r2c1, full-width bottom). They are one sticky grid item now. This also explains the intermittency (only after an analyze run left a status) and why navigating away fixed it (remount cleared the status).

## DEV-279 — Generate recap does not produce a recap

`generateDaySummary` caught every provider error (no key, quota, timeout — already shaped into actionable messages by the orchestration layer) and returned the degraded fallback with the reason buried in a console.warn. The result now carries `degradedReason` to the UI: "The full recap couldn't be generated — {reason} Showing the day's facts; Generate recap retries." A truncated JSON reply with a complete `summary` field is also salvaged instead of discarded.

## Verification

- `npm run typecheck` / `npm run lint` — clean (0 errors; 103 pre-existing warnings)
- `npm test` — 321 files, 2,146 pass, 0 fail (6 new tests)
- `npm run timeline:eval -- --strict`, `verify:synthetic-day`, `verify:ai-turn`, `verify:remote-web`, `contract:check` — all green
- New regression coverage: `tests/analyzedDayPersistence.test.ts` (the exact DEV-277 scenario: mid-day analyze + evening accrual; plus the session-id re-key variant), merge-invariance in `tests/blockDuration.test.ts`, span-key carry in `tests/aiLabelCarryForward.test.ts`

`verify:real-day` (private, local) still needs a run against an accepted snapshot before acceptance — it refuses CI and cannot run from this environment without the isolated user-data path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI recap fallback messages now explain why generation failed and suggest retrying.
  * Timeline corrections are grouped into a clearer, non-destructive preview.
  * AI-generated block names are preserved more reliably after timeline rebuilds.
* **Bug Fixes**
  * Improved recovery of summaries from incomplete AI responses.
  * Corrected active-time calculations across merged or split sessions.
  * Improved timeline detail panel behavior and selection clearing.
* **Tests**
  * Expanded coverage for label persistence, summary recovery, and active-time calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->