### PR TITLE
Phase 4: calm quick-check, unambiguous columns (DEV-284/286)

### DIFF
--- a/src/main/services/dayClarifications.ts
+++ b/src/main/services/dayClarifications.ts
@@ -114,6 +114,13 @@ export function detectDayClarifications(
     if (meeting.marked || meeting.attendance === 'matched') continue
     const minutes = (meeting.endMs - meeting.startMs) / 60_000
     if (minutes < MIN_MEETING_MINUTES) continue
+    // Never interrogate a window the person clearly worked through (DEV-284).
+    // Tracked blocks covering most of the scheduled span already tell the
+    // day's story; the answer would not materially change the account
+    // (day-recap-and-analysis spec §The clarification contract).
+    const coveredMs = payload.blocks.reduce((sum, block) => sum
+      + Math.max(0, Math.min(block.endTime, meeting.endMs) - Math.max(block.startTime, meeting.startMs)), 0)
+    if (coveredMs > (meeting.endMs - meeting.startMs) / 2) continue
     const eventKey = scheduledEventKey(Math.round((meeting.startMs - dayStartMs) / 60_000), meeting.title)
     const id = `${payload.date}:meeting:${eventKey}`
     if (skipped.has(id)) continue

--- a/src/renderer/views/Timeline.tsx
+++ b/src/renderer/views/Timeline.tsx
@@ -377,14 +377,31 @@ function CalendarBlockCard({
           }} />
         )}
       </div>
-      {/* Title + time only — the narrative lives in the detail panel (day
-          view) or the popover (week view), shown on click. Cards stay calm. */}
+      {/* Title + time on every card — the narrative lives in the detail panel
+          (day view) or the popover (week view), shown on click. A TALL card
+          additionally carries its one-line account, so hours of the day are
+          never a large empty rectangle (DEV-286); short cards stay calm. */}
       {showTime && (
         <div style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: compact ? 10 : 11, color: 'var(--color-text-tertiary)', marginTop: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
           <ClockGlyph size={compact ? 9 : 10} />
           <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
             {timeRange} · {formatDuration(blockDisplayedSpanSeconds(block))}
           </span>
+        </div>
+      )}
+      {!compact && !dimmed && height >= 110 && (
+        <div style={{
+          marginTop: 6,
+          fontSize: 11.5,
+          lineHeight: 1.5,
+          color: 'var(--color-text-secondary)',
+          display: '-webkit-box',
+          WebkitBoxOrient: 'vertical',
+          WebkitLineClamp: 3,
+          overflow: 'hidden',
+          overflowWrap: 'break-word',
+        }}>
+          {blockNarrative(block) ?? blockShortSummary(block)}
         </div>
       )}
       </div>
@@ -490,30 +507,40 @@ function CalendarDayTrack({
   const showNowLine = nowMinutes != null && nowMinutes >= trackStartMin && nowMinutes <= trackEndMin
   const hourCount = Math.max(0, bounds.endHour - bounds.startHour + 1)
 
-  // Google-Calendar lane layout: a block and an overlapping calendar event (or
-  // two overlapping blocks) share the track in side-by-side columns instead of
-  // stacking on top of each other. Lanes are assigned across blocks AND the
-  // unmatched scheduled-meeting outlines together so an event never buries a
-  // block. Edge insets: 4px outer margin, and a 6px gutter between columns.
+  // The columns have ONE meaning (calendar-and-blocks spec, DEV-286): blocks
+  // are the spine and always start at the left; scheduled events are quieter
+  // context in their own column on the right, only where they overlap tracked
+  // time. Blocks are a partition of the day and never overlap each other, so
+  // they never split among themselves; events may overlap other events and
+  // lane only against each other. Edge insets: 4px outer margin, 6px gutter.
   const unmatchedMeetings = compact ? [] : scheduledMeetings.filter((m) => m.matchedBlockId == null)
   const laneKeyForMeeting = (m: TimelineScheduledMeeting) => `m:${m.startMs}:${m.title}`
-  const laneInputs: { key: string; start: number; end: number }[] = [
-    ...unmatchedMeetings.map((m) => ({ key: laneKeyForMeeting(m), start: m.startMs, end: m.endMs })),
-    ...blocks.map((block) => ({
-      key: `b:${block.id}`,
-      start: block.startTime,
-      end: block.isLive && nowMs != null ? Math.max(block.endTime, nowMs) : block.endTime,
-    })),
-  ]
-  const lanePlacements = assignLanes(laneInputs)
-  const laneByKey = new Map(laneInputs.map((input, i) => [input.key, lanePlacements[i]]))
-  const laneGeometry = (key: string): { left: string; width: string } => {
-    const placement = laneByKey.get(key) ?? { lane: 0, lanes: 1 }
-    const columnPct = 100 / placement.lanes
-    const gutter = placement.lanes > 1 ? 6 : 8
+  const blockLayoutEnd = (block: WorkContextBlock): number =>
+    block.isLive && nowMs != null ? Math.max(block.endTime, nowMs) : block.endTime
+  const spansOverlap = (aStart: number, aEnd: number, bStart: number, bEnd: number): boolean =>
+    Math.min(aEnd, bEnd) - Math.max(aStart, bStart) > 0
+  // The event column's share of the track where an event sits beside a block.
+  const EVENT_COLUMN_PCT = 38
+  const eventLaneInputs = unmatchedMeetings.map((m) => ({ key: laneKeyForMeeting(m), start: m.startMs, end: m.endMs }))
+  const eventPlacements = assignLanes(eventLaneInputs)
+  const eventLaneByKey = new Map(eventLaneInputs.map((input, i) => [input.key, eventPlacements[i]]))
+  const blockGeometry = (block: WorkContextBlock): { left: string; width: string } => {
+    const besideEvent = unmatchedMeetings.some((m) =>
+      spansOverlap(block.startTime, blockLayoutEnd(block), m.startMs, m.endMs))
+    return besideEvent
+      ? { left: '4px', width: `calc(${100 - EVENT_COLUMN_PCT}% - 10px)` }
+      : { left: '4px', width: 'calc(100% - 8px)' }
+  }
+  const meetingGeometry = (meeting: TimelineScheduledMeeting): { left: string; width: string } => {
+    const placement = eventLaneByKey.get(laneKeyForMeeting(meeting)) ?? { lane: 0, lanes: 1 }
+    const besideBlock = blocks.some((block) =>
+      spansOverlap(block.startTime, blockLayoutEnd(block), meeting.startMs, meeting.endMs))
+    const regionLeftPct = besideBlock ? 100 - EVENT_COLUMN_PCT : 0
+    const regionWidthPct = besideBlock ? EVENT_COLUMN_PCT : 100
+    const columnPct = regionWidthPct / placement.lanes
     return {
-      left: `calc(${placement.lane * columnPct}% + 4px)`,
-      width: `calc(${columnPct}% - ${gutter}px)`,
+      left: `calc(${regionLeftPct + placement.lane * columnPct}% + ${besideBlock ? 0 : 4}px)`,
+      width: `calc(${columnPct}% - ${besideBlock || placement.lanes > 1 ? 6 : 8}px)`,
     }
   }
 
@@ -542,6 +569,12 @@ function CalendarDayTrack({
         const top = topFor(gap.startTime)
         const gapHeight = topFor(gap.endTime) - top
         if (gapHeight < 26) return null
+        // A scheduled event can span the same empty stretch ("Wind down for
+        // bed" over an idle evening). The caption keeps its own readable
+        // backdrop and sits above the event outline so the two never render
+        // as colliding text (DEV-286).
+        const overlapsEvent = unmatchedMeetings.some((m) =>
+          spansOverlap(gap.startTime, gap.endTime, m.startMs, m.endMs))
         return (
           <div
             key={`gap:${gap.startTime}`}
@@ -555,9 +588,20 @@ function CalendarDayTrack({
               alignItems: 'center',
               justifyContent: 'center',
               pointerEvents: 'none',
+              zIndex: 2,
             }}
           >
-            <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', whiteSpace: 'nowrap' }}>
+            <span style={{
+              fontSize: 11,
+              color: 'var(--color-text-tertiary)',
+              whiteSpace: 'nowrap',
+              ...(overlapsEvent ? {
+                background: 'var(--color-surface)',
+                border: '1px solid var(--color-border-ghost)',
+                borderRadius: 999,
+                padding: '2px 8px',
+              } : {}),
+            }}>
               {gap.label} · {formatDuration(Math.max(60, Math.round((gap.endTime - gap.startTime) / 1000)))}
             </span>
           </div>
@@ -613,7 +657,7 @@ function CalendarDayTrack({
               // them (the Apple/Google convention) — imperceptible on a lone
               // event, decisive in a stack.
               height: Math.max(18, ghostHeight - 2),
-              ...laneGeometry(laneKeyForMeeting(meeting)),
+              ...meetingGeometry(meeting),
               borderRadius: 5,
               // --color-border is transparent by design; events need a real
               // (still hairline) edge to exist against their faint fill.
@@ -677,7 +721,7 @@ function CalendarDayTrack({
             block={block}
             top={top}
             height={height}
-            {...laneGeometry(`b:${block.id}`)}
+            {...blockGeometry(block)}
             compact={compact}
             isSelected={selectedBlockId === block.id}
             inMergeRange={selectedBlockId !== block.id && (selectedSpanIds?.has(block.id) ?? false)}

--- a/tests/dayClarifications.test.ts
+++ b/tests/dayClarifications.test.ts
@@ -72,7 +72,9 @@ test('asks about a substantial unnamed block and an unconfirmed meeting, most-ma
       block({ id: 'blk_short', label: 'Development', startMin: 200, durationMin: 10 }),
     ],
     [
-      { title: 'Standup', startMs: base, endMs: base + 30 * 60_000, attendeeCount: 3, participants: [], attendance: 'calendar_only', marked: null, matchedBlockId: null },
+      // Over empty time — nothing tracked proves or disproves it, so it is a
+      // real question. A meeting inside tracked hours is gated (DEV-284).
+      { title: 'Standup', startMs: base + 7 * 3_600_000, endMs: base + 7.5 * 3_600_000, attendeeCount: 3, participants: [], attendance: 'calendar_only', marked: null, matchedBlockId: null },
       { title: 'Already tracked', startMs: base + 3 * 3_600_000, endMs: base + 3.5 * 3_600_000, attendeeCount: 2, participants: [], attendance: 'matched', marked: null, matchedBlockId: 'x' },
     ],
   )
@@ -88,6 +90,25 @@ test('asks about a substantial unnamed block and an unconfirmed meeting, most-ma
   const meeting = clarifications.find((c) => c.kind === 'unconfirmed-meeting')!
   assert.match(meeting.question, /Standup/)
   assert.ok(meeting.eventKey, 'meeting clarification carries the attendance event key')
+  db.close()
+})
+
+test('DEV-284: a meeting during hours the person clearly worked through is never asked about', () => {
+  const db = createProductionTestDatabase()
+  // The July 22 shape: "Deep work (1:00–2:30)" scheduled inside a tracked
+  // block running 12:34–2:42. The activity already tells the story.
+  const payload = payloadWith(
+    [block({ id: 'blk_work', label: 'Shipping the recap agent', startMin: 0, durationMin: 240 })],
+    [
+      { title: 'Deep work', startMs: base + 30 * 60_000, endMs: base + 120 * 60_000, attendeeCount: null, participants: [], attendance: 'calendar_only', marked: null, matchedBlockId: null },
+      // Only a sliver overlaps tracked time — still a genuine open question.
+      { title: 'Evening sync', startMs: base + 230 * 60_000, endMs: base + 290 * 60_000, attendeeCount: 2, participants: [], attendance: 'calendar_only', marked: null, matchedBlockId: null },
+    ],
+  )
+  const clarifications = detectDayClarifications(db, payload)
+  const questions = clarifications.map((c) => c.question)
+  assert.ok(!questions.some((q) => /Deep work/.test(q)), `must not ask about a worked-through window: ${questions.join(' | ')}`)
+  assert.ok(questions.some((q) => /Evening sync/.test(q)), 'a mostly-uncovered meeting still gets its question')
   db.close()
 })
 


### PR DESCRIPTION
Stacked on #256 (Phase 3). Linear: DEV-284, DEV-286. Completes the four-phase arc from the July 22 review session (#254 → #255 → #256 → this).

## DEV-284 — Quick-check asks about meetings during worked hours

`detectDayClarifications` now skips a scheduled meeting whose window is mostly covered by tracked blocks — your "Were you in Deep work (1:00–2:30)?" beside a tracked 12:34–2:42 block is the pinned regression case. This is the clarification contract applied literally: ask only when the answer would materially change the day's account; tracked activity through the window already tells the story. A meeting with only a sliver of overlap (or over empty time) keeps its answer-or-skip question. Judgment call to review: "mostly covered" = more than half the scheduled span.

The panel clutter had two other components already fixed upstream in this stack: the detached floating status card was the Phase 1 grid-item bug (#254), and the stacked meeting questions mostly disappear with this gating (the cap of 2 and the recap → questions → actions → status ordering with a separated footer were already in place).

## DEV-286 — Ambiguous columns, colliding labels, empty blocks

- **The columns have one meaning now.** Previously blocks and events fed one shared lane pool, so any temporal overlap could throw either into either column. Blocks are the spine: they always start at the left and never split among themselves (they're a partition of the day). Scheduled events render in their own right-hand column (38% of the track — a design judgment, flag if you want a different ratio) only where they overlap tracked time, and lane only against other events. An event over empty time keeps the full width as a quiet outline.
- **"Idle · 22m" never collides with an event card.** A gap caption that shares its stretch with a scheduled event gets a readable pill backdrop and renders above the outline.
- **Tall blocks aren't empty rectangles.** A block tall enough (≥110px) carries its one-line account (the AI narrative, or the Phase 3 activity summary) under the title, clamped to three lines; short cards stay title + time, and the sticky-header behavior for scrolled tall blocks is unchanged.

## Verification

- `npm run typecheck` / `lint` — clean; `npm test` — 322 files, 2,155 pass, 0 fail
- `npm run timeline:eval -- --strict`, `verify:synthetic-day`, `contract:check` — green
- New test: the exact DEV-284 shape (covered window gated, sliver-overlap window still asked)

`verify:real-day` still needs a local run against an accepted snapshot before acceptance — and the layout changes in this phase in particular deserve a visual pass on your real July 22 day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)