### PR TITLE
Phase 3: the accurate day — same-work merging, grounded summaries, honest slabs (DEV-280/281/285)

### DIFF
--- a/shared/app-normalization.v1.json
+++ b/shared/app-normalization.v1.json
@@ -13,6 +13,8 @@
     "com.operasoftware.Opera": "opera", "opera.exe": "opera",
     "com.vivaldi.Vivaldi": "vivaldi", "vivaldi.exe": "vivaldi",
     "cursor": "cursor", "cursor.exe": "cursor",
+    "com.exafunction.windsurf": "windsurf", "windsurf": "windsurf",
+    "windsurf.exe": "windsurf",
     "com.microsoft.VSCode": "vscode", "code.exe": "vscode",
     "com.apple.dt.Xcode": "xcode", "xcode.exe": "xcode",
     "com.apple.Terminal": "terminal",
@@ -128,6 +130,7 @@
     "vivaldi": { "displayName": "Vivaldi", "defaultCategory": "browsing", "capabilities": ["browser"] },
 
     "cursor": { "displayName": "Cursor", "defaultCategory": "development" },
+    "windsurf": { "displayName": "Windsurf", "defaultCategory": "development" },
     "vscode": { "displayName": "Visual Studio Code", "defaultCategory": "development" },
     "xcode": { "displayName": "Xcode", "defaultCategory": "development" },
     "terminal": { "displayName": "Terminal", "defaultCategory": "development" },

--- a/src/main/services/analyzeDay.ts
+++ b/src/main/services/analyzeDay.ts
@@ -123,7 +123,23 @@ function applyAIInsightToTimelineBlock(
   return true
 }
 
-// Runs of consecutive blocks that carry the same label and belong together:
+// Two labels name the same work when they are equal, or when one is the
+// leading phrase of the other — "Preparing handoff" beside "Preparing handoff
+// documentation and reviewing tasks" is one activity split by the engine
+// (DEV-281). The WHOLE shorter label must be the prefix, at least two words
+// long, so "Reviewing tasks" never joins "Reviewing email".
+export function labelsNameSameWork(left: string, right: string): boolean {
+  const tokens = (value: string): string[] =>
+    value.toLowerCase().replace(/[^a-z0-9\s]+/g, ' ').split(/\s+/).filter(Boolean)
+  const a = tokens(left)
+  const b = tokens(right)
+  if (a.length === 0 || b.length === 0) return false
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a]
+  if (shorter.length < 2 && shorter.length !== longer.length) return false
+  return shorter.every((token, index) => longer[index] === token)
+}
+
+// Runs of consecutive blocks that name the same work and belong together:
 // non-live, non-provisional, not renamed by the person, separated by no real
 // absence and no explicit cut. Adjacency is judged over the day's full block
 // sequence — a differently-labeled or ineligible block between two matches
@@ -152,7 +168,7 @@ export function sameLabelFragmentRuns(
     }
     const previous = run[run.length - 1]
     const joinable = previous
-      && labelKey(previous) === labelKey(block)
+      && (labelKey(previous) === labelKey(block) || labelsNameSameWork(previous.label.current, block.label.current))
       && !cuts.some((cut) => cut >= previous.endTime && cut <= block.startTime)
       && !absenceSpannedBy([...run.flatMap((member) => member.sessions), ...block.sessions])
     if (joinable) {

--- a/src/renderer/lib/apps.ts
+++ b/src/renderer/lib/apps.ts
@@ -58,9 +58,24 @@ export function normalizeAppNameKey(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, '')
 }
 
+// A reverse-DNS bundle id sometimes reaches display when no catalog entry or
+// OS name exists ("com.exafunction.windsurf"). A person should read the app's
+// name, not its identifier: use the last meaningful segment.
+const REVERSE_DNS_RE = /^(?:com|org|net|io|co|dev|app|ai|id)\.[a-z0-9.-]+$/i
+const GENERIC_BUNDLE_TAIL = new Set(['app', 'desktop', 'mac', 'macos', 'client', 'electron'])
+
+function bundleIdDisplayStem(value: string): string {
+  const segments = value.split('.').filter(Boolean)
+  for (let index = segments.length - 1; index >= 1; index--) {
+    if (!GENERIC_BUNDLE_TAIL.has(segments[index].toLowerCase())) return segments[index]
+  }
+  return segments[segments.length - 1] ?? value
+}
+
 export function formatDisplayAppName(rawName: string): string {
   const baseName = (rawName.split(/[\\/]/).pop() ?? rawName).trim()
-  const stripped = baseName.replace(/\.(exe|app|lnk)$/i, '')
+  const debundled = REVERSE_DNS_RE.test(baseName) ? bundleIdDisplayStem(baseName) : baseName
+  const stripped = debundled.replace(/\.(exe|app|lnk)$/i, '')
   const spaced = stripped
     .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
     .replace(/[_-]+/g, ' ')

--- a/src/renderer/lib/timelineText.ts
+++ b/src/renderer/lib/timelineText.ts
@@ -1,9 +1,9 @@
 import type { AppCategory, WorkContextBlock } from '@shared/types'
 import { sanitizeForModel } from '@shared/aiSanitize'
 import { blockActiveSeconds } from '@shared/blockDuration'
-import { isArtifactCompatibleWithBlockCategory, looksLikeRawArtifactLabel, naturalizeLabel } from '@shared/blockLabel'
+import { isArtifactCompatibleWithBlockCategory, naturalizeLabel } from '@shared/blockLabel'
+import { rawLabelForm } from '@shared/labelVoice'
 import { activityCategoryLabel } from '@shared/activityCategories'
-import { formatDisplayAppName } from './apps'
 import { formatDuration } from './format'
 
 const PAGE_ARTIFACT_LABEL_CATEGORIES: ReadonlySet<AppCategory> = new Set([
@@ -65,10 +65,12 @@ function artifactPhraseForCategory(
   return artifactTitle
 }
 
-/** Deterministic renderer fallback only. Persisted main-process narrative wins. */
+/** Deterministic renderer fallback only. Persisted main-process narrative wins.
+ *  It describes the ACTIVITY, never the tools (DEV-280): the subject when a
+ *  clean artifact names one, the category mix otherwise — no "mostly in
+ *  Cursor" clauses, no window titles. */
 export function blockShortSummary(block: WorkContextBlock): string {
   const duration = formatDuration(blockActiveSeconds(block))
-  const allApps = block.topApps.filter((app) => app.category !== 'system' && app.category !== 'uncategorized')
   const sites = pageArtifactLabelAllowed(block)
     ? block.websites.slice(0, 2).map((site) => shortDomainLabel(site.domain))
     : []
@@ -78,33 +80,26 @@ export function blockShortSummary(block: WorkContextBlock): string {
   ))
   const rawArtifact = topArtifact ? safeTimelineText(topArtifact.displayTitle.trim()) : null
   const cleanArtifact = rawArtifact ? naturalizeLabel(rawArtifact) || rawArtifact : null
-  const naturalizedArtifact = cleanArtifact && !looksLikeRawArtifactLabel(cleanArtifact) ? cleanArtifact : null
+  const naturalizedArtifact = cleanArtifact && !rawLabelForm(cleanArtifact) ? cleanArtifact : null
 
-  const orderedApps = (() => {
-    if (!topArtifact) return allApps
-    if (topArtifact.artifactType === 'page') {
-      const browsers = allApps.filter((app) => app.isBrowser)
-      return browsers.length > 0 ? browsers : allApps
-    }
-    if (topArtifact.ownerBundleId) {
-      const owners = allApps.filter((app) => app.bundleId === topArtifact.ownerBundleId)
-      return owners.length > 0 ? owners : allApps
-    }
-    return allApps
-  })()
-  const appNames = orderedApps.slice(0, 2).map((app) => formatDisplayAppName(app.appName))
-  const primaryApp = appNames[0] ?? null
-  const secondaryApp = appNames[1] ?? null
   const { verb, noun } = categoryVerbPhrase(block.dominantCategory)
-  const supportingClause = secondaryApp
-    ? `, mostly in ${primaryApp} with ${secondaryApp} as supporting context`
-    : primaryApp ? `, mostly in ${primaryApp}` : ''
+  // The other real activities inside the block, so a long mixed block is not
+  // summarized by its top category alone (the "ignores my morning" failure).
+  const otherActivities = Object.entries(block.categoryDistribution ?? {})
+    .filter((entry): entry is [AppCategory, number] =>
+      typeof entry[1] === 'number' && entry[1] >= 60
+      && entry[0] !== block.dominantCategory
+      && entry[0] !== 'system' && entry[0] !== 'uncategorized')
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 2)
+    .map(([category]) => activityCategoryLabel(category).toLowerCase())
+  const alongside = otherActivities.length > 0
+    ? `, with ${otherActivities.join(' and ')} alongside`
+    : ''
 
   if (naturalizedArtifact) {
-    return `Spent ${duration} ${verb} ${artifactPhraseForCategory(naturalizedArtifact, topArtifact!.artifactType, block.dominantCategory)}${supportingClause}.`
+    return `Spent ${duration} ${verb} ${artifactPhraseForCategory(naturalizedArtifact, topArtifact!.artifactType, block.dominantCategory)}${alongside}.`
   }
-  if (primaryApp && sites.length > 0) return `Spent ${duration} ${verb} ${noun} across ${sites.join(' and ')}${supportingClause}.`
-  if (primaryApp) return `Spent ${duration} ${verb} ${noun}${supportingClause}.`
-  if (sites.length > 0) return `Spent ${duration} ${verb} ${noun} across ${sites.join(' and ')}.`
-  return `Spent ${duration} on ${activityCategoryLabel(block.dominantCategory).toLowerCase()}.`
+  if (sites.length > 0) return `Spent ${duration} ${verb} ${noun} across ${sites.join(' and ')}${alongside}.`
+  return `Spent ${duration} ${verb} ${noun}${alongside}.`
 }

--- a/src/renderer/views/Timeline.tsx
+++ b/src/renderer/views/Timeline.tsx
@@ -575,25 +575,34 @@ function CalendarDayTrack({
         const ghostHeight = Math.max(20, topFor(meeting.endMs) - top)
         const confirmed = meeting.attendance === 'matched'
         const declined = meeting.marked === 'skipped' || meeting.marked === 'unrelated'
+        // Calendar-and-blocks spec: when tracked activity overlaps the event,
+        // the blocks are the spine and the event is faint context beside them
+        // — never a filled slab competing with the real work (DEV-285). Only
+        // an event over genuinely empty time keeps the attended hatch, and it
+        // says plainly that nothing was captured.
+        const overlapsActivity = blocks.some((block) =>
+          Math.min(block.endTime, meeting.endMs) - Math.max(block.startTime, meeting.startMs) > 0)
         // Outlined ghost card (decided Jul 22, DEV-264): a real card spanning
         // the event's scheduled duration — hairline border, near-transparent
         // fill. Dashed = unconfirmed plan; solid + check = you attended;
         // struck title, fainter = you said you didn't. "Planned" next to the
         // solid "happened" blocks — never activity, never counted time.
         const stateLine = confirmed
-          ? '✓ Attended'
+          ? (overlapsActivity ? '✓ Attended' : '✓ Attended · nothing captured')
           : meeting.marked === 'skipped'
             ? 'Skipped'
             : meeting.marked === 'moved'
               ? 'Moved'
               : meeting.marked === 'unrelated'
                 ? 'Unrelated'
-                : 'Scheduled'
+                : (overlapsActivity ? 'Scheduled' : 'Scheduled · nothing captured')
         return (
           <div
             key={`scheduled:${meeting.startMs}:${meeting.title}`}
             title={confirmed
-              ? `${meeting.title} — you marked this attended`
+              ? (overlapsActivity
+                ? `${meeting.title} — you marked this attended; the tracked blocks beside it are the observed activity`
+                : `${meeting.title} — you marked this attended; no screen activity was captured in this window`)
               : `${meeting.title} — on your calendar; no observed activity supports that you attended`}
             onClick={onScheduledMeetingClick ? (event) => onScheduledMeetingClick(meeting, event) : undefined}
             style={{
@@ -610,8 +619,9 @@ function CalendarDayTrack({
               // (still hairline) edge to exist against their faint fill.
               border: confirmed ? '1px solid rgba(127, 127, 127, 0.35)' : '1px dashed rgba(127, 127, 127, 0.35)',
               // Attended reads as "consumed": the Apple-Calendar diagonal
-              // hatch, unmistakable at a glance without adding any words.
-              background: confirmed
+              // hatch — but only over empty time. Over tracked activity the
+              // blocks carry the story and the event stays a quiet outline.
+              background: confirmed && !overlapsActivity
                 ? 'repeating-linear-gradient(-45deg, rgba(127, 127, 127, 0.13) 0 3px, transparent 3px 8px)'
                 : 'rgba(127, 127, 127, 0.05)',
               padding: '3px 9px',
@@ -2020,12 +2030,18 @@ function BlockDetailInspector({
   // The category appears once (DEV-272). A duration chip that merely restates
   // the type tag ("Browsing" under a "Browsing" tag) is dropped; only a genuine
   // split across two-plus categories earns its own chips.
-  const categorySplitAll = Object.entries(block.categoryDistribution ?? {})
+  const categoryEntries = Object.entries(block.categoryDistribution ?? {})
     .filter((entry): entry is [AppCategory, number] => typeof entry[1] === 'number' && entry[1] >= 60)
     .sort((a, b) => b[1] - a[1])
+  const categorySplitAll: Array<[string, number]> = categoryEntries
     .slice(0, 3)
+    .map(([category, seconds]) => [activityCategoryLabel(category), seconds])
+  // The chips must reconcile with the block (DEV-280): what the top three
+  // don't cover is shown, not silently dropped.
+  const categoryResidual = categoryEntries.slice(3).reduce((sum, [, seconds]) => sum + seconds, 0)
+  if (categoryResidual >= 60) categorySplitAll.push(['Everything else', categoryResidual])
   const categorySplit = categorySplitAll.length <= 1
-    ? categorySplitAll.filter(([category]) => activityCategoryLabel(category) !== typeTag)
+    ? categorySplitAll.filter(([label]) => label !== typeTag)
     : categorySplitAll
   // The type tag is dropped when it only echoes the block's own title (a
   // "Browsing" block titled "Browsing"), so the category is stated once, not
@@ -2196,6 +2212,12 @@ function BlockDetailInspector({
             </div>
             <div style={{ fontSize: 12.5, color: 'var(--color-text-secondary)', marginTop: 3 }}>
               {formatFullDate(payload.date)} ⋅ {formatClockTime(block.startTime)} – {formatClockTime(block.endTime)} · {formatDuration(blockDisplayedSpanSeconds(block))}
+              {/* When the block spans lulls, the active number the chips and
+                  summary reconcile against is stated, not left to arithmetic
+                  the person cannot do (DEV-280). */}
+              {blockDisplayedSpanSeconds(block) - blockActiveSeconds(block) >= 60 && (
+                <> · {formatDuration(blockActiveSeconds(block))} active</>
+              )}
             </div>
           </div>
           <button type="button" aria-label="Back to day summary" title="Back to day summary" onClick={onClose} style={{ ...iconButtonStyle(), flexShrink: 0, marginTop: -3, marginRight: -3 }} {...iconHover}>
@@ -2230,8 +2252,8 @@ function BlockDetailInspector({
                   {typeTag}
                 </span>
               )}
-              {categorySplit.map(([category, seconds]) => (
-                <span key={category} style={{
+              {categorySplit.map(([label, seconds]) => (
+                <span key={label} style={{
                   padding: '3px 9px',
                   borderRadius: 999,
                   fontSize: 11,
@@ -2239,7 +2261,7 @@ function BlockDetailInspector({
                   color: 'var(--color-text-tertiary)',
                   border: '1px solid var(--color-border-ghost)',
                 }}>
-                  {activityCategoryLabel(category)} · {formatDuration(seconds)}
+                  {label} · {formatDuration(seconds)}
                 </span>
               ))}
             </div>

--- a/tests/appIdentityBranding.test.ts
+++ b/tests/appIdentityBranding.test.ts
@@ -8,6 +8,10 @@ test('mac-specific app aliases resolve to the right canonical app identities', (
   assert.equal(resolveCanonicalApp('com.TickTick.task.mac', 'TickTick').displayName, 'TickTick')
   assert.equal(resolveCanonicalApp('com.openai.atlas', 'ChatGPT Atlas').displayName, 'ChatGPT')
   assert.equal(resolveCanonicalApp('ai.perplexity.comet', 'Comet').displayName, 'Comet')
+  // Windsurf's rebranded bundle reports "Devin" as its OS name (DEV-280): the
+  // bundle id is the truth and must win over the process name.
+  assert.equal(resolveCanonicalApp('com.exafunction.windsurf', 'Devin').displayName, 'Windsurf')
+  assert.equal(resolveCanonicalApp('com.exafunction.windsurf', '').displayName, 'Windsurf')
   assert.equal(resolveCanonicalApp('com.apple.systempreferences', 'System Settings').displayName, 'System Settings')
   assert.equal(resolveCanonicalApp('com.daylens.app.dev', 'Daylens').displayName, 'Daylens')
 })

--- a/tests/blockShortSummary.test.ts
+++ b/tests/blockShortSummary.test.ts
@@ -17,6 +17,7 @@ function makeBlock(overrides: Partial<{
   category: AppCategory
   appName: string | null
   artifactTitle: string | null
+  artifactType: string
   domain: string | null
 }>): WorkContextBlock {
   const startTime = Date.UTC(2026, 3, 23, 9, 0, 0)
@@ -52,7 +53,7 @@ function makeBlock(overrides: Partial<{
     topArtifacts: overrides.artifactTitle
       ? [{
           displayTitle: overrides.artifactTitle,
-          artifactType: 'page',
+          artifactType: overrides.artifactType ?? 'page',
           totalSeconds: 600,
           ownerBundleId: null,
         }]
@@ -82,7 +83,31 @@ test('no summary ever doubles its verb ("Spent Xm spent on…")', () => {
   }
 })
 
-test('the ChatGPT shape reads as one clean sentence', () => {
-  const summary = blockShortSummary(makeBlock({ category: 'aiTools', appName: 'ChatGPT', artifactTitle: 'ChatGPT' }))
-  assert.equal(summary, 'Spent 37m working with ChatGPT, mostly in ChatGPT.')
+test('the summary describes the activity, never the hosting tool (DEV-280)', () => {
+  // The July 22 failure: "Spent 7h 28m editing Cursor Agents, mostly in
+  // Cursor" — a window title as the object and the tool as the location.
+  for (const category of ALL_CATEGORIES) {
+    const summary = blockShortSummary(makeBlock({ category, appName: 'Cursor', artifactTitle: null }))
+    assert.doesNotMatch(summary, /mostly in|supporting context/i, `category "${category}" names the tool: "${summary}"`)
+    assert.doesNotMatch(summary, /\bCursor\b/, `category "${category}" names the app: "${summary}"`)
+  }
+})
+
+test('a clean subject is kept; a raw filename subject is dropped', () => {
+  const withSubject = blockShortSummary(makeBlock({ category: 'research', artifactTitle: 'Intro to Machine Learning' }))
+  assert.equal(withSubject, 'Spent 37m researching Intro to Machine Learning.')
+  const withRawSubject = blockShortSummary(makeBlock({ category: 'development', artifactTitle: 'handoff.md', artifactType: 'document' }))
+  assert.doesNotMatch(withRawSubject, /handoff\.md/, `raw filename must not surface: "${withRawSubject}"`)
+})
+
+test('a mixed block names the other activities alongside the dominant one', () => {
+  const block = makeBlock({ category: 'development' })
+  ;(block as { categoryDistribution: Partial<Record<AppCategory, number>> }).categoryDistribution = {
+    development: 5 * 3600,
+    research: 45 * 60,
+    writing: 35 * 60,
+  }
+  const summary = blockShortSummary(block)
+  assert.match(summary, /research/i)
+  assert.match(summary, /writing/i)
 })

--- a/tests/sameLabelFragmentMerge.test.ts
+++ b/tests/sameLabelFragmentMerge.test.ts
@@ -160,6 +160,21 @@ test('runs break at different labels, renames, provisional blocks, and user cuts
   ], []).length, 0)
 })
 
+test('DEV-281: adjacent blocks naming the same work join even when one label is longer', () => {
+  const runs = sameLabelFragmentRuns([
+    fakeBlock({ id: 'a', startH: 16, endH: 17, label: 'Preparing handoff documentation and reviewing tasks' }),
+    fakeBlock({ id: 'b', startH: 17, endH: 18, label: 'Preparing handoff' }),
+  ], [])
+  assert.equal(runs.length, 1)
+  assert.equal(runs[0].length, 2)
+
+  // A shared first word alone is NOT the same work.
+  assert.equal(sameLabelFragmentRuns([
+    fakeBlock({ id: 'a', startH: 9, endH: 10, label: 'Reviewing tasks' }),
+    fakeBlock({ id: 'b', startH: 10, endH: 11, label: 'Reviewing email' }),
+  ], []).length, 0)
+})
+
 test('a real absence between same-label blocks breaks the run', () => {
   const a = fakeBlock({ id: 'a', startH: 9, endH: 10, label: 'Working on Cursor Agents' })
   // Sessions end at 10:00; the next block's sessions start at 11:00 — a real


### PR DESCRIPTION
Stacked on #255 (Phase 2). Linear: DEV-281, DEV-280, DEV-285.

## DEV-281 — Similar and adjacent blocks are not merged

The deterministic fragment-repair pass (`sameLabelFragmentRuns`) only joined blocks with *character-identical* labels. It now joins adjacent blocks whose labels name the same work: one label is the leading phrase of the other, the whole shorter label must be the prefix and at least two words — so "Preparing handoff" merges with "Preparing handoff documentation and reviewing tasks" (your 4:01–6:18 example), while "Reviewing tasks" never joins "Reviewing email". All existing guards hold: a real absence, a user cut, a rename, or a provisional block still breaks the run, and the merge rides the durable boundary-correction path.

The broader "whole Daylens afternoon in one block" case (differently-named blocks that are one intent) is the AI regroup's job, which runs in the same Analyze pass — Phase 2's relabel retry and Phase 1's visible provider errors make that pass actually complete now.

## DEV-280 — Summaries describe the wrong work and name tools

- **The deterministic block summary describes the activity, never the tools.** "Spent 7h 28m editing Cursor Agents, mostly in Cursor" is structurally impossible: the "mostly in <app>" clause is gone, a raw-form subject (filename, window title) is dropped, and a mixed block names its other real activities ("…, with research and writing alongside") so a long block is not summarized by its top category alone.
- **The numbers reconcile.** Category chips gain an "Everything else" entry for whatever the top three didn't cover, and a block that spans lulls states its active total next to its clock range ("9:00 – 6:27 · 9h 27m · 6h 20m active") — the chips sum to the active number that is now on screen.
- **Windsurf is Windsurf.** `com.exafunction.windsurf` joins the app catalog, so the OS-reported name "Devin" no longer wins; and any reverse-DNS bundle id that reaches a display path renders as its app-name stem, never "Com.exafunction.windsurf". Deliberate trade-off: the `app_normalization` component version is **not** bumped, because a bump triggers `resetDerivedState` — the destructive wipe of every analyzed day flagged on DEV-277. New capture resolves correctly at once; existing rows converge on natural rebuilds (which now carry labels forward, Phase 1).

## DEV-285 — Real morning study shows as an empty hatched slab

Per the accepted calendar-and-blocks spec ("the block stands as the work it was; the event is faint scheduled context"): a scheduled event whose window overlaps tracked blocks renders as a quiet outline beside them — the attended hatch fill only ever covers genuinely empty time. And an event over empty time now says so plainly: "✓ Attended · nothing captured" / "Scheduled · nothing captured" in the card and a full sentence in the tooltip, instead of a large consumed-looking slab.

## Verification

- `npm run typecheck` / `lint` — clean; `npm test` — 322 files, 2,154 pass, 0 fail
- `npm run timeline:eval -- --strict`, `verify:synthetic-day` — green
- New/updated tests: same-work prefix joining + the "Reviewing tasks/Reviewing email" non-join, the tool-naming ban across every category, subject keeping/dropping, mixed-block alongside clause, Windsurf bundle attribution

`verify:real-day` still needs a local run against an accepted snapshot before acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)