### PR TITLE
Phase 2: labels name the work, never the window (DEV-276/278)

### DIFF
--- a/docs/specs/label-voice.md
+++ b/docs/specs/label-voice.md
@@ -29,7 +29,15 @@ or the telemetry that captured it.
 ## Rules
 
 Every rule is a named, deterministic check in `src/shared/labelVoice.ts`,
-returning pass or fail plus the offending fragment. Rules come in two tiers:
+returning pass or fail plus the offending fragment. The rules are not only
+scored: the label chooser (`finalizedLabelForBlock`) rejects any candidate that
+fails an invariant rule, and rejects an interpreted candidate (the AI label, an
+artifact title) that reproduces a captured title verbatim or is a bare app
+name. A rejected candidate falls to the next in priority; a person's own
+override is never touched. The AI labeler gets one corrective retry with the
+violation named before the deterministic fallback stands (DEV-276).
+
+Rules come in two tiers:
 
 - **Invariant** rules hold for every produced label, including deterministic
   fallback labels. A violation is a defect in the labeling path.
@@ -42,7 +50,7 @@ returning pass or fail plus the offending fragment. Rules come in two tiers:
 | Rule | Requirement | Fails on |
 | --- | --- | --- |
 | `nonempty-bounded` | A label exists and stays a short phrase: never empty, at most 90 characters and 12 words, no trailing sentence punctuation. | “” · a full sentence ending in a period |
-| `no-raw-artifact-forms` | No raw machine forms reach a label: URLs, bare domains, data/office file extensions, underscore filenames, SCREAMING identifiers, notification counts, browser-tab soup (3+ `\|` segments), trailing browser names. | “https://github.com/…” · “youtube.com” · “report_final_v2.xlsx” · “AGENT-EXECUTION-PLAN.md” · “(3) Inbox” · “W2_Reading \| Intro to ML \| Perusall” · “Docs — Google Chrome” |
+| `no-raw-artifact-forms` | No raw machine forms reach a label: URLs, bare domains, filenames of any kind (code filenames included — DEV-276), JSON fragments, bracketed title fragments, underscore filenames, SCREAMING identifiers, notification counts, browser-tab soup (3+ `\|` segments), trailing browser names. | “https://github.com/…” · “youtube.com” · “handoff.md” · “report_final_v2.xlsx” · “AGENT-EXECUTION-PLAN.md” · “{"questions":[…” · “[Week 1]” · “(3) Inbox” · “W2_Reading \| Intro to ML \| Perusall” · “Docs — Google Chrome” |
 | `no-plumbing-or-hype` | Everyday words only: no capture vocabulary (“foreground”, “window title”, “app session”, “captured signal”, “telemetry”, “bundle id”) and none of the assistant voice contract’s banned marketing filler (“deep dive”, “seamless”, “streamline”, …). | “Foreground app sessions” · “Deep dive into metrics” |
 | `no-judgment` | A label never judges productivity, focus, distraction, or personal worth. Naming a real focus-timer session stays allowed. | “Unproductive browsing” · “Wasted afternoon” · “Doomscrolling” |
 | `leisure-activity-shaped` | A leisure block’s label reads as the activity — “Watching…”, “On…”, “Listening…”, “Browsing…” — never a bare page or video title. | “Big Buck Bunny 4K60” as a leisure label |

--- a/src/main/ipc/db.handlers.ts
+++ b/src/main/ipc/db.handlers.ts
@@ -455,6 +455,7 @@ export function registerDbHandlers(): void {
       relabeled: result.relabeled,
       attempted: result.attempted,
       failed: result.failures.length,
+      failureReason: result.failures[0] ?? null,
     }
   })
 

--- a/src/main/jobs/aiService.ts
+++ b/src/main/jobs/aiService.ts
@@ -33,8 +33,9 @@ import {
   parseStarterSuggestions,
 } from '../lib/followUpSuggestions'
 import { transformInstruction } from '@shared/answerTransforms'
-import { looksLikeRawArtifactLabel, userVisibleBlockLabel } from '@shared/blockLabel'
-import { rawLabelForm } from '@shared/labelVoice'
+import { userVisibleBlockLabel } from '@shared/blockLabel'
+import { evaluateLabelVoice, labelVoiceContextForBlock, rawLabelForm } from '@shared/labelVoice'
+import { activityCategoryLabel } from '@shared/activityCategories'
 import { partitionDomainsWorkFirst } from '@shared/workKind'
 import { appNarrativeScopeKey, THIN_APP_NARRATIVE_SUMMARY } from '@shared/appNarrativeContract'
 import { userProfileDirective } from '@shared/userProfile'
@@ -3002,6 +3003,16 @@ export async function suggestAppCategory(bundleId: string, appName: string): Pro
   return noSuggestion
 }
 
+// The deterministic name used when the model cannot produce a voiced label.
+// The evidence-based fallback is usually fine, but it can itself be a raw
+// artifact form ("handoff.md") — never persist that as an "ai" label; name the
+// category honestly instead (a floor the clarification agent then asks about).
+function voiceSafeFallbackLabel(block: WorkContextBlock): string {
+  const fallback = userVisibleLabelForBlock(block)
+  if (!rawLabelForm(fallback)) return fallback
+  return activityCategoryLabel(block.dominantCategory)
+}
+
 export async function generateWorkBlockInsight(
   block: WorkContextBlock,
   options?: {
@@ -3033,37 +3044,68 @@ export async function generateWorkBlockInsight(
     'Return only valid JSON.',
   ].join(' ')
 
-  try {
-    const { text, config } = await withTimeout(
-      executeTextAIJob(
-        {
-          jobType: options?.jobType ?? (block.isLive ? 'block_label_preview' : 'block_label_finalize'),
-          screen: 'timeline_day',
-          triggerSource: options?.triggerSource ?? (block.isLive ? 'system' : 'background'),
-          systemPrompt,
-          userMessage: [
-            workBlockPrompt(block),
-            options?.rejectedLabel?.trim()
-              ? `The previous label "${options.rejectedLabel.trim()}" was marked inaccurate by the user. Produce a clearly different, more accurate label grounded only in the evidence above.`
-              : '',
-            options?.userHint?.trim()
-              ? `The user described their day as: "${options.userHint.trim()}". Treat this as a strong hint for what they were doing, but stay grounded in the evidence above, and only apply it where it fits this block's activity.`
-              : '',
-          ].filter(Boolean).join('\n\n'),
-        },
-        sendWithProvider,
-      ),
-      BLOCK_INSIGHT_TIMEOUT_MS,
-      'Block insight timed out',
-    )
-    options?.onModel?.(config.model)
-    const parsed = parseWorkBlockInsight(text)
+  // The label-voice contract (label-voice.md, DEV-276): the model's label must
+  // clear the invariant rules and must not echo a captured title or a bare app
+  // name — a raw window title, filename, ticket description, or JSON string is
+  // never a label. A rejected label gets exactly one corrective retry with the
+  // violation named; if that also fails, the deterministic evidence name (voice
+  // gated itself) stands and the block stays a re-analysis target.
+  const voiceContext = labelVoiceContextForBlock(block)
+  const labelRejection = (candidate: string | null | undefined): string | null => {
+    const label = candidate?.trim()
+    if (!label) return 'the label was empty'
+    for (const finding of evaluateLabelVoice(label, voiceContext)) {
+      if (finding.passed) continue
+      if (finding.tier === 'invariant'
+        || finding.rule === 'no-verbatim-window-title'
+        || finding.rule === 'activity-not-software') {
+        return finding.detail ?? finding.rule
+      }
+    }
+    return null
+  }
 
-    // §3.5 / invariant 3: even the model may not name a block after a raw machine
-    // identifier (AGENT, AGENT-EXECUTION-PLAN.md). If it does, drop to the guarded
-    // evidence-based name rather than persist the raw token as an "ai" label.
-    const aiLabel = parsed?.label?.trim()
-    const label = aiLabel && !looksLikeRawArtifactLabel(aiLabel) ? aiLabel : userVisibleLabelForBlock(block)
+  try {
+    const requestInsight = async (voiceFeedback?: string) => {
+      const { text, config } = await withTimeout(
+        executeTextAIJob(
+          {
+            jobType: options?.jobType ?? (block.isLive ? 'block_label_preview' : 'block_label_finalize'),
+            screen: 'timeline_day',
+            triggerSource: options?.triggerSource ?? (block.isLive ? 'system' : 'background'),
+            systemPrompt,
+            userMessage: [
+              workBlockPrompt(block),
+              options?.rejectedLabel?.trim()
+                ? `The previous label "${options.rejectedLabel.trim()}" was marked inaccurate by the user. Produce a clearly different, more accurate label grounded only in the evidence above.`
+                : '',
+              options?.userHint?.trim()
+                ? `The user described their day as: "${options.userHint.trim()}". Treat this as a strong hint for what they were doing, but stay grounded in the evidence above, and only apply it where it fits this block's activity.`
+                : '',
+              voiceFeedback ?? '',
+            ].filter(Boolean).join('\n\n'),
+          },
+          sendWithProvider,
+        ),
+        BLOCK_INSIGHT_TIMEOUT_MS,
+        'Block insight timed out',
+      )
+      options?.onModel?.(config.model)
+      return parseWorkBlockInsight(text)
+    }
+
+    let parsed = await requestInsight()
+    let rejection = labelRejection(parsed?.label)
+    if (rejection && !block.isLive) {
+      parsed = await requestInsight(
+        `Your previous label "${parsed?.label ?? ''}" was rejected: ${rejection}. `
+        + 'Name what the person was DOING in everyday words (verb + object). '
+        + 'Never a window title, page title, filename, app name, ticket text, or JSON.',
+      )
+      rejection = labelRejection(parsed?.label)
+    }
+
+    const label = rejection ? voiceSafeFallbackLabel(block) : parsed!.label!.trim()
     const insight = {
       label,
       narrative: parsed?.narrative || fallbackNarrativeForBlock(block),
@@ -3080,7 +3122,7 @@ export async function generateWorkBlockInsight(
   } catch (error) {
     if (options?.throwOnError) throw error
     const insight = {
-      label: userVisibleLabelForBlock(block),
+      label: voiceSafeFallbackLabel(block),
       narrative: fallbackNarrativeForBlock(block),
     }
     if (!block.isLive && block.aiLabel) {

--- a/src/main/jobs/aiService.ts
+++ b/src/main/jobs/aiService.ts
@@ -36,7 +36,7 @@ import { transformInstruction } from '@shared/answerTransforms'
 import { userVisibleBlockLabel } from '@shared/blockLabel'
 import { evaluateLabelVoice, labelVoiceContextForBlock, rawLabelForm } from '@shared/labelVoice'
 import { activityCategoryLabel } from '@shared/activityCategories'
-import { partitionDomainsWorkFirst } from '@shared/workKind'
+import { effectiveBlockKind, partitionDomainsWorkFirst } from '@shared/workKind'
 import { appNarrativeScopeKey, THIN_APP_NARRATIVE_SUMMARY } from '@shared/appNarrativeContract'
 import { userProfileDirective } from '@shared/userProfile'
 import { parseDaySummaryResultText } from '../lib/daySummarySuggestions'
@@ -3050,7 +3050,9 @@ export async function generateWorkBlockInsight(
   // never a label. A rejected label gets exactly one corrective retry with the
   // violation named; if that also fails, the deterministic evidence name (voice
   // gated itself) stands and the block stays a re-analysis target.
-  const voiceContext = labelVoiceContextForBlock(block)
+  // The block kind matters: without it the leisure-shape rule is inert here
+  // and a bare video title would only be caught later by the label chooser.
+  const voiceContext = labelVoiceContextForBlock(block, effectiveBlockKind(block))
   const labelRejection = (candidate: string | null | undefined): string | null => {
     const label = candidate?.trim()
     if (!label) return 'the label was empty'

--- a/src/main/services/analyzeDay.ts
+++ b/src/main/services/analyzeDay.ts
@@ -395,7 +395,11 @@ export async function analyzeTimelineDay(
     // one attempt (DEV-278): retry the failed ones once, serially, before
     // reporting anything as un-nameable.
     const firstPassFailed = insights.filter((result): result is { block: WorkContextBlock; error: string } => 'error' in result)
-    if (firstPassFailed.length > 0 && firstPassFailed.length < relabelTargets.length) {
+    // "Everything failed" only signals an outage when there was more than one
+    // call to corroborate it — a day with a single relabel target must still
+    // get its retry (DEV-278).
+    const looksLikeOutage = firstPassFailed.length === relabelTargets.length && relabelTargets.length > 1
+    if (firstPassFailed.length > 0 && !looksLikeOutage) {
       named -= firstPassFailed.length
       const retried = await mapWithConcurrency(firstPassFailed.map((entry) => entry.block), 1, nameBlock)
       const retriedByBlock = new Map(retried.map((result) => [result.block.id, result]))

--- a/src/main/services/analyzeDay.ts
+++ b/src/main/services/analyzeDay.ts
@@ -375,7 +375,7 @@ export async function analyzeTimelineDay(
     type RelabelOutcome =
       | { block: WorkContextBlock; insight: WorkContextInsight }
       | { block: WorkContextBlock; error: string }
-    const insights = await mapWithConcurrency(relabelTargets, RELABEL_CONCURRENCY, async (block): Promise<RelabelOutcome> => {
+    const nameBlock = async (block: WorkContextBlock): Promise<RelabelOutcome> => {
       try {
         const insight = await blockInsight(
           { ...block, label: { ...block.label, override: null } },
@@ -387,7 +387,22 @@ export async function analyzeTimelineDay(
       } finally {
         emitProgress({ stage: 'naming', done: ++named, total: relabelTargets.length })
       }
-    })
+    }
+    let insights = await mapWithConcurrency(relabelTargets, RELABEL_CONCURRENCY, nameBlock)
+
+    // Provider failures under concurrency are usually transient (a 429, one
+    // slow call hitting the timeout). A run must not give up on a block after
+    // one attempt (DEV-278): retry the failed ones once, serially, before
+    // reporting anything as un-nameable.
+    const firstPassFailed = insights.filter((result): result is { block: WorkContextBlock; error: string } => 'error' in result)
+    if (firstPassFailed.length > 0 && firstPassFailed.length < relabelTargets.length) {
+      named -= firstPassFailed.length
+      const retried = await mapWithConcurrency(firstPassFailed.map((entry) => entry.block), 1, nameBlock)
+      const retriedByBlock = new Map(retried.map((result) => [result.block.id, result]))
+      insights = insights.map((result) =>
+        'error' in result ? retriedByBlock.get(result.block.id) ?? result : result)
+    }
+
     for (const result of insights) {
       if ('error' in result) {
         console.warn(`[timeline] AI re-analysis failed for block ${result.block.id}:`, result.error)

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -57,6 +57,7 @@ import { isHostFilteredFromArtifacts, isHostBlockedForLabel, isHostBlockedForApp
 import { categoryForDomain } from '@shared/domainCategories'
 import { blockActiveSeconds } from '@shared/blockDuration'
 import { looksLikeRawArtifactLabel } from '@shared/blockLabel'
+import { evaluateLabelVoice, labelVoiceContextForBlock, rawLabelForm } from '@shared/labelVoice'
 import { activityCategoryLabel } from '@shared/activityCategories'
 import { DEFAULT_TIMELINE_BLOCK_REVIEW, isTimelineBlockReviewState, isTrustedTimelineBlock } from '@shared/timelineReview'
 import { inferWorkIntent } from '@shared/workIntent'
@@ -4327,6 +4328,35 @@ function preferredArtifactLabel(block: WorkContextBlock): string | null {
   return usefulDerivedLabel(domainLabel)
 }
 
+// Deterministic project name from editor-style window titles ("checkout.ts —
+// acme-portal", "insightsQueryRouter.ts - daylens - Cursor"). A filename is
+// never a label (DEV-276), but the project segment beside it names the work
+// honestly until the AI produces a real activity phrase.
+function editorProjectLabel(block: WorkContextBlock): string | null {
+  if (block.dominantCategory !== 'development') return null
+  const titles = [...(block.evidenceSummary.windowTitles ?? [])]
+    .sort((left, right) => (right.totalSeconds ?? 0) - (left.totalSeconds ?? 0))
+  for (const entry of titles) {
+    const title = entry.title?.trim()
+    if (!title) continue
+    const segments = title.split(/\s+[—–-]\s+/).map((segment) => segment.trim()).filter(Boolean)
+    if (segments.length < 2) continue
+    const appName = entry.appName?.trim().toLowerCase()
+    const last = segments[segments.length - 1].toLowerCase()
+    const withoutApp = appName && (last === appName || appName.includes(last) || last.includes(appName))
+      ? segments.slice(0, -1)
+      : segments
+    if (withoutApp.length < 2) continue
+    // Only the "<file> … <project>" shape: the first segment must be file-ish,
+    // and the project segment must itself be a clean, short token.
+    if (!rawLabelForm(withoutApp[0])) continue
+    const project = withoutApp[withoutApp.length - 1]
+    if (!project || project.length > 40 || rawLabelForm(project)) continue
+    return `Working on ${project}`
+  }
+  return null
+}
+
 function hasLegacyWeakAiLabel(block: WorkContextBlock): boolean {
   const aiLabel = block.aiLabel?.trim()
   return Boolean(aiLabel) && !usefulBlockLabel(block, aiLabel)
@@ -4382,10 +4412,37 @@ function finalizedLabelForBlock(
   const projectHint = concurrentEvidence
     ? extractProjectHintFromEvidence(block, concurrentEvidence)
     : null
-  const artifactLabel = preferredArtifactLabel(block)
-  const workflowLabel = usefulBlockLabel(block, block.workflowRefs[0]?.label)
-  const ruleLabel = usefulBlockLabel(block, block.ruleBasedLabel)
-  const rawAiLabel = usefulBlockLabel(block, block.aiLabel)
+  // Label-voice enforcement (label-voice.md, DEV-276): every candidate except
+  // the person's own override must clear the invariant rules — no raw window
+  // titles, filenames, ticket text, JSON, telemetry vocabulary, or judgment.
+  // Interpreted candidates (AI, artifact) additionally must not reproduce a
+  // captured title verbatim or be a bare app name: titles are evidence inside
+  // the block; the label interprets them. A rejected candidate falls to the
+  // next in priority; the floors stay honest category/evidence names.
+  // 'invariants' rejects the machine forms every label must avoid; 'floor'
+  // additionally rejects a verbatim captured title (a window title is never a
+  // label, DEV-276 — not even as a fallback); 'interpreted' also rejects a
+  // bare app name, since an AI or artifact candidate must name the activity.
+  const voiceContext = labelVoiceContextForBlock(block, blockKindFor(block))
+  const clearsLabelVoice = (
+    candidate: string | null | undefined,
+    tier: 'invariants' | 'floor' | 'interpreted' = 'invariants',
+  ): string | null => {
+    const label = candidate?.trim()
+    if (!label) return null
+    for (const finding of evaluateLabelVoice(label, voiceContext)) {
+      if (finding.passed) continue
+      if (finding.tier === 'invariant') return null
+      if (tier !== 'invariants' && finding.rule === 'no-verbatim-window-title') return null
+      if (tier === 'interpreted' && finding.rule === 'activity-not-software') return null
+    }
+    return label
+  }
+
+  const artifactLabel = clearsLabelVoice(preferredArtifactLabel(block), 'interpreted')
+  const workflowLabel = clearsLabelVoice(usefulBlockLabel(block, block.workflowRefs[0]?.label))
+  const ruleLabel = clearsLabelVoice(usefulBlockLabel(block, block.ruleBasedLabel))
+  const rawAiLabel = clearsLabelVoice(usefulBlockLabel(block, block.aiLabel), 'interpreted')
   // F1: the AI labeler can also lift a YouTube tab title verbatim into the
   // block headline when it sees that page in the evidence. Reject any
   // suggested label that matches an entertainment/social/adult page title
@@ -4398,14 +4455,30 @@ function finalizedLabelForBlock(
   // floors. The project hint ("<project> development") is a FLOOR, not an
   // override: it must never beat a real AI label like "Refactoring the timeline
   // coalescer" (the §6 quality bar). It sits just above the bare rule label.
+  // A verbatim captured title never stands as a label (DEV-276), but a
+  // descriptive multi-word title still names the block's subject — wrap it as
+  // an activity phrase so the subject survives when no interpreted name
+  // exists. Short fragments ("Cursor Agents") stay rejected: the category
+  // floor is more honest than a dressed-up tool fragment.
+  const floorLabel = userVisibleLabelForBlock(block)
+  const wrappedVerbatimFloor = (): string | null => {
+    if (!FOCUSED_CATEGORIES.includes(block.dominantCategory)) return null
+    if (!clearsLabelVoice(floorLabel)) return null
+    if (floorLabel.split(/\s+/).filter(Boolean).length < 3) return null
+    return clearsLabelVoice(`Working on ${floorLabel}`, 'floor')
+  }
+
   const chosen = override?.label?.trim()
-    || memoryPattern?.label
+    || clearsLabelVoice(memoryPattern?.label)
     || aiLabel
     || artifactLabel
+    || clearsLabelVoice(editorProjectLabel(block))
     || workflowLabel
-    || projectHint?.label
+    || clearsLabelVoice(projectHint?.label)
     || ruleLabel
-    || userVisibleLabelForBlock(block)
+    || clearsLabelVoice(floorLabel, 'floor')
+    || wrappedVerbatimFloor()
+    || prettyCategory(block.dominantCategory)
 
   const source = override?.label?.trim()
     ? 'user'

--- a/src/renderer/views/Timeline.tsx
+++ b/src/renderer/views/Timeline.tsx
@@ -1632,7 +1632,7 @@ function analyzeOutcomeMessage(result: RebuildTimelineDayResult, provisional: bo
   if (result.failed > 0) {
     // Never a bare failure count (DEV-278): say why and how to finish the job.
     const rawReason = result.failureReason?.trim()
-    const reason = rawReason ? (/[.!?]$/.test(rawReason) ? rawReason : `${rawReason}.`) : null
+    const reason = rawReason ? (/[.!?…]$/.test(rawReason) ? rawReason : `${rawReason}.`) : null
     message += reason
       ? ` · ${result.failed} couldn’t be named — ${reason} Re-analyze retries them.`
       : ` · ${result.failed} couldn’t be named — Re-analyze retries them.`

--- a/src/renderer/views/Timeline.tsx
+++ b/src/renderer/views/Timeline.tsx
@@ -1629,7 +1629,14 @@ function analyzeOutcomeMessage(result: RebuildTimelineDayResult, provisional: bo
   if (result.relabeled > 0) parts.push(`Re-labeled ${result.relabeled} block${plural(result.relabeled)}`)
   if (result.mergedCount > 0) parts.push(`merged ${result.mergedCount} block${plural(result.mergedCount)}`)
   let message = parts.length > 0 ? parts.join(' · ') : 'Refreshed the day'
-  if (result.failed > 0) message += ` (${result.failed} couldn’t be re-labeled)`
+  if (result.failed > 0) {
+    // Never a bare failure count (DEV-278): say why and how to finish the job.
+    const rawReason = result.failureReason?.trim()
+    const reason = rawReason ? (/[.!?]$/.test(rawReason) ? rawReason : `${rawReason}.`) : null
+    message += reason
+      ? ` · ${result.failed} couldn’t be named — ${reason} Re-analyze retries them.`
+      : ` · ${result.failed} couldn’t be named — Re-analyze retries them.`
+  }
   return message
 }
 

--- a/src/shared/labelVoice.ts
+++ b/src/shared/labelVoice.ts
@@ -229,9 +229,10 @@ function wordCount(value: string): number {
 // version number ("1.0.45") or trailing ellipsis never matches.
 const BARE_FILENAME_RE = /^[\w()[\]#@~+-]+\.[a-z][a-z0-9]{0,5}$/i
 // Structural JSON: an opening brace, an array of objects/strings, or a quoted
-// key with a colon anywhere. A colon in prose ("Sprint planning: retro") and a
-// bracketed title fragment ("[Week 1]") never match.
-const JSON_FRAGMENT_RE = /^\{|^\[\s*[{["]|"[^"]*"\s*:/
+// key whose colon is followed by a JSON value opener. A colon in prose
+// ("Sprint planning: retro", 'Reviewed the "Q3 Roadmap": key priorities') and
+// a bracketed title fragment ("[Week 1]") never match.
+const JSON_FRAGMENT_RE = /^\{|^\[\s*[{["]|"[^"]*"\s*:\s*[{[\d"]/
 // A label that is nothing but a bracketed fragment is tab-title cruft
 // ("[Week 1]"), never an activity.
 const BRACKETED_FRAGMENT_RE = /^\[[^\]]*\]$/

--- a/src/shared/labelVoice.ts
+++ b/src/shared/labelVoice.ts
@@ -222,12 +222,26 @@ function wordCount(value: string): number {
   return value.split(/\s+/).filter(Boolean).length
 }
 
+// A label that is one token ending in a file extension is the artifact, not
+// the activity ("handoff.md", "run.ts"). DEV-276 recorded that a filename is
+// never a label — including ordinary code filenames, which an earlier design
+// allowed as deterministic fallbacks. Requires a letter-led extension so a
+// version number ("1.0.45") or trailing ellipsis never matches.
+const BARE_FILENAME_RE = /^[\w()[\]#@~+-]+\.[a-z][a-z0-9]{0,5}$/i
+// Structural JSON: an opening brace, an array of objects/strings, or a quoted
+// key with a colon anywhere. A colon in prose ("Sprint planning: retro") and a
+// bracketed title fragment ("[Week 1]") never match.
+const JSON_FRAGMENT_RE = /^\{|^\[\s*[{["]|"[^"]*"\s*:/
+// A label that is nothing but a bracketed fragment is tab-title cruft
+// ("[Week 1]"), never an activity.
+const BRACKETED_FRAGMENT_RE = /^\[[^\]]*\]$/
+
 /**
  * The raw machine form a label carries, or null when it carries none.
  * Also used for intent subjects: a subject must not be a machine artifact
- * either. Ordinary code filenames and repo paths ("run.ts", "src/main") are
- * deliberately allowed here — rejecting those is the AI naming path's job and
- * is scored by the target-tier rules instead.
+ * either. Repo paths ("src/main") remain allowed; single filenames do not
+ * (DEV-276: a raw window title, a filename, a ticket description, or a JSON
+ * string is never a label).
  */
 export function rawLabelForm(value: string | null | undefined): string | null {
   const text = (value ?? '').trim()
@@ -238,6 +252,9 @@ export function rawLabelForm(value: string | null | undefined): string | null {
   if (RAW_FILE_EXTENSION_RE.test(text)) return 'file extension'
   if (UNDERSCORE_FILENAME_RE.test(text)) return 'underscore filename'
   if (looksLikeRawArtifactLabel(text)) return 'machine identifier'
+  if (BARE_FILENAME_RE.test(text)) return 'filename'
+  if (JSON_FRAGMENT_RE.test(text)) return 'JSON fragment'
+  if (BRACKETED_FRAGMENT_RE.test(text)) return 'bracketed title fragment'
   if (NOTIFICATION_COUNT_RE.test(text)) return 'notification count'
   if (text.split(/\s*\|\s*/).filter(Boolean).length >= 3) return 'browser-tab soup'
   if (TRAILING_BROWSER_RE.test(text)) return 'trailing browser name'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -420,6 +420,9 @@ export interface RebuildTimelineDayResult {
   relabeled: number
   attempted: number
   failed: number
+  /** Why the failed blocks could not be named (first distinct reason), in words
+   *  the person can act on — so the UI never reports a bare count (DEV-278). */
+  failureReason?: string | null
 }
 
 /** A progress tick streamed while a day is analyzed (DEV-270). `stage` names

--- a/tests/analyzeParallelProgress.test.ts
+++ b/tests/analyzeParallelProgress.test.ts
@@ -80,7 +80,7 @@ test('per-block naming runs in parallel and streams truthful progress', async ()
   db.close()
 })
 
-test('a partial naming failure is surfaced, not swallowed', async () => {
+test('a transient naming failure is retried and recovers (DEV-278)', async () => {
   const db = createProductionTestDatabase()
   seedFourBlocks(db)
   materializeTimelineDayProjection(db, TEST_DATE, null)
@@ -96,7 +96,28 @@ test('a partial naming failure is surfaced, not swallowed', async () => {
     onProgress: () => {},
   })
 
+  assert.equal(result.failures.length, 0, 'a one-off provider hiccup is retried, not reported as un-nameable')
+  assert.ok(result.relabeled >= 3, `every block ends up named; relabeled ${result.relabeled}`)
+  db.close()
+})
+
+test('a persistent naming failure is surfaced with its reason, not swallowed', async () => {
+  const db = createProductionTestDatabase()
+  seedFourBlocks(db)
+  materializeTimelineDayProjection(db, TEST_DATE, null)
+
+  const doomedStart = localMs(8)
+  const result = await analyzeTimelineDay(db, TEST_DATE, {
+    regroupPlan: async () => [],
+    blockInsight: async (block) => {
+      if (block.startTime === doomedStart) throw new Error('provider rejected the request')
+      return { label: `Named ${block.startTime}`, narrative: '' }
+    },
+    onProgress: () => {},
+  })
+
   assert.ok(result.failures.length >= 1, 'the failed block is reported, never silently dropped')
+  assert.match(result.failures[0], /provider rejected the request/, 'the reason travels with the failure')
   assert.ok(result.relabeled >= 1, 'the blocks that succeeded are still named')
   db.close()
 })

--- a/tests/analyzeParallelProgress.test.ts
+++ b/tests/analyzeParallelProgress.test.ts
@@ -101,6 +101,29 @@ test('a transient naming failure is retried and recovers (DEV-278)', async () =>
   db.close()
 })
 
+test('DEV-278: a day with a single relabel target still gets its retry', async () => {
+  const db = createProductionTestDatabase()
+  // One sitting → one relabel target. Its lone first-pass failure must not be
+  // mistaken for a provider outage.
+  insertSession(db, 'daylens tracker work', 8, 40, 'development', { bundleId: 'com.mitchellh.ghostty', name: 'Ghostty' })
+  materializeTimelineDayProjection(db, TEST_DATE, null)
+
+  let call = 0
+  const result = await analyzeTimelineDay(db, TEST_DATE, {
+    regroupPlan: async () => [],
+    blockInsight: async (block) => {
+      call++
+      if (call === 1) throw new Error('provider hiccup')
+      return { label: `Named ${block.startTime}`, narrative: '' }
+    },
+    onProgress: () => {},
+  })
+
+  assert.equal(result.failures.length, 0, 'the lone transient failure is retried, not reported')
+  assert.ok(result.relabeled >= 1, 'the block ends up named')
+  db.close()
+})
+
 test('a persistent naming failure is surfaced with its reason, not swallowed', async () => {
   const db = createProductionTestDatabase()
   seedFourBlocks(db)

--- a/tests/labelVoice.test.ts
+++ b/tests/labelVoice.test.ts
@@ -78,6 +78,7 @@ test('no-raw-artifact-forms names the machine form it rejects', () => {
   assert.equal(rawLabelForm('Wants to run AskUserQuestion: {"questions":[…'), 'JSON fragment')
   assert.equal(rawLabelForm('[Week 1]'), 'bracketed title fragment')
   assert.equal(rawLabelForm('Sprint planning: retro notes'), null)
+  assert.equal(rawLabelForm('Reviewed the "Q3 Roadmap": key priorities'), null)
   assert.equal(rawLabelForm('Version 1.0.45 release notes'), null)
   assert.equal(rawLabelForm('Reviewed the quarterly report'), null)
   assert.ok(failedRules('(3) Inbox').includes('no-raw-artifact-forms'))

--- a/tests/labelVoice.test.ts
+++ b/tests/labelVoice.test.ts
@@ -68,10 +68,17 @@ test('no-raw-artifact-forms names the machine form it rejects', () => {
   assert.equal(rawLabelForm('Reviewed the FY2026 report'), null)
   assert.equal(rawLabelForm('W2 Reading | Intro to ML | Perusall'), 'browser-tab soup')
   assert.equal(rawLabelForm('Quarterly plan - Google Chrome'), 'trailing browser name')
-  // Ordinary code filenames stay allowed: rejecting those is the AI naming
-  // path's job, scored by the target tier instead.
+  // DEV-276: a filename of any kind is never a label — including ordinary
+  // code/text filenames an earlier design allowed. Repo paths stay allowed.
+  assert.equal(rawLabelForm('handoff.md'), 'filename')
+  assert.equal(rawLabelForm('run.ts'), 'filename')
   assert.equal(rawLabelForm('timeline-eval/run.ts'), null)
-  assert.equal(rawLabelForm('run.ts'), null)
+  // DEV-276: JSON and bracketed tab-title fragments are machine forms.
+  assert.equal(rawLabelForm('{"questions":[{"header":"Scope"}]}'), 'JSON fragment')
+  assert.equal(rawLabelForm('Wants to run AskUserQuestion: {"questions":[…'), 'JSON fragment')
+  assert.equal(rawLabelForm('[Week 1]'), 'bracketed title fragment')
+  assert.equal(rawLabelForm('Sprint planning: retro notes'), null)
+  assert.equal(rawLabelForm('Version 1.0.45 release notes'), null)
   assert.equal(rawLabelForm('Reviewed the quarterly report'), null)
   assert.ok(failedRules('(3) Inbox').includes('no-raw-artifact-forms'))
 })

--- a/tests/labelVoiceEnforcement.test.ts
+++ b/tests/labelVoiceEnforcement.test.ts
@@ -1,0 +1,103 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import Database from 'better-sqlite3'
+import type { AppCategory } from '../src/shared/types.ts'
+import { createProductionTestDatabase } from './support/testDatabase.ts'
+import { writeAIBlockLabel } from '../src/main/db/queries.ts'
+import { rawLabelForm } from '../src/shared/labelVoice.ts'
+import { materializeTimelineDayProjection } from '../src/main/core/query/projections.ts'
+
+// DEV-276: a raw window title, a filename, a ticket description, or a JSON
+// string is never a label. The label chooser enforces the voice invariants on
+// every candidate (and verbatim-title rejection on interpreted ones), so the
+// July 22 shapes — "handoff.md", "[Week 1]", a whole pasted ticket, a JSON
+// blob stored as an "ai" label — can never surface as a block's name.
+
+const TEST_DATE = '2026-04-22'
+
+function localMs(hour: number, minute = 0): number {
+  return new Date(2026, 3, 22, hour, minute, 0, 0).getTime()
+}
+
+function insertSession(
+  db: Database.Database,
+  title: string,
+  startHour: number,
+  durationMinutes: number,
+  category: AppCategory,
+  app: { bundleId: string; name: string },
+): void {
+  const startTime = localMs(startHour)
+  db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec,
+      category, is_focused, window_title, raw_app_name, capture_source, capture_version
+    ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, 'test', 1)
+  `).run(app.bundleId, app.name, startTime, startTime + durationMinutes * 60_000, durationMinutes * 60, category, title, app.name)
+}
+
+test('a filename window title never becomes the block label', () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, 'handoff.md', 9, 90, 'development', { bundleId: 'com.exafunction.windsurf', name: 'Windsurf' })
+
+  const blocks = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  assert.ok(blocks.length >= 1)
+  for (const block of blocks) {
+    assert.notEqual(block.label.current, 'handoff.md', 'the filename window title is evidence, never the label')
+    assert.equal(rawLabelForm(block.label.current), null,
+      `label "${block.label.current}" carries a raw machine form`)
+  }
+  db.close()
+})
+
+test('garbage persisted as an "ai" label is re-gated on read and never surfaces', () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, 'DEV-270 Block detail panel summary', 9, 90, 'development', { bundleId: 'com.todesktop.230313mzl4w4u92', name: 'Cursor' })
+  const analyzed = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  assert.ok(analyzed.length >= 1)
+
+  // The July 22 shapes, written straight into the ai-label store.
+  const ticketDescription = 'DEV-270 Block detail panel summary is not a collect and accurate representation of where the user actually spent time on each block and the recap is confidently wrong about the day'
+  writeAIBlockLabel(db, { blockId: analyzed[0].id, label: ticketDescription })
+
+  const reread = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  for (const block of reread) {
+    assert.notEqual(block.label.current, ticketDescription, 'a pasted ticket description never surfaces as a label')
+    assert.ok(block.label.current.length <= 90, `label stays bounded; got ${block.label.current.length} chars`)
+  }
+  db.close()
+})
+
+test('a JSON string persisted as an "ai" label never surfaces', () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, 'Claude Code session', 9, 90, 'development', { bundleId: 'com.mitchellh.ghostty', name: 'Ghostty' })
+  const analyzed = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  assert.ok(analyzed.length >= 1)
+
+  const jsonLabel = 'Wants to run AskUserQuestion: {"questions":[{"header":"Scope"}]}'
+  writeAIBlockLabel(db, { blockId: analyzed[0].id, label: jsonLabel })
+
+  const reread = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  for (const block of reread) {
+    assert.notEqual(block.label.current, jsonLabel)
+    assert.equal(rawLabelForm(block.label.current), null,
+      `label "${block.label.current}" carries a raw machine form`)
+  }
+  db.close()
+})
+
+test('a verbatim captured window title never becomes an interpreted label', () => {
+  const db = createProductionTestDatabase()
+  // "Cursor Agents" is the literal window title; the AI store echoes it.
+  insertSession(db, 'Cursor Agents', 9, 90, 'development', { bundleId: 'com.todesktop.230313mzl4w4u92', name: 'Cursor' })
+  const analyzed = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  assert.ok(analyzed.length >= 1)
+  writeAIBlockLabel(db, { blockId: analyzed[0].id, label: 'Cursor Agents' })
+
+  const reread = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  for (const block of reread) {
+    assert.notEqual(block.label.current, 'Cursor Agents',
+      'a captured window title is evidence inside the block, never its verbatim label')
+  }
+  db.close()
+})


### PR DESCRIPTION
Stacked on #254 (Phase 1). Linear: DEV-276 (Urgent), DEV-278.

## DEV-276 — Block labels print the raw window title instead of naming the work

The heart of the bug: when the model's label failed the (single, narrow) raw-artifact check, the AI path silently substituted the deterministic evidence label — often a naturalized window/artifact title like "handoff.md" or "[Week 1]" — and persisted *that* as an "ai" label. Meanwhile the label chooser only scored the label-voice rules; it never enforced them.

Now:

- **`rawLabelForm` covers the July 22 shapes**: bare filenames of any kind (code filenames included — this supersedes the earlier design that allowed them; recorded in `docs/specs/label-voice.md`), JSON fragments, and bracketed title fragments, alongside the existing URL/domain/date/SCREAMING/tab-soup forms.
- **`finalizedLabelForBlock` enforces the rules** on every candidate except the person's own override: invariant failures reject any candidate; interpreted candidates (AI label, artifact title) are additionally rejected for reproducing a captured title verbatim or being a bare app name; even the fallback floor may not be a verbatim title.
- **Two deterministic fallbacks keep rejected blocks specific instead of generic**: the project segment of an editor window title ("checkout.ts — acme-portal" → "Working on acme-portal"), and a wrapped descriptive title ("Working on daylens timeline segmentation pull request") when the captured title is a multi-word description rather than a fragment (fragments like "Cursor Agents" fall to the honest category floor). The 3-word fragment/description cutoff is a judgment call — flag it in review if you want a different line.
- **The AI labeler validates its own output** against the same rules and retries once with the violation named in the prompt; if the retry also fails, the voice-gated deterministic name stands and the block remains a re-analysis target.

Regression tests (`tests/labelVoiceEnforcement.test.ts`) pin the exact July 22 shapes: a filename window title, a pasted ticket description stored as an "ai" label, a JSON string, and a verbatim window title — none can surface as a label anymore, even when already persisted in the database.

Getting to the *ideal* labels ("Studying machine learning", "Developing Daylens") still requires the AI naming pass to run — which Phase 1's DEV-279 fix (surfaced provider errors) and this phase's DEV-278 fix (retry) make far more likely to succeed. Enforcement guarantees the floor is never a raw machine form.

## DEV-278 — Re-analyze relabels part of the day, gives up on the rest, never asks

- A block whose naming call fails is **retried once** before being reported (a lone 429 or timeout under 4-way concurrency was exactly the "6 relabeled, 3 failed" signature). If every call failed, the provider is down and the retry is skipped rather than doubling the wait.
- The outcome message **names the reason** and the recovery: "Re-labeled 6 blocks · 3 couldn't be named — Block insight timed out. Re-analyze retries them." (`failureReason` added to `RebuildTimelineDayResult`.)
- Blocks that stay unnamed keep honest floor labels, which the **existing answer-or-skip clarification cards already target** (`detectDayClarifications` keys on exactly these labels) — so the questions the issue asked for now appear for un-nameable blocks.

## Verification

- `npm run typecheck` / `lint` — clean; `npm test` — 322 files, 2,151 pass, 0 fail
- `npm run timeline:eval -- --strict` — green; target-tier label-voice misses on the fixtures dropped from 4 to 2 (both pre-existing one-word comm labels)
- `verify:synthetic-day`, `verify:ai-turn`, `contract:check` — green
- Doc edit: `docs/specs/label-voice.md` (enforcement paragraph; `no-raw-artifact-forms` extended with filenames/JSON/bracketed fragments per DEV-276)

`verify:real-day` still needs a local run against an accepted snapshot before acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Timeline labels now avoid filenames, JSON fragments, bracketed titles, and other machine-generated text.
  - Work blocks use clearer, human-readable labels with safer deterministic fallbacks when AI suggestions are unsuitable.
  - Failed relabeling attempts now receive an automatic retry when possible.

- **Bug Fixes**
  - Rejected or previously stored invalid labels are filtered before appearing in the timeline.

- **User Experience**
  - Relabeling failures now display specific reasons and indicate that re-analysis will retry failed items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->