### PR TITLE
Interactive landing hero and AI-forward positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Daylens is a working cross-platform desktop application undergoing an incrementa
 | Document                                           | Purpose                                                          |
 | -------------------------------------------------- | ---------------------------------------------------------------- |
 | [Product direction](docs/product/product.md)       | The product promise, problem, principles, and boundaries         |
+| [Landing positioning](docs/product/landing-positioning.md) | Accepted public-site audience, promise, and AI-forward voice |
 | [V2 direction](docs/product/v2.md)                 | Accepted V2 scope, sequencing, and technical boundaries          |
 | [Vocabulary](docs/product/vocabulary.md)           | Shared meanings for product and architecture terms               |
 | [Architecture](docs/codebase/architecture.md)      | How the current application works and how data flows             |

--- a/apps/web/app/components/ChangelogPageClient.tsx
+++ b/apps/web/app/components/ChangelogPageClient.tsx
@@ -218,16 +218,6 @@ export function ChangelogPageClient() {
                     </section>
                   ))}
 
-                  <div className="lp-ray-release-footer">
-                    <a
-                      href={release.linkUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="lp-ray-release-link"
-                    >
-                      {release.linkLabel}
-                    </a>
-                  </div>
                 </div>
               </article>
             ))}

--- a/apps/web/app/components/LandingClient.tsx
+++ b/apps/web/app/components/LandingClient.tsx
@@ -9,7 +9,6 @@ import { assetPath } from "../lib/basePath";
 import {
   LINUX_STATUS_HREF,
   MAC_DOWNLOAD_HREF,
-  UNIFIED_DESKTOP_REPO_URL,
   WINDOWS_DOWNLOAD_HREF,
 } from "../lib/platformLinks";
 
@@ -405,19 +404,6 @@ export function LandingClient() {
               <article className="dlx-bento__cell">
                 <h3>It doesn&apos;t phone home.</h3>
                 <p>No analytics. No usage beacons. The only network call is the one you ask for.</p>
-              </article>
-
-              <article className="dlx-bento__cell dlx-bento__cell--code">
-                <h3>The repo is on GitHub.</h3>
-                <p>Audit it, fork it, file an issue. No lock-in, ever.</p>
-                <a
-                  href={UNIFIED_DESKTOP_REPO_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="dlx-bento__link"
-                >
-                  View on GitHub <ArrowIcon />
-                </a>
               </article>
             </div>
           </div>

--- a/apps/web/app/components/MarketingChrome.tsx
+++ b/apps/web/app/components/MarketingChrome.tsx
@@ -1,9 +1,9 @@
+import Image from "next/image";
 import Link from "next/link";
-import { Code2 } from "lucide-react";
+import { assetPath } from "../lib/basePath";
 import {
   LINUX_STATUS_HREF,
   MAC_DOWNLOAD_HREF,
-  UNIFIED_DESKTOP_REPO_URL,
   WINDOWS_DOWNLOAD_HREF,
 } from "../lib/platformLinks";
 
@@ -16,37 +16,54 @@ const NAV_LINKS: Array<{ href: string; label: string; key: MarketingNavKey }> = 
   { href: "/changelog", label: "Changelog", key: "changelog" },
 ];
 
-function DaylensMark() {
+function DaylensLogo({ size = 28 }: { size?: number }) {
   return (
-    <span className="v2-site-mark" aria-hidden="true">
-      <span />
-      <span />
-      <span />
-    </span>
+    <>
+      <Image
+        src={assetPath("/app-icon.png")}
+        alt=""
+        width={size}
+        height={size}
+        className="rounded-md"
+        style={{ width: size, height: size }}
+      />
+      <span className="text-sm font-medium tracking-tight text-zinc-900">Daylens</span>
+    </>
   );
 }
 
-export function MarketingInnerNav({ current }: { current: MarketingNavKey; theme?: "dark" | "light"; variant?: "default" | "capsule"; landing?: boolean }) {
+export function MarketingInnerNav({
+  current,
+}: {
+  current: MarketingNavKey;
+  theme?: "dark" | "light";
+  variant?: "default" | "capsule";
+  landing?: boolean;
+}) {
   return (
-    <header className="v2-site-header">
-      <div className="v2-site-header-inner">
-        <Link href="/" className="v2-site-logo" aria-label="Daylens home">
-          <DaylensMark />
-          <span>Daylens</span>
+    <header className="sticky top-0 z-50 px-4 pt-4 pb-2">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 rounded-full border border-zinc-200 bg-white/80 p-2 pl-4 backdrop-blur-xl">
+        <Link href="/" className="flex items-center gap-2" aria-label="Daylens home">
+          <DaylensLogo />
         </Link>
-        <nav className="v2-site-nav" aria-label="Public site">
+        <nav className="hidden items-center gap-7 lg:flex" aria-label="Public site">
           {NAV_LINKS.map((link) => (
-            <Link key={link.href} href={link.href} aria-current={current === link.key ? "page" : undefined}>
+            <Link
+              key={link.href}
+              href={link.href}
+              aria-current={current === link.key ? "page" : undefined}
+              className="text-sm font-medium text-zinc-600 transition-colors hover:text-zinc-900 aria-[current=page]:text-zinc-900"
+            >
               {link.label}
             </Link>
           ))}
         </nav>
-        <div className="v2-site-actions">
-          <a href={UNIFIED_DESKTOP_REPO_URL} target="_blank" rel="noopener noreferrer" className="v2-site-source">
-            <Code2 size={15} />
-            <span>GitHub</span>
-          </a>
-        </div>
+        <a
+          href={MAC_DOWNLOAD_HREF}
+          className="inline-flex h-9 items-center justify-center rounded-full bg-zinc-900 px-5 text-xs font-medium text-white transition-colors hover:bg-zinc-800"
+        >
+          Download
+        </a>
       </div>
     </header>
   );
@@ -57,7 +74,9 @@ export function MarketingFooter({ variant = "full" }: { variant?: "full" | "mini
     <footer className={`v2-site-footer${variant === "minimal" ? " is-minimal" : ""}`}>
       <div className="v2-site-footer-inner">
         <div className="v2-site-footer-top">
-          <Link href="/" className="v2-site-logo"><DaylensMark /><span>Daylens</span></Link>
+          <Link href="/" className="flex items-center gap-2" aria-label="Daylens home">
+            <DaylensLogo size={20} />
+          </Link>
           <nav aria-label="Footer">
             <Link href="/docs">Docs</Link>
             <Link href="/roadmap">Roadmap</Link>
@@ -65,13 +84,11 @@ export function MarketingFooter({ variant = "full" }: { variant?: "full" | "mini
             <a href={MAC_DOWNLOAD_HREF}>macOS</a>
             <a href={WINDOWS_DOWNLOAD_HREF}>Windows</a>
             <a href={LINUX_STATUS_HREF}>Linux</a>
-            <a href={UNIFIED_DESKTOP_REPO_URL} target="_blank" rel="noopener noreferrer">GitHub</a>
           </nav>
         </div>
         {variant === "full" && <div className="v2-site-wordmark">daylens</div>}
         <div className="v2-site-footer-bottom">
-          <span>Built in Rwanda</span>
-          <span>Local first, open source</span>
+          <span>Local first</span>
         </div>
       </div>
     </footer>

--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -1,14 +1,11 @@
+import Link from "next/link";
 import { MarketingFooter, MarketingInnerNav } from "../components/MarketingChrome";
-import {
-  LINUX_STATUS_HREF,
-  UNIFIED_DESKTOP_ISSUES_URL,
-  UNIFIED_DESKTOP_REPO_URL,
-} from "../lib/platformLinks";
+import { LINUX_STATUS_HREF } from "../lib/platformLinks";
 
 export const metadata = {
   title: "Docs — Daylens",
   description:
-    "Everything you need to know about Daylens: timeline reconstruction, the Apps and AI surfaces, privacy, and platform status.",
+    "How Daylens remembers your workday, answers in plain language, and stays private on your laptop.",
 };
 
 const TOC = [
@@ -51,9 +48,9 @@ export default function DocsPage() {
               maxWidth: "44ch",
             }}
           >
-            Daylens is a local-first work-history product. These docs explain what is already real
-            today, what still needs validation, and where the public site intentionally stays
-            conservative.
+            Daylens is a private memory of what you do on your laptop — for you to ask in
+            plain language, and for the AI tools you already use. These docs explain what is
+            real today and where we stay conservative.
           </p>
         </div>
       </section>
@@ -139,7 +136,7 @@ export default function DocsPage() {
                 </p>
                 <ul className="lp-docs-bullets">
                   {[
-                    "The unified desktop repo is now the cross-platform source of truth for macOS, Windows, and Linux.",
+                    "Daylens is one cross-platform desktop product for macOS, Windows, and Linux.",
                     "macOS install, onboarding, and menu-bar polish are implemented, but the final packaged-app feel still needs human validation.",
                     "A deterministic daily, weekly, and monthly recap now exists inside the AI surface, but it is not yet fully shipped and proven.",
                     "Persistent AI threads, artifacts, focus flows, exports, and several settings refinements are in the product, with many still marked implemented pending verification.",
@@ -202,22 +199,25 @@ export default function DocsPage() {
               <section id="ai" style={{ scrollMarginTop: 80 }} className="lp-docs-section">
                 <h2 className="text-headline lp-docs-section-title">AI</h2>
                 <p className="lp-docs-body">
-                  The AI surface turns tracked local evidence into grounded questions and outputs.
-                  Starter prompts, freeform chat, tables, charts, artifact creation, and feedback all
-                  live here. The AI layer is orchestration over local data, not the primary runtime of
-                  the product.
+                  The AI surface is how Daylens memory becomes useful in conversation. Ask what you
+                  got done, where an afternoon went, or what you were last deep in — and get an
+                  answer grounded in the same facts as Timeline and Apps. You can also bring that
+                  context into the AI tools you already use when you opt in.
                 </p>
                 <p className="lp-docs-body">
-                  That also means the truthfulness bar is higher here. Deterministic recap cards and
-                  durable AI state are implemented now, while provider-backed packaged flows still
-                  need broader real-world proof before they should be treated as fully settled.
+                  Starter prompts, freeform chat, tables, charts, artifacts, and feedback all live
+                  here. The AI layer is orchestration over local data, not the primary runtime of the
+                  product. Deterministic recap cards and durable AI state are implemented now, while
+                  provider-backed packaged flows still need broader real-world proof before they
+                  should be treated as fully settled.
                 </p>
                 <div className="lp-docs-examples">
                   {[
-                    "How much time did I spend on Client X this week?",
-                    "What was I doing between 2 and 4 PM on Wednesday?",
-                    "Show me everything I touched for Project X.",
-                    "Create a summary report I can share with a client.",
+                    "What did I actually get done this week?",
+                    "What did I work on for Acme?",
+                    "Where did Tuesday afternoon go?",
+                    "What did I read before that meeting?",
+                    "Draft my weekly update report from what I got done this week.",
                   ].map((q) => (
                     <div key={q} className="lp-docs-example">
                       <span className="lp-docs-example-q">Q</span>
@@ -229,7 +229,8 @@ export default function DocsPage() {
                   <span className="lp-docs-infobox-label">Note:</span>
                   AI-powered answers depend on a configured provider and send activity summaries such
                   as app names, titles, durations, and related evidence needed to answer the query.
-                  They do not rely on screenshots or keystroke capture.
+                  They do not rely on screenshots or keystroke capture. Your activity database stays
+                  on your laptop; what leaves is what you choose to send when you ask.
                 </div>
               </section>
 
@@ -315,7 +316,6 @@ export default function DocsPage() {
                     ["No screenshots", "Daylens uses window, app, browser, and artifact evidence rather than grabbing screen images."],
                     ["No keylogging", "The product does not record what you type."],
                     ["Optional sync", "Workspace and web access flows are additive, not required for the core desktop experience."],
-                    ["Open source", "The public repos are available so behavior can be inspected instead of guessed at."],
                   ].map(([title, body]) => (
                     <div key={title as string} className="lp-docs-privacy-item">
                       <span className="lp-docs-check">✓</span>
@@ -354,7 +354,7 @@ export default function DocsPage() {
                     },
                     {
                       q: "Where is the source of truth?",
-                      a: "The unified desktop source of truth currently lives in the daylens repository, which carries the cross-platform product and release docs.",
+                      a: "Your local Daylens database on your machine. Optional sync and web access are additive; they do not replace the desktop history store.",
                     },
                   ].map(({ q, a }) => (
                     <details key={q} className="lp-docs-faq-item">
@@ -392,22 +392,9 @@ export default function DocsPage() {
                   Need the current implementation status rather than the product overview?
                 </p>
                 <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
-                  <a
-                    href={UNIFIED_DESKTOP_ISSUES_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="lp-btn-ghost-dark"
-                  >
-                    Review launch status →
-                  </a>
-                  <a
-                    href={UNIFIED_DESKTOP_REPO_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="lp-btn-ghost-dark"
-                  >
-                    Browse source →
-                  </a>
+                  <Link href="/roadmap" className="lp-btn-ghost-dark">
+                    See the roadmap →
+                  </Link>
                 </div>
               </div>
             </article>

--- a/apps/web/app/hackathon/components/HackathonLanding.tsx
+++ b/apps/web/app/hackathon/components/HackathonLanding.tsx
@@ -1,30 +1,21 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { motion, AnimatePresence } from "motion/react";
-import { Check, ChevronLeftIcon, ChevronRightIcon, ZoomIn, X } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import { ChevronDown, FileSpreadsheet } from "lucide-react";
 import { Counter } from "./Counter";
 import { ThemeToggle } from "./ThemeToggle";
+import { HeroDemo } from "./hero-demo/HeroDemo";
+import { DEMO_ASKS } from "./hero-demo/demoData";
 import { assetPath } from "@/app/lib/basePath";
 import {
   MAC_DOWNLOAD_HREF,
   WINDOWS_DOWNLOAD_HREF,
   LINUX_STATUS_HREF,
 } from "@/app/lib/platformLinks";
-
-import { Swiper, SwiperSlide } from "swiper/react";
-import { Autoplay, EffectCoverflow, Navigation, Pagination } from "swiper/modules";
 import { cn } from "@/app/lib/cn";
-
-// Import Swiper styles
-import "swiper/css";
-import "swiper/css/effect-coverflow";
-import "swiper/css/pagination";
-import "swiper/css/navigation";
-
-const GITHUB_URL = "https://github.com/irachrist1/daylens-v1";
 
 // ─── Content ────────────────────────────────────────────────────────────────
 
@@ -34,66 +25,37 @@ const STATS = [
   { label: "Data shared with anyone else", value: 0, suffix: "%" },
 ];
 
-const QUERIES = [
-  {
-    q: "What did I learn about machine learning this week?",
-    a: "Neural network fundamentals, forward propagation, L-layer networks, plus the hands-on Coursera labs from Tuesday and Wednesday.",
-    img: "/hackathon/05-ai-ml-query.png",
-    tag: "ai chat",
-    zoom: "1.35",
-    origin: "80% 35%"
-  },
-  {
-    q: "What did I work on today?",
-    a: "13h 22m tracked, 24 blocks, 28 apps and 22 sites. Right-side narrative reads back the shape of the day, not just the totals.",
-    img: "/hackathon/01-timeline-day.png",
-    tag: "timeline",
-    zoom: "1.25",
-    origin: "85% 35%"
-  },
-  {
-    q: "How long was I in Ghostty during Building & Testing blocks?",
-    a: "5h 20m across three days. Broken down to the minute per session. The query routes to block + app intersections.",
-    img: "/hackathon/06-ai-ghostty-query.png",
-    tag: "ai chat",
-    zoom: "1.35",
-    origin: "80% 20%"
-  },
-  {
-    q: "Show me what I actually consumed in Dia.",
-    a: "Domain breakdown for every browser app, with a generated summary of what each app was used for — not just hours-in-tab.",
-    img: "/hackathon/03-apps-all.png",
-    tag: "apps",
-    zoom: "1.3",
-    origin: "85% 35%"
-  },
-];
+const EXAMPLE_ASKS = DEMO_ASKS;
 
 const PILLARS = [
   {
-    title: "Content Indexer",
-    body: "A background job sends every new browser session to Claude with a two-sentence, topic-tagged prompt. Results land in a local SQLite table the chat can search. Built this week.",
+    title: "Ask in plain language",
+    body: "Ask what you got done, where an afternoon went, or what you were last deep in — and get an answer grounded in what actually happened on your laptop.",
   },
   {
-    title: "Tool-calling chat",
-    body: "Claude with SQLite tables and the content index as tools. Deterministic router handles common shapes first. searchContentByTopic returns what you actually consumed.",
+    title: "Answers from real work",
+    body: "Timeline, Apps, and AI read the same memory. Drafts, summaries, and recalls come from evidence you can still open and correct — not from a blank page.",
   },
   {
-    title: "MCP server",
-    body: "Opt-in MCP exposes Daylens to Claude Desktop, Cursor, and Claude Code. Your work history becomes context for any agent. Off by default, revocable from Settings.",
+    title: "Context for the tools you already use",
+    body: "Opt in to share Daylens memory with Claude, Cursor, and other agents when you want your day as context there too. Off until you turn it on.",
   },
   {
-    title: "Local-first by design",
-    body: "Every byte lives in a single SQLite file on your laptop. The only thing that leaves the device is the question you choose to ask.",
+    title: "Private on your laptop",
+    body: "Your activity lives in a local database on your machine. What leaves the device is what you choose to send when you ask — not a silent copy of your whole day.",
   },
 ];
 
-const SUPPORTED_APPS = [
+const SUPPORTED_APPS: Array<{
+  name: string;
+  src: string;
+  invertInDark?: boolean;
+}> = [
   { name: "VS Code", src: "/brands/vscode.ico" },
   { name: "Claude", src: "/brands/claude-app.png" },
   { name: "Dia", src: "/brands/dia.png" },
   { name: "Chrome", src: "/brands/chrome.svg" },
-  { name: "Notion", src: "/brands/notion.svg" },
+  { name: "Notion", src: "/brands/notion.svg", invertInDark: true },
   { name: "Figma", src: "/brands/figma.svg" },
   { name: "Linear", src: "/brands/linear.svg" },
   { name: "Slack", src: "/brands/slack.png" },
@@ -139,6 +101,98 @@ function Button({
   );
 }
 
+function ExampleAskAccordion() {
+  const [openIndex, setOpenIndex] = useState(0);
+
+  return (
+    <ul className="mt-12 flex flex-col gap-3 text-left">
+      {EXAMPLE_ASKS.map((item, index) => {
+        const isOpen = openIndex === index;
+        return (
+          <li
+            key={item.q}
+            className={cn(
+              "overflow-hidden rounded-2xl border transition-colors",
+              isOpen
+                ? "border-zinc-300 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900/60"
+                : "border-zinc-200 bg-white dark:border-zinc-800 dark:bg-transparent",
+            )}
+          >
+            <button
+              type="button"
+              aria-expanded={isOpen}
+              onClick={() => setOpenIndex(isOpen ? -1 : index)}
+              className="flex w-full items-start gap-4 px-5 py-4 text-left md:px-6 md:py-5"
+            >
+              <span className="min-w-0 flex-1 text-base font-medium tracking-tight md:text-lg">
+                “{item.q}”
+              </span>
+              <ChevronDown
+                className={cn(
+                  "mt-1 size-5 shrink-0 text-zinc-400 transition-transform duration-300",
+                  isOpen && "rotate-180",
+                )}
+                aria-hidden
+              />
+            </button>
+            <AnimatePresence initial={false}>
+              {isOpen && (
+                <motion.div
+                  key="answer"
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: 0.28, ease: [0.25, 0.46, 0.45, 0.94] }}
+                  className="overflow-hidden"
+                >
+                  <div className="border-t border-zinc-200 px-5 pb-5 pt-4 dark:border-zinc-800 md:px-6 md:pb-6">
+                    <p className="whitespace-pre-line text-sm leading-relaxed text-zinc-600 dark:text-zinc-300 md:text-base">
+                      {item.a}
+                    </p>
+                    {item.attachment && (
+                      <div className="mt-4 flex max-w-md items-center gap-3 rounded-xl border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-950">
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-400">
+                          <FileSpreadsheet className="size-5" aria-hidden />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                            {item.attachment.title}
+                          </p>
+                          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                            {item.attachment.kind}
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          className="shrink-0 rounded-lg border border-zinc-200 px-3 py-1.5 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
+                        >
+                          Open
+                        </button>
+                      </div>
+                    )}
+                    {item.evidence.length > 0 && (
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {item.evidence.map((chip) => (
+                          <span
+                            key={chip}
+                            className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs text-zinc-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-400"
+                          >
+                            {chip}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
 function AppleIcon() {
   return (
     <svg
@@ -178,23 +232,6 @@ function LinuxIcon() {
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export function HackathonLanding() {
-  const [zoomImage, setZoomImage] = useState<{ img: string; q: string; a: string; tag: string; zoom: string; origin: string } | null>(null);
-
-  useEffect(() => {
-    if (!zoomImage) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setZoomImage(null);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [zoomImage]);
-
   return (
     <div className="min-h-screen bg-white text-zinc-900 antialiased dark:bg-zinc-950 dark:text-zinc-100">
       {/* NAVBAR */}
@@ -210,24 +247,6 @@ export function HackathonLanding() {
             />
             <span className="text-sm font-medium tracking-tight">Daylens</span>
           </Link>
-          <nav className="hidden gap-7 lg:flex">
-            {[
-              { label: "Demos", href: "#demos" },
-              { label: "Privacy", href: "#privacy" },
-              { label: "Architecture", href: "#architecture" },
-              { label: "GitHub", href: GITHUB_URL },
-            ].map((l) => (
-              <a
-                key={l.label}
-                href={l.href}
-                target={l.href.startsWith("http") ? "_blank" : undefined}
-                rel={l.href.startsWith("http") ? "noreferrer" : undefined}
-                className="text-sm font-medium text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-              >
-                {l.label}
-              </a>
-            ))}
-          </nav>
           <div className="flex items-center gap-2">
             <ThemeToggle />
             <Button href="#download" variant="primary" className="h-9 text-xs">
@@ -243,43 +262,28 @@ export function HackathonLanding() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
-          className="mx-auto flex max-w-6xl flex-col items-center gap-14 lg:items-stretch"
+          className="mx-auto flex w-full max-w-7xl flex-col items-center gap-14"
         >
-          <section className="flex w-full flex-col items-start justify-between gap-8 lg:flex-row lg:gap-12">
+          <section className="flex w-full max-w-6xl flex-col items-start justify-between gap-8 lg:flex-row lg:gap-12">
             <h1 className="max-w-2xl text-balance text-4xl font-medium leading-[1.05] tracking-tighter md:text-6xl lg:text-7xl">
               Your digital life, made searchable on demand.
             </h1>
             <div className="flex max-w-md flex-col gap-6 lg:pt-3">
               <p className="text-base leading-relaxed text-zinc-600 dark:text-zinc-400 md:text-lg">
-                Daylens is a local-first memory system for your laptop. It
-                watches what you do, enriches it with Claude, and lets you ask
-                anything in plain language.
+                Daylens watches what you do on your laptop, keeps it private,
+                and lets you ask anything in plain language — or bring that
+                context into the AI tools you already use.
               </p>
               <div className="flex flex-row gap-2">
-                <Button href="#demos" variant="primary">
-                  See it answer
-                </Button>
-                <Button href="#download" variant="outline">
+                <Button href="#download" variant="primary">
                   Download
                 </Button>
               </div>
             </div>
           </section>
 
-          <div className="relative mx-auto w-full max-w-6xl overflow-hidden rounded-xl border border-zinc-200 shadow-[0_30px_80px_-20px_rgba(0,0,0,0.12)] dark:border-zinc-800 dark:shadow-[0_30px_80px_-20px_rgba(0,0,0,0.6)] lg:rounded-[2rem]">
-            <Image
-              src={assetPath("/hackathon/01-timeline-day.png")}
-              alt="Daylens today view — a reconstructed timeline of your work"
-              width={2538}
-              height={1802}
-              priority
-              quality={95}
-              sizes="(max-width: 768px) calc(100vw - 2rem), (max-width: 1280px) calc(100vw - 2rem), 1152px"
-              className="h-auto w-full"
-              style={{
-                imageRendering: "-webkit-optimize-contrast",
-              }}
-            />
+          <div className="relative mx-auto w-full max-w-6xl">
+            <HeroDemo />
           </div>
         </motion.div>
       </section>
@@ -292,8 +296,8 @@ export function HackathonLanding() {
               The apps you already live in.
             </h2>
             <p className="mt-3 max-w-md text-base text-zinc-500 dark:text-zinc-400">
-              Daylens watches without integrations, plug-ins, or permissions
-              you'll regret.
+              Daylens watches your workspace quietly — without a pile of
+              integrations to set up first.
             </p>
           </div>
 
@@ -308,7 +312,10 @@ export function HackathonLanding() {
                   alt={app.name}
                   width={32}
                   height={32}
-                  className="size-8 opacity-90"
+                  className={cn(
+                    "size-8 opacity-90",
+                    app.invertInDark && "dark:invert",
+                  )}
                 />
               </div>
             ))}
@@ -346,218 +353,18 @@ export function HackathonLanding() {
         </div>
       </section>
 
-      {/* DEMOS */}
-      <section id="demos" className="px-4 py-20 lg:py-28 overflow-hidden">
-        <div className="mx-auto max-w-7xl">
-          <div className="mb-16 text-center lg:mb-24">
-            <h2 className="text-3xl font-medium tracking-tight sm:text-4xl">
-              Ask anything. Get a real answer.
-            </h2>
-            <p className="mx-auto mt-4 max-w-xl text-base text-zinc-500 dark:text-zinc-400">
-              Four queries, four real answers from real data on a real laptop.
-              No mocks. No edits.
-            </p>
-          </div>
-
-          <div className="relative mx-auto max-w-5xl px-4 md:px-8">
-            {/* Custom Carousel Styles */}
-            <style>{`
-              .demos-swiper {
-                width: 100%;
-                padding-bottom: 50px !important;
-                overflow: visible !important;
-              }
-              .demos-swiper .swiper-slide {
-                width: 100%;
-                max-width: 600px;
-                opacity: 0.35;
-                filter: blur(4px);
-                transform: scale(0.93);
-                transition: opacity 0.4s ease, filter 0.4s ease, transform 0.4s ease;
-              }
-              .demos-swiper .swiper-slide-active {
-                opacity: 1;
-                filter: blur(0px);
-                transform: scale(1);
-              }
-              .demos-swiper img {
-                image-rendering: -webkit-optimize-contrast;
-                image-rendering: crisp-edges;
-              }
-              .demos-swiper .swiper-pagination-bullet {
-                background: #71717a !important; /* zinc-400 */
-                opacity: 0.4;
-                transition: opacity 0.2s ease, background-color 0.2s ease;
-              }
-              .demos-swiper .swiper-pagination-bullet-active {
-                background: #18181b !important; /* zinc-900 */
-                opacity: 1;
-              }
-              .dark .demos-swiper .swiper-pagination-bullet-active {
-                background: #f4f4f5 !important; /* zinc-100 */
-                opacity: 1;
-              }
-            `}</style>
-
-            <Swiper
-              modules={[Autoplay, Pagination, Navigation]}
-              grabCursor={true}
-              centeredSlides={true}
-              slidesPerView="auto"
-              loop={true}
-              autoplay={{
-                delay: 4000,
-                disableOnInteraction: false,
-                pauseOnMouseEnter: true,
-              }}
-              pagination={{
-                clickable: true,
-              }}
-              navigation={{
-                nextEl: ".demos-swiper-button-next",
-                prevEl: ".demos-swiper-button-prev",
-              }}
-              className="demos-swiper"
-            >
-              {QUERIES.map((query, i) => (
-                <SwiperSlide key={query.q}>
-                  <motion.article
-                    initial={{ opacity: 0, y: 20 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    viewport={{ once: true }}
-                    transition={{
-                      duration: 0.45,
-                      ease: [0.25, 0.46, 0.45, 0.94],
-                    }}
-                    className="flex h-full min-h-[420px] min-w-0 flex-col justify-between gap-5 rounded-2xl border border-zinc-200 bg-white p-6 shadow-xl dark:border-zinc-800 dark:bg-zinc-900 md:p-8"
-                  >
-                    <header className="flex flex-col gap-2.5">
-                      <p className="text-lg font-medium leading-snug tracking-tight text-zinc-900 dark:text-zinc-100 md:text-xl">
-                        "{query.q}"
-                      </p>
-                    </header>
-
-                    <div
-                      onClick={() => setZoomImage(query)}
-                      className="group/img relative mt-auto overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950 cursor-pointer aspect-[16/10]"
-                    >
-                      {/* Animated Scale Wrapper on Hover */}
-                      <div className="w-full h-full overflow-hidden transition-transform duration-300 group-hover/img:scale-[1.02]">
-                        <Image
-                          src={assetPath(query.img)}
-                          alt={query.q}
-                          width={1280}
-                          height={800}
-                          quality={95}
-                          sizes="(max-width: 768px) 100vw, 1000px"
-                          className="w-full h-full object-cover"
-                          style={{
-                            transform: `scale(${query.zoom})`,
-                            transformOrigin: query.origin,
-                          }}
-                        />
-                      </div>
-                      {/* Hover Overlay */}
-                      <div className="absolute inset-0 bg-black/0 transition-all duration-300 group-hover/img:bg-black/20 flex items-center justify-center">
-                        <div className="p-2.5 rounded-full bg-white/90 dark:bg-zinc-900/90 shadow-md border border-zinc-200 dark:border-zinc-800 opacity-0 scale-90 transition-all duration-300 group-hover/img:opacity-100 group-hover/img:scale-100 flex items-center gap-1.5 text-xs font-medium text-zinc-900 dark:text-zinc-100">
-                          <ZoomIn className="size-4" />
-                          <span>Click to expand</span>
-                        </div>
-                      </div>
-                    </div>
-                  </motion.article>
-                </SwiperSlide>
-              ))}
-            </Swiper>
-
-            {/* Custom Navigation Buttons */}
-            <div className="absolute left-0 top-1/2 z-10 w-full -translate-y-1/2 pointer-events-none hidden md:flex justify-between px-0 md:-px-4">
-              <button className="demos-swiper-button-prev p-3 rounded-full bg-white/90 dark:bg-zinc-900/90 border border-zinc-200 dark:border-zinc-800 shadow-lg hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-all active:scale-95 pointer-events-auto -translate-x-1/2">
-                <ChevronLeftIcon className="h-5 w-5 text-zinc-800 dark:text-zinc-200" />
-              </button>
-              <button className="demos-swiper-button-next p-3 rounded-full bg-white/90 dark:bg-zinc-900/90 border border-zinc-200 dark:border-zinc-800 shadow-lg hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-all active:scale-95 pointer-events-auto translate-x-1/2">
-                <ChevronRightIcon className="h-5 w-5 text-zinc-800 dark:text-zinc-200" />
-              </button>
-            </div>
-          </div>
+      {/* EXAMPLE ASKS */}
+      <section className="px-4 py-20 lg:py-28">
+        <div className="mx-auto max-w-3xl text-center">
+          <h2 className="text-3xl font-medium tracking-tight sm:text-4xl">
+            Ask anything about your day.
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-base text-zinc-500 dark:text-zinc-400">
+            Open a question to see the kind of answer Daylens gives — grounded
+            in what actually happened, not a blank page.
+          </p>
+          <ExampleAskAccordion />
         </div>
-      </section>
-
-      {/* PRIVACY */}
-      <section id="privacy" className="px-4 py-20 lg:py-28">
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, margin: "-100px" }}
-          transition={{ duration: 0.5, ease: [0.25, 0.46, 0.45, 0.94] }}
-          className="mx-auto w-full max-w-7xl rounded-[2rem] bg-zinc-900 px-6 pt-16 pb-8 dark:bg-zinc-100 md:px-12 md:py-20"
-        >
-          <div className="mx-auto max-w-4xl">
-            <div className="mb-12 flex flex-col items-center text-center">
-              <h2 className="text-3xl font-medium tracking-tight text-white dark:text-zinc-900 sm:text-4xl">
-                Nothing leaves your device unless you ask.
-              </h2>
-              <p className="mt-4 max-w-md text-sm text-white/70 dark:text-zinc-600 sm:text-base">
-                The privacy model is not a feature. It is the constraint that
-                makes the rest of the product trustworthy.
-              </p>
-            </div>
-
-            <div className="overflow-hidden rounded-2xl bg-white dark:bg-zinc-950">
-              <div className="flex flex-col md:flex-row">
-                <div className="flex flex-col border-b border-zinc-200 p-8 dark:border-zinc-800 md:basis-2/5 md:border-b-0 md:border-r md:p-10">
-                  <h3 className="text-center text-3xl font-medium tracking-tight">
-                    Local-first
-                  </h3>
-                  <p className="mt-2 text-center text-base text-zinc-500 dark:text-zinc-400">
-                    A single SQLite file on your laptop. No cloud. No account.
-                  </p>
-                  <p className="mt-8 text-center text-lg font-medium">
-                    Free, forever, on every Mac.
-                  </p>
-                  <div className="mt-8 flex flex-col gap-3">
-                    <Button href={MAC_DOWNLOAD_HREF} variant="primary" className="w-full">
-                      <AppleIcon /> Download for Mac
-                    </Button>
-                    <Button href={GITHUB_URL} target="_blank" rel="noreferrer" variant="outline" className="w-full">
-                      Read the source
-                    </Button>
-                  </div>
-                  <p className="mt-8 text-center text-xs text-zinc-400 dark:text-zinc-500">
-                    Open source. CBC Spring 2026 Hackathon submission.
-                  </p>
-                </div>
-
-                <div className="flex flex-col justify-between p-8 md:basis-3/5 md:p-10">
-                  <ul className="flex flex-col gap-3">
-                    {[
-                      "Every byte stored locally in SQLite",
-                      "Zero background telemetry",
-                      "Zero third-party analytics",
-                      "Only your question is sent to Claude, per query",
-                      "MCP access is opt-in and revocable",
-                      "Settings shows every captured field",
-                      "Delete the database, delete every byte",
-                    ].map((line) => (
-                      <li key={line} className="flex items-center gap-3">
-                        <Check className="size-4" strokeWidth={2} />
-                        <span className="text-sm font-medium">{line}</span>
-                      </li>
-                    ))}
-                  </ul>
-
-                  <div className="mt-8 border-t border-zinc-200 pt-6 dark:border-zinc-800">
-                    <p className="text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
-                      Daylens is designed around the inverse of surveillance.
-                      You see what is captured. You decide what your AI can
-                      read. The product is self-knowledge under your control.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </motion.div>
       </section>
 
       {/* ARCHITECTURE */}
@@ -565,11 +372,11 @@ export function HackathonLanding() {
         <div className="mx-auto max-w-7xl">
           <div className="mb-16 text-center">
             <h2 className="text-3xl font-medium tracking-tight sm:text-4xl">
-              Three Claude integrations, not one.
+              What the AI can do.
             </h2>
             <p className="mx-auto mt-4 max-w-xl text-base text-zinc-500 dark:text-zinc-400">
-              Substantive use of the API. Not a chatbot wrapped around your
-              schedule.
+              Built for knowledge workers — anyone who lives on a laptop and
+              already uses AI.
             </p>
           </div>
 
@@ -591,30 +398,6 @@ export function HackathonLanding() {
         </div>
       </section>
 
-      {/* DEMO VIDEO PLACEHOLDER */}
-      <section id="video" className="px-4 py-20 lg:py-28">
-        <div className="mx-auto max-w-5xl text-center">
-          <h2 className="text-3xl font-medium tracking-tight sm:text-4xl">
-            See it answer in real time.
-          </h2>
-          <p className="mx-auto mt-4 max-w-xl text-base text-zinc-500 dark:text-zinc-400">
-            A three-minute walkthrough against live data. Same four queries.
-            Real answers.
-          </p>
-
-          <div className="mt-12 overflow-hidden rounded-2xl border border-zinc-200 shadow-[0_20px_50px_-15px_rgba(0,0,0,0.12)] dark:border-zinc-800">
-            <div className="flex aspect-video flex-col items-center justify-center bg-zinc-50 text-zinc-400 dark:bg-zinc-900 dark:text-zinc-600">
-              <svg width="56" height="56" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M8 5v14l11-7z" />
-              </svg>
-              <p className="mt-3 font-mono text-xs uppercase tracking-widest">
-                demo · uploading
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
       {/* DOWNLOAD */}
       <section id="download" className="px-4 py-24 lg:py-32">
         <div className="mx-auto max-w-3xl text-center">
@@ -622,8 +405,8 @@ export function HackathonLanding() {
             Get your history back.
           </h2>
           <p className="mx-auto mt-5 max-w-xl text-base text-zinc-500 dark:text-zinc-400">
-            Open source. Local-first. Available now for macOS. Windows and
-            Linux are next.
+            Private by default. Available now for macOS. Windows and Linux are
+            next.
           </p>
           <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
             <Button href={MAC_DOWNLOAD_HREF} variant="primary">
@@ -636,25 +419,13 @@ export function HackathonLanding() {
               <LinuxIcon /> Linux status
             </Button>
           </div>
-          <p className="mt-6 text-xs text-zinc-400 dark:text-zinc-500">
-            Source on{" "}
-            <a
-              href={GITHUB_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="underline underline-offset-4 hover:text-zinc-900 dark:hover:text-zinc-100"
-            >
-              GitHub
-            </a>
-            .
-          </p>
         </div>
       </section>
 
       {/* FOOTER */}
       <footer className="border-t border-zinc-200 px-4 py-10 dark:border-zinc-800">
-        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 text-sm text-zinc-500 dark:text-zinc-400 md:flex-row">
-          <div className="flex items-center gap-2">
+        <div className="mx-auto grid max-w-6xl grid-cols-1 items-center gap-4 text-sm text-zinc-500 dark:text-zinc-400 md:grid-cols-3">
+          <div className="flex items-center justify-center gap-2 md:justify-start">
             <Image
               src={assetPath("/app-icon.png")}
               alt="Daylens"
@@ -666,64 +437,19 @@ export function HackathonLanding() {
               Daylens
             </span>
           </div>
-          <p className="font-mono text-[11px] uppercase tracking-widest">
-            CBC Spring 2026 · ALU · Christian Tonny
+          <div className="flex justify-center">
+            <Link
+              href="/docs"
+              className="transition-colors hover:text-zinc-900 dark:hover:text-zinc-100"
+            >
+              Docs
+            </Link>
+          </div>
+          <p className="text-center font-mono text-[11px] uppercase tracking-widest md:text-right">
+            Christian Tonny
           </p>
         </div>
       </footer>
-
-      {/* LIGHTBOX MODAL */}
-      <AnimatePresence>
-        {zoomImage && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="fixed inset-0 z-[100] flex flex-col items-center justify-center p-4 md:p-8 bg-zinc-950/80 backdrop-blur-md cursor-zoom-out"
-            onClick={() => setZoomImage(null)}
-          >
-            {/* Modal Content */}
-            <motion.div
-              initial={{ scale: 0.95, y: 10 }}
-              animate={{ scale: 1, y: 0 }}
-              exit={{ scale: 0.95, y: 10 }}
-              transition={{ type: "spring", damping: 25, stiffness: 300 }}
-              className="relative w-full max-w-5xl bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden shadow-2xl flex flex-col cursor-default"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {/* Close Button */}
-              <button
-                onClick={() => setZoomImage(null)}
-                className="absolute right-4 top-4 z-10 p-2.5 rounded-full bg-zinc-950/60 hover:bg-zinc-800 border border-zinc-800/80 text-zinc-400 hover:text-white transition-all active:scale-95 shadow-md cursor-pointer"
-              >
-                <X className="size-5" />
-              </button>
-
-              {/* High-res Image Wrapper */}
-              <div className="relative w-full aspect-[16/10] overflow-hidden bg-zinc-950 flex items-center justify-center">
-                <img
-                  src={assetPath(zoomImage.img)}
-                  alt={zoomImage.q}
-                  className="w-full h-full object-cover select-none"
-                  style={{
-                    imageRendering: "-webkit-optimize-contrast",
-                    transform: `scale(${zoomImage.zoom})`,
-                    transformOrigin: zoomImage.origin,
-                  }}
-                />
-              </div>
-
-              {/* Bottom Caption Bar */}
-              <div className="p-5 md:p-6 bg-zinc-950 border-t border-zinc-900 flex flex-col gap-2">
-                <h4 className="text-base font-semibold leading-snug text-white md:text-lg">
-                  "{zoomImage.q}"
-                </h4>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
     </div>
   );
 }

--- a/apps/web/app/hackathon/components/hero-demo/DemoAI.tsx
+++ b/apps/web/app/hackathon/components/hero-demo/DemoAI.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { type FormEvent, useEffect, useRef, useState } from "react";
+import { FileSpreadsheet, ArrowUp, Search } from "lucide-react";
+import { DEMO_ASKS, matchDemoAsk, replyToFreeform, type DemoAsk } from "./demoData";
+import { cn } from "@/app/lib/cn";
+
+type ChatTurn = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  ask?: DemoAsk;
+};
+
+type Thread = {
+  id: string;
+  title: string;
+  group: "Today" | "Yesterday" | "Previous 30 Days";
+  askIndex?: number;
+};
+
+const THREADS: Thread[] = [
+  { id: "new", title: "Ask anything", group: "Today" },
+  { id: "week", title: "What did I get done", group: "Today", askIndex: 0 },
+  { id: "acme", title: "Acme this week", group: "Yesterday", askIndex: 1 },
+  { id: "tuesday", title: "Tuesday afternoon", group: "Yesterday", askIndex: 2 },
+  { id: "report", title: "Weekly update report", group: "Previous 30 Days", askIndex: 4 },
+];
+
+function AttachmentCard({ title, kind }: { title: string; kind: string }) {
+  return (
+    <div className="mt-3 flex max-w-sm items-center gap-3 rounded-xl border border-zinc-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-950">
+      <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-400">
+        <FileSpreadsheet className="size-4" aria-hidden />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">{title}</p>
+        <p className="text-xs text-zinc-500 dark:text-zinc-400">{kind}</p>
+      </div>
+      <button
+        type="button"
+        className="shrink-0 rounded-lg border border-zinc-200 px-2.5 py-1 text-xs font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-900"
+      >
+        Open
+      </button>
+    </div>
+  );
+}
+
+export function DemoAI() {
+  const [input, setInput] = useState("");
+  const [turns, setTurns] = useState<ChatTurn[]>([]);
+  const [streamingId, setStreamingId] = useState<string | null>(null);
+  const [streamedText, setStreamedText] = useState("");
+  const [activeThreadId, setActiveThreadId] = useState("new");
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const stickToBottom = useRef(true);
+  const streamTimer = useRef<number | null>(null);
+
+  function isNearBottom(el: HTMLDivElement): boolean {
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }
+
+  function scrollToBottomIfSticky() {
+    if (!stickToBottom.current) return;
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+      return;
+    }
+    bottomRef.current?.scrollIntoView({ block: "end" });
+  }
+
+  useEffect(() => {
+    scrollToBottomIfSticky();
+  }, [turns, streamedText]);
+
+  useEffect(() => {
+    return () => {
+      if (streamTimer.current) window.clearInterval(streamTimer.current);
+    };
+  }, []);
+
+  function runAsk(ask: DemoAsk, threadId?: string) {
+    if (streamTimer.current) {
+      window.clearInterval(streamTimer.current);
+      streamTimer.current = null;
+    }
+
+    if (threadId) setActiveThreadId(threadId);
+    stickToBottom.current = true;
+
+    const userTurn: ChatTurn = {
+      id: `u-${Date.now()}`,
+      role: "user",
+      text: ask.q,
+    };
+    const assistantId = `a-${Date.now()}`;
+    setTurns([userTurn]);
+    setStreamingId(assistantId);
+    setStreamedText("");
+    setInput("");
+
+    let i = 0;
+    streamTimer.current = window.setInterval(() => {
+      i += 2;
+      const next = ask.a.slice(0, i);
+      setStreamedText(next);
+      if (i >= ask.a.length) {
+        if (streamTimer.current) window.clearInterval(streamTimer.current);
+        streamTimer.current = null;
+        setTurns([userTurn, { id: assistantId, role: "assistant", text: ask.a, ask }]);
+        setStreamingId(null);
+        setStreamedText("");
+      }
+    }, 16);
+  }
+
+  function selectThread(thread: Thread) {
+    setActiveThreadId(thread.id);
+    if (thread.askIndex !== undefined) {
+      const ask = DEMO_ASKS[thread.askIndex];
+      if (ask) runAsk(ask, thread.id);
+      return;
+    }
+    if (streamTimer.current) {
+      window.clearInterval(streamTimer.current);
+      streamTimer.current = null;
+    }
+    setTurns([]);
+    setStreamingId(null);
+    setStreamedText("");
+  }
+
+  function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    const matched = matchDemoAsk(input);
+    if (matched) {
+      runAsk(matched);
+      return;
+    }
+    if (!input.trim()) return;
+
+    stickToBottom.current = true;
+    const userTurn: ChatTurn = {
+      id: `u-${Date.now()}`,
+      role: "user",
+      text: input.trim(),
+    };
+    const nudge: ChatTurn = {
+      id: `a-${Date.now()}`,
+      role: "assistant",
+      text: replyToFreeform(input),
+    };
+    setTurns((prev) => [...prev, userTurn, nudge]);
+    setInput("");
+  }
+
+  const isEmpty = turns.length === 0 && !streamingId;
+  const groups = ["Today", "Yesterday", "Previous 30 Days"] as const;
+  const activeThread = THREADS.find((t) => t.id === activeThreadId) ?? THREADS[0]!;
+
+  return (
+    <div className="flex h-full min-h-0">
+      {/* Thread list — mirrors desktop AI sidebar */}
+      <aside className="flex w-[180px] shrink-0 flex-col border-r border-zinc-200 bg-zinc-50/80 dark:border-zinc-800 dark:bg-zinc-900/40 xl:w-[200px]">
+        <div className="border-b border-zinc-200 px-3 py-2.5 dark:border-zinc-800">
+          <div className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-2 py-1.5 text-xs text-zinc-400 dark:border-zinc-700 dark:bg-zinc-950">
+            <Search className="size-3.5 shrink-0" aria-hidden />
+            Search chats
+          </div>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+          {groups.map((group) => {
+            const items = THREADS.filter((t) => t.group === group);
+            if (items.length === 0) return null;
+            return (
+              <div key={group} className="mb-3">
+                <p className="px-2 py-1 font-mono text-[9px] uppercase tracking-widest text-zinc-400">
+                  {group}
+                </p>
+                <ul className="flex flex-col gap-0.5">
+                  {items.map((thread) => (
+                    <li key={thread.id}>
+                      <button
+                        type="button"
+                        onClick={() => selectThread(thread)}
+                        className={cn(
+                          "w-full truncate rounded-lg px-2 py-1.5 text-left text-xs transition-colors",
+                          activeThreadId === thread.id
+                            ? "bg-zinc-200/90 font-medium text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
+                            : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800/60",
+                        )}
+                      >
+                        {thread.title}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex shrink-0 items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+          <div>
+            <p className="text-sm font-medium tracking-tight">{activeThread.title}</p>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              Scripted demo · same memory as Timeline
+            </p>
+          </div>
+        </div>
+
+        <div
+          ref={scrollRef}
+          onScroll={() => {
+            const el = scrollRef.current;
+            if (!el) return;
+            stickToBottom.current = isNearBottom(el);
+          }}
+          className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
+        >
+          {isEmpty ? (
+            <div className="mx-auto flex h-full w-full max-w-lg flex-col justify-center gap-4">
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                Ask about this sample week — answers are grounded in the same Timeline and
+                Apps memory.
+              </p>
+              <ul className="flex flex-col gap-2">
+                {DEMO_ASKS.map((ask) => (
+                  <li key={ask.q}>
+                    <button
+                      type="button"
+                      onClick={() => runAsk(ask)}
+                      className="w-full rounded-xl border border-zinc-200 bg-white px-3.5 py-2.5 text-left text-sm text-zinc-700 transition-colors hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-200 dark:hover:border-zinc-700 dark:hover:bg-zinc-900"
+                    >
+                      “{ask.q}”
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <div className="mx-auto flex w-full max-w-lg flex-col gap-3">
+              {turns.map((turn) =>
+                turn.role === "user" ? (
+                  <div key={turn.id} className="flex justify-end">
+                    <span className="max-w-[min(100%,20rem)] rounded-2xl bg-zinc-900 px-3.5 py-2 text-sm leading-relaxed text-white dark:bg-white dark:text-zinc-900">
+                      {turn.text}
+                    </span>
+                  </div>
+                ) : (
+                  <div key={turn.id} className="w-full text-sm leading-relaxed">
+                    <p className="whitespace-pre-line text-zinc-700 dark:text-zinc-200">
+                      {turn.text}
+                    </p>
+                    {turn.ask?.attachment && (
+                      <AttachmentCard
+                        title={turn.ask.attachment.title}
+                        kind={turn.ask.attachment.kind}
+                      />
+                    )}
+                    {turn.ask && turn.ask.evidence.length > 0 && (
+                      <div className="mt-3 flex flex-wrap gap-1.5">
+                        {turn.ask.evidence.map((chip) => (
+                          <span
+                            key={chip}
+                            className="rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-[11px] text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400"
+                          >
+                            {chip}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ),
+              )}
+
+              {streamingId && (
+                <div className="w-full text-sm leading-relaxed">
+                  <p className="whitespace-pre-line text-zinc-700 dark:text-zinc-200">
+                    {streamedText}
+                    <span className="ml-0.5 inline-block h-3.5 w-[2px] animate-pulse bg-zinc-400 align-middle" />
+                  </p>
+                </div>
+              )}
+              <div ref={bottomRef} />
+            </div>
+          )}
+        </div>
+
+        <form
+          onSubmit={onSubmit}
+          className="shrink-0 border-t border-zinc-200 p-3 dark:border-zinc-800"
+        >
+          <div className="mx-auto flex w-full max-w-lg items-end gap-2 rounded-2xl border border-zinc-200 bg-white px-3 py-2 dark:border-zinc-700 dark:bg-zinc-950">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Ask anything — / for commands, @ to mention…"
+              className="min-w-0 flex-1 bg-transparent py-1.5 text-sm outline-none placeholder:text-zinc-400"
+              disabled={streamingId !== null}
+            />
+            <button
+              type="submit"
+              disabled={streamingId !== null || !input.trim()}
+              className="flex size-8 shrink-0 items-center justify-center rounded-full bg-zinc-900 text-white transition-opacity disabled:opacity-30 dark:bg-white dark:text-zinc-900"
+              aria-label="Send"
+            >
+              <ArrowUp className="size-4" />
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/hackathon/components/hero-demo/DemoApps.tsx
+++ b/apps/web/app/hackathon/components/hero-demo/DemoApps.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { DEMO_APPS } from "./demoData";
+import { assetPath } from "@/app/lib/basePath";
+import { cn } from "@/app/lib/cn";
+
+export function DemoApps() {
+  const [selectedId, setSelectedId] = useState(DEMO_APPS[0]!.id);
+  const selected = DEMO_APPS.find((app) => app.id === selectedId) ?? DEMO_APPS[0]!;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <p className="text-sm font-medium tracking-tight">Today</p>
+        <div className="flex items-center gap-1 rounded-lg border border-zinc-200 p-0.5 text-xs dark:border-zinc-700">
+          <span className="rounded-md bg-zinc-900 px-2.5 py-1 font-medium text-white dark:bg-white dark:text-zinc-900">
+            Day
+          </span>
+          <span className="px-2.5 py-1 text-zinc-400">7d</span>
+          <span className="px-2.5 py-1 text-zinc-400">30d</span>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        <ul className="w-[200px] shrink-0 overflow-y-auto border-r border-zinc-200 p-2 dark:border-zinc-800 sm:w-[220px]">
+          {DEMO_APPS.map((app) => {
+            const isSelected = app.id === selected.id;
+            return (
+              <li key={app.id}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedId(app.id)}
+                  className={cn(
+                    "flex w-full items-center gap-3 rounded-xl px-2.5 py-2.5 text-left transition-colors",
+                    isSelected
+                      ? "bg-zinc-100 dark:bg-zinc-800"
+                      : "hover:bg-zinc-50 dark:hover:bg-zinc-900",
+                  )}
+                >
+                  <Image
+                    src={assetPath(app.brandSrc)}
+                    alt=""
+                    width={22}
+                    height={22}
+                    className={cn("size-[22px]", app.invertInDark && "dark:invert")}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">{app.name}</span>
+                    <span className="block truncate text-[11px] text-zinc-500 dark:text-zinc-400">
+                      {app.category} · {app.durationLabel}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        <div className="min-w-0 flex-1 overflow-y-auto p-4">
+          <div className="rounded-2xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-950">
+            <div className="flex items-start gap-3">
+              <Image
+                src={assetPath(selected.brandSrc)}
+                alt=""
+                width={36}
+                height={36}
+                className={cn("size-9", selected.invertInDark && "dark:invert")}
+              />
+              <div className="min-w-0">
+                <h3 className="text-base font-medium tracking-tight">{selected.name}</h3>
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                  {selected.category} · Tracked for {selected.durationLabel} ·{" "}
+                  {selected.sessionsLabel}
+                </p>
+              </div>
+            </div>
+            <p className="mt-3 text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+              {selected.narrative}
+            </p>
+          </div>
+
+          <p className="mt-5 font-mono text-[10px] uppercase tracking-widest text-zinc-400">
+            What you did there
+          </p>
+          <ul className="mt-2 space-y-2">
+            {selected.sessions.map((session) => (
+              <li
+                key={`${session.title}-${session.when}`}
+                className="rounded-xl border border-zinc-200 bg-zinc-50 px-3 py-2.5 dark:border-zinc-800 dark:bg-zinc-900/50"
+              >
+                <p className="text-sm font-medium">{session.title}</p>
+                <p className="text-[11px] text-zinc-500 dark:text-zinc-400">{session.when}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/hackathon/components/hero-demo/DemoTimeline.tsx
+++ b/apps/web/app/hackathon/components/hero-demo/DemoTimeline.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Image from "next/image";
+import {
+  APP_BRANDS,
+  CATEGORY_COLORS,
+  DEMO_BLOCKS,
+  DEMO_DAY_LABEL,
+  DEMO_MONTH_DAYS,
+  DEMO_MONTH_LABEL,
+  DEMO_WEEK_BLOCKS,
+  DEMO_WEEK_DAYS,
+  DEMO_WEEK_LABEL,
+  blockAccentStyle,
+  blockDurationMinutes,
+  formatClock,
+  formatDuration,
+  type DemoBlock,
+} from "./demoData";
+import { assetPath } from "@/app/lib/basePath";
+import { cn } from "@/app/lib/cn";
+
+const DAY_START = 9;
+const DAY_END = 18;
+const PX_PER_HOUR = 72;
+
+type TimelineView = "day" | "week" | "month";
+
+function blockTop(block: DemoBlock): number {
+  return ((block.startHour - DAY_START) * 60 + block.startMinute) * (PX_PER_HOUR / 60);
+}
+
+function blockHeight(block: DemoBlock): number {
+  return Math.max(blockDurationMinutes(block) * (PX_PER_HOUR / 60), 52);
+}
+
+function AppIconRow({ apps }: { apps: string[] }) {
+  return (
+    <ul className="mt-1.5 flex flex-wrap items-center gap-2">
+      {apps.map((name) => {
+        const brand = APP_BRANDS[name];
+        return (
+          <li key={name} className="flex items-center gap-1.5">
+            {brand ? (
+              <Image
+                src={assetPath(brand.src)}
+                alt=""
+                width={16}
+                height={16}
+                className={cn("size-4", brand.invertInDark && "dark:invert")}
+              />
+            ) : (
+              <span className="flex size-4 items-center justify-center rounded bg-zinc-200 text-[8px] font-medium text-zinc-600 dark:bg-zinc-700 dark:text-zinc-300">
+                {name.slice(0, 1)}
+              </span>
+            )}
+            <span className="text-xs text-zinc-600 dark:text-zinc-300">{name}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function ViewSwitcher({
+  view,
+  onChange,
+}: {
+  view: TimelineView;
+  onChange: (view: TimelineView) => void;
+}) {
+  return (
+    <div className="flex items-center gap-0.5 rounded-lg border border-zinc-200 p-0.5 text-xs dark:border-zinc-700">
+      {(["day", "week", "month"] as const).map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => onChange(option)}
+          className={cn(
+            "rounded-md px-2.5 py-1 capitalize transition-colors",
+            view === option
+              ? "bg-blue-600 font-medium text-white"
+              : "text-zinc-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200",
+          )}
+        >
+          {option}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function DayView({
+  selectedId,
+  onSelect,
+}: {
+  selectedId: string;
+  onSelect: (id: string) => void;
+}) {
+  const hours = useMemo(
+    () => Array.from({ length: DAY_END - DAY_START }, (_, i) => DAY_START + i),
+    [],
+  );
+  const trackHeight = (DAY_END - DAY_START) * PX_PER_HOUR;
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+      <div className="relative" style={{ height: trackHeight }}>
+        {hours.map((hour) => (
+          <div
+            key={hour}
+            className="pointer-events-none absolute inset-x-0 border-t border-zinc-100 dark:border-zinc-800/80"
+            style={{ top: (hour - DAY_START) * PX_PER_HOUR }}
+          >
+            <span className="absolute -top-2.5 left-0 font-mono text-[10px] text-zinc-400 dark:text-zinc-500">
+              {formatClock(hour, 0).replace(":00", "")}
+            </span>
+          </div>
+        ))}
+
+        {DEMO_BLOCKS.map((block) => {
+          const isSelected = block.id === selectedId;
+          const accent = blockAccentStyle(block.category, isSelected);
+          return (
+            <button
+              key={block.id}
+              type="button"
+              onClick={() => onSelect(block.id)}
+              className="absolute right-0 left-10 overflow-hidden rounded-xl border px-3 py-2 text-left transition-shadow"
+              style={{
+                top: blockTop(block),
+                height: blockHeight(block),
+                backgroundColor: accent.backgroundColor,
+                borderColor: accent.borderColor,
+              }}
+            >
+              <p className="truncate text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                {block.title}
+              </p>
+              <p className="mt-0.5 truncate text-[11px] text-zinc-600 dark:text-zinc-400">
+                {formatClock(block.startHour, block.startMinute)} –{" "}
+                {formatClock(block.endHour, block.endMinute)}
+                {" · "}
+                {formatDuration(blockDurationMinutes(block))}
+              </p>
+              {blockHeight(block) > 64 && (
+                <p className="mt-1 line-clamp-2 text-[11px] leading-snug text-zinc-600 dark:text-zinc-400">
+                  {block.body}
+                </p>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function WeekView({
+  selectedId,
+  onSelect,
+}: {
+  selectedId: string;
+  onSelect: (id: string) => void;
+}) {
+  const hours = useMemo(
+    () => Array.from({ length: DAY_END - DAY_START }, (_, i) => DAY_START + i),
+    [],
+  );
+  const trackHeight = (DAY_END - DAY_START) * PX_PER_HOUR;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="grid shrink-0 grid-cols-[36px_repeat(7,minmax(0,1fr))] border-b border-zinc-200 dark:border-zinc-800">
+        <div />
+        {DEMO_WEEK_DAYS.map((day) => (
+          <div
+            key={day.label}
+            className="border-l border-zinc-100 px-1 py-2 text-center dark:border-zinc-800"
+          >
+            <p className="font-mono text-[10px] uppercase tracking-wide text-zinc-400">
+              {day.label}
+            </p>
+            <p
+              className={cn(
+                "mt-0.5 text-sm font-medium",
+                day.date === 28
+                  ? "mx-auto flex size-6 items-center justify-center rounded-full bg-blue-600 text-xs text-white"
+                  : "text-zinc-700 dark:text-zinc-200",
+              )}
+            >
+              {day.date}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div
+          className="grid grid-cols-[36px_repeat(7,minmax(0,1fr))]"
+          style={{ height: trackHeight, minWidth: 640 }}
+        >
+          <div className="relative">
+            {hours.map((hour) => (
+              <span
+                key={hour}
+                className="absolute left-0 font-mono text-[9px] text-zinc-400"
+                style={{ top: (hour - DAY_START) * PX_PER_HOUR - 6 }}
+              >
+                {formatClock(hour, 0).replace(":00", "")}
+              </span>
+            ))}
+          </div>
+
+          {DEMO_WEEK_DAYS.map((day, dayIndex) => (
+            <div
+              key={day.label}
+              className="relative border-l border-zinc-100 dark:border-zinc-800"
+            >
+              {hours.map((hour) => (
+                <div
+                  key={hour}
+                  className="pointer-events-none absolute inset-x-0 border-t border-zinc-100 dark:border-zinc-800/80"
+                  style={{ top: (hour - DAY_START) * PX_PER_HOUR }}
+                />
+              ))}
+              {DEMO_WEEK_BLOCKS.filter((b) => b.dayIndex === dayIndex).map((block) => {
+                const isSelected = block.id === selectedId;
+                const accent = blockAccentStyle(block.category, isSelected);
+                return (
+                  <button
+                    key={block.id}
+                    type="button"
+                    onClick={() => onSelect(block.id)}
+                    className="absolute inset-x-0.5 overflow-hidden rounded-md border px-1 py-0.5 text-left"
+                    style={{
+                      top: blockTop(block),
+                      height: blockHeight(block),
+                      backgroundColor: accent.backgroundColor,
+                      borderColor: accent.borderColor,
+                    }}
+                  >
+                    <p className="truncate text-[10px] font-medium leading-tight text-zinc-900 dark:text-zinc-100">
+                      {block.title}
+                    </p>
+                    {blockHeight(block) > 40 && (
+                      <p className="truncate text-[9px] text-zinc-600 dark:text-zinc-400">
+                        {formatDuration(blockDurationMinutes(block))}
+                      </p>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MonthView({ onPickDay }: { onPickDay: () => void }) {
+  return (
+    <div className="min-h-0 flex-1 overflow-auto p-3">
+      <div className="grid grid-cols-7 gap-px overflow-hidden rounded-xl border border-zinc-200 bg-zinc-200 dark:border-zinc-800 dark:bg-zinc-800">
+        {["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].map((d) => (
+          <div
+            key={d}
+            className="bg-zinc-50 px-2 py-1.5 font-mono text-[10px] uppercase tracking-wide text-zinc-400 dark:bg-zinc-900"
+          >
+            {d}
+          </div>
+        ))}
+        {DEMO_MONTH_DAYS.map((cell, index) => (
+          <button
+            key={`${cell.day}-${index}`}
+            type="button"
+            disabled={!cell.inMonth}
+            onClick={() => {
+              if (cell.isToday) onPickDay();
+            }}
+            className={cn(
+              "flex min-h-[88px] flex-col bg-white p-1.5 text-left dark:bg-zinc-950",
+              !cell.inMonth && "bg-zinc-50/80 dark:bg-zinc-900/40",
+              cell.isToday && "ring-1 ring-inset ring-blue-500",
+            )}
+          >
+            <span
+              className={cn(
+                "ml-auto flex size-5 items-center justify-center text-[11px]",
+                cell.isToday
+                  ? "rounded-full bg-blue-600 font-medium text-white"
+                  : cell.inMonth
+                    ? "text-zinc-700 dark:text-zinc-300"
+                    : "text-zinc-300 dark:text-zinc-600",
+              )}
+            >
+              {cell.day}
+            </span>
+            <ul className="mt-0.5 flex flex-1 flex-col gap-0.5 overflow-hidden">
+              {cell.entries.slice(0, 3).map((entry) => (
+                <li
+                  key={`${entry.time}-${entry.title}`}
+                  className="flex items-center gap-1 truncate text-[9px] text-zinc-600 dark:text-zinc-400"
+                >
+                  <span
+                    className="size-1.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: CATEGORY_COLORS[entry.category] }}
+                  />
+                  <span className="truncate">
+                    {entry.time} {entry.title}
+                  </span>
+                </li>
+              ))}
+              {cell.more ? (
+                <li className="text-[9px] text-zinc-400">+{cell.more} more</li>
+              ) : null}
+            </ul>
+            {cell.tracked && cell.inMonth ? (
+              <p className="mt-auto pt-0.5 text-[9px] text-zinc-400">{cell.tracked} tracked</p>
+            ) : null}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DemoTimeline() {
+  const [view, setView] = useState<TimelineView>("day");
+  const [selectedId, setSelectedId] = useState<string>(DEMO_BLOCKS[1]?.id ?? DEMO_BLOCKS[0]!.id);
+
+  const selected = useMemo(() => {
+    return (
+      DEMO_WEEK_BLOCKS.find((b) => b.id === selectedId) ??
+      DEMO_BLOCKS.find((b) => b.id === selectedId) ??
+      DEMO_BLOCKS[0]!
+    );
+  }, [selectedId]);
+
+  const totalMinutes = DEMO_BLOCKS.reduce((sum, b) => sum + blockDurationMinutes(b), 0);
+  const headerLabel =
+    view === "day" ? DEMO_DAY_LABEL : view === "week" ? DEMO_WEEK_LABEL : DEMO_MONTH_LABEL;
+  const headerSub =
+    view === "day"
+      ? `${formatDuration(totalMinutes)} tracked · ${DEMO_BLOCKS.length} blocks`
+      : view === "week"
+        ? "Sample week · click a block for details"
+        : "Click May 28 to open the day";
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+        <div>
+          <p className="text-sm font-medium tracking-tight text-zinc-900 dark:text-zinc-100">
+            {headerLabel}
+          </p>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">{headerSub}</p>
+        </div>
+        <ViewSwitcher view={view} onChange={setView} />
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {view === "day" && <DayView selectedId={selectedId} onSelect={setSelectedId} />}
+        {view === "week" && <WeekView selectedId={selectedId} onSelect={setSelectedId} />}
+        {view === "month" && (
+          <MonthView
+            onPickDay={() => {
+              setView("day");
+              setSelectedId(DEMO_BLOCKS[1]?.id ?? DEMO_BLOCKS[0]!.id);
+            }}
+          />
+        )}
+
+        {view !== "month" && (
+          <aside className="flex w-[220px] shrink-0 flex-col overflow-y-auto border-l border-zinc-200 bg-zinc-50/80 p-4 dark:border-zinc-800 dark:bg-zinc-900/40 xl:w-[260px]">
+            <p className="font-mono text-[10px] uppercase tracking-widest text-zinc-400">
+              Details
+            </p>
+            <div className="mt-2 flex items-center gap-2">
+              <span
+                className="size-2.5 rounded-full"
+                style={{ backgroundColor: CATEGORY_COLORS[selected.category] }}
+              />
+              <h3 className="text-base font-medium tracking-tight text-zinc-900 dark:text-zinc-100">
+                {selected.title}
+              </h3>
+            </div>
+            <p className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+              {formatClock(selected.startHour, selected.startMinute)} –{" "}
+              {formatClock(selected.endHour, selected.endMinute)}
+              {" · "}
+              {formatDuration(blockDurationMinutes(selected))}
+            </p>
+            <p className="mt-3 text-sm leading-relaxed text-zinc-600 dark:text-zinc-300">
+              {selected.body}
+            </p>
+            <div className="mt-4 flex flex-wrap gap-1.5">
+              {selected.evidence.map((chip) => (
+                <span
+                  key={chip}
+                  className="rounded-full border border-zinc-200 bg-white px-2.5 py-1 text-[11px] text-zinc-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-400"
+                >
+                  {chip}
+                </span>
+              ))}
+            </div>
+            <p className="mt-4 font-mono text-[10px] uppercase tracking-widest text-zinc-400">
+              Apps
+            </p>
+            <AppIconRow apps={selected.apps} />
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/hackathon/components/hero-demo/HeroDemo.tsx
+++ b/apps/web/app/hackathon/components/hero-demo/HeroDemo.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { CalendarDays, LayoutGrid, Sparkles, Settings } from "lucide-react";
+import { DemoTimeline } from "./DemoTimeline";
+import { DemoApps } from "./DemoApps";
+import { DemoAI } from "./DemoAI";
+import { assetPath } from "@/app/lib/basePath";
+import { cn } from "@/app/lib/cn";
+
+type DemoTab = "timeline" | "apps" | "ai";
+
+const NAV: Array<{ id: DemoTab; label: string; icon: typeof CalendarDays }> = [
+  { id: "timeline", label: "Timeline", icon: CalendarDays },
+  { id: "apps", label: "Apps", icon: LayoutGrid },
+  { id: "ai", label: "AI", icon: Sparkles },
+];
+
+export function HeroDemo() {
+  const [tab, setTab] = useState<DemoTab>("timeline");
+
+  return (
+    <div className="w-full">
+      {/* Interactive shell — md+ */}
+      <div
+        className="hidden overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-[0_24px_80px_-32px_rgba(0,0,0,0.35)] dark:border-zinc-800 dark:bg-zinc-950 dark:shadow-[0_24px_80px_-32px_rgba(0,0,0,0.7)] md:block"
+        style={{ height: "min(640px, 70vh)" }}
+      >
+        <div className="flex h-full min-h-0">
+          <nav className="flex w-[148px] shrink-0 flex-col border-r border-zinc-200 bg-zinc-50/90 dark:border-zinc-800 dark:bg-zinc-900/50">
+            <div className="flex items-center gap-2 px-3.5 pb-2 pt-3.5">
+              <Image
+                src={assetPath("/app-icon.png")}
+                alt=""
+                width={22}
+                height={22}
+                className="size-[22px] rounded-[5px]"
+              />
+              <span className="text-sm font-medium tracking-tight">Daylens</span>
+            </div>
+            <ul className="mt-3 flex flex-1 flex-col gap-0.5 px-2">
+              {NAV.map((item) => {
+                const Icon = item.icon;
+                const active = tab === item.id;
+                return (
+                  <li key={item.id}>
+                    <button
+                      type="button"
+                      onClick={() => setTab(item.id)}
+                      className={cn(
+                        "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-sm transition-colors",
+                        active
+                          ? "bg-zinc-200/80 font-medium text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100"
+                          : "text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800/60",
+                      )}
+                    >
+                      <Icon className="size-4 shrink-0 opacity-70" aria-hidden />
+                      {item.label}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+            <div className="border-t border-zinc-200 px-2 py-2 dark:border-zinc-800">
+              <div className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm text-zinc-400">
+                <Settings className="size-4 opacity-60" aria-hidden />
+                Settings
+              </div>
+            </div>
+          </nav>
+
+          <div className="min-w-0 flex-1">
+            {tab === "timeline" && <DemoTimeline />}
+            {tab === "apps" && <DemoApps />}
+            {tab === "ai" && <DemoAI />}
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile: static product image (shell is too dense below md) */}
+      <div className="md:hidden">
+        <Image
+          src={assetPath("/hackathon/01-timeline-day.png")}
+          alt="Daylens today view — a reconstructed timeline of your work"
+          width={2538}
+          height={1802}
+          priority
+          quality={90}
+          sizes="100vw"
+          className="h-auto w-full rounded-2xl border border-zinc-200 dark:border-zinc-800"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/hackathon/components/hero-demo/demoData.ts
+++ b/apps/web/app/hackathon/components/hero-demo/demoData.ts
@@ -1,0 +1,807 @@
+export type DemoAttachment = {
+  title: string;
+  kind: string;
+};
+
+export type DemoAsk = {
+  q: string;
+  a: string;
+  evidence: string[];
+  attachment?: DemoAttachment;
+  aliases?: string[];
+};
+
+/** Matches Daylens activity color groups (Settings → Activity colors). */
+export type DemoCategory =
+  | "development"
+  | "writing"
+  | "email"
+  | "productivity"
+  | "design"
+  | "meetings"
+  | "communication"
+  | "entertainment"
+  | "social"
+  | "browsing"
+  | "research";
+
+export const CATEGORY_COLORS: Record<DemoCategory, string> = {
+  development: "#3b82f6",
+  writing: "#ca8a04",
+  email: "#ca8a04",
+  productivity: "#ca8a04",
+  design: "#ca8a04",
+  meetings: "#8b5cf6",
+  communication: "#8b5cf6",
+  entertainment: "#ef4444",
+  social: "#ef4444",
+  browsing: "#64748b",
+  research: "#64748b",
+};
+
+export type DemoBlock = {
+  id: string;
+  title: string;
+  startHour: number;
+  startMinute: number;
+  endHour: number;
+  endMinute: number;
+  body: string;
+  evidence: string[];
+  apps: string[];
+  category: DemoCategory;
+  /** 0 = Mon … 6 = Sun within the demo week */
+  dayIndex?: number;
+};
+
+export type DemoAppBrand = {
+  src: string;
+  invertInDark?: boolean;
+};
+
+export type DemoApp = {
+  id: string;
+  name: string;
+  category: string;
+  brandSrc: string;
+  invertInDark?: boolean;
+  durationLabel: string;
+  sessionsLabel: string;
+  narrative: string;
+  sessions: Array<{ title: string; when: string }>;
+};
+
+export type DemoMonthEntry = {
+  time: string;
+  title: string;
+  category: DemoCategory;
+};
+
+export type DemoMonthDay = {
+  day: number;
+  inMonth: boolean;
+  isToday?: boolean;
+  tracked?: string;
+  more?: number;
+  entries: DemoMonthEntry[];
+};
+
+export const DEMO_DAY_LABEL = "Wednesday, May 28";
+export const DEMO_WEEK_LABEL = "May 26 – Jun 1";
+export const DEMO_MONTH_LABEL = "May 2026";
+
+export const DEMO_WEEK_DAYS = [
+  { label: "Mon", date: 26 },
+  { label: "Tue", date: 27 },
+  { label: "Wed", date: 28 },
+  { label: "Thu", date: 29 },
+  { label: "Fri", date: 30 },
+  { label: "Sat", date: 31 },
+  { label: "Sun", date: 1 },
+] as const;
+
+/** Brand assets for inspector app chips. Missing names fall back to initials. */
+export const APP_BRANDS: Record<string, DemoAppBrand> = {
+  Cursor: { src: "/brands/vscode.ico" },
+  Notion: { src: "/brands/notion.svg", invertInDark: true },
+  Dia: { src: "/brands/dia.png" },
+  Chrome: { src: "/brands/chrome.svg" },
+  Slack: { src: "/brands/slack.png" },
+  Figma: { src: "/brands/figma.svg" },
+  Linear: { src: "/brands/linear.svg" },
+  Claude: { src: "/brands/claude-app.png" },
+};
+
+export const DEMO_ASKS: DemoAsk[] = [
+  {
+    q: "What did I actually get done this week?",
+    a: "Three threads carried the week. The Acme proposal took about six hours across Monday through Wednesday. The launch checklist in Notion stretched from Tuesday afternoon into Thursday. And you spent a solid block researching vendor pricing — mostly in Dia and Chrome. Wednesday morning on the proposal was your densest stretch.",
+    evidence: ["6h Acme proposal", "Launch checklist", "Vendor research"],
+    aliases: ["get done", "what did i do", "this week", "accomplish"],
+  },
+  {
+    q: "What did I work on for Acme?",
+    a: "About 4h 20m on Acme this week: the Q3 proposal draft in Notion and Docs, two review passes with Mara in Slack, and a 45-minute walkthrough deck in Figma on Thursday. Most of the deep work landed before lunch on Wednesday.",
+    evidence: ["4h 20m total", "Notion · Docs · Figma", "Slack with Mara"],
+    aliases: ["acme", "proposal", "q3"],
+  },
+  {
+    q: "Where did Tuesday afternoon go?",
+    a: "After lunch you were in a 40-minute sync, then roughly two hours deep on the launch checklist. From about 3:40 you drifted into email and LinkedIn for half an hour, then finished in Dia on competitor pages. The checklist was the real work; the last hour was lighter.",
+    evidence: ["40m sync", "2h launch checklist", "Dia · email"],
+    aliases: ["tuesday", "afternoon", "where did"],
+  },
+  {
+    q: "What did I read before that meeting?",
+    a: "In the hour before the 2pm sync you opened three things: the Acme brief in Notion, Mara's comment thread in Slack, and a pricing comparison tab in Dia you'd started on Monday. The brief held your attention longest.",
+    evidence: ["Acme brief", "Slack thread", "Pricing tabs"],
+    aliases: ["read before", "meeting", "before that"],
+  },
+  {
+    q: "Draft my weekly update report from what I got done this week.",
+    a: "You moved three things this week: the Acme Q3 proposal through two review rounds, the launch checklist nearly to done, and a vendor pricing recommendation into Notion. Wednesday carried most of the deep work. Full write-up is in the spreadsheet.",
+    evidence: [],
+    attachment: {
+      title: "Weekly update — May 26.xlsx",
+      kind: "Spreadsheet",
+    },
+    aliases: ["weekly update", "draft", "report", "excel", "spreadsheet"],
+  },
+];
+
+/** Wednesday focus day (also dayIndex 2 in the week grid). */
+export const DEMO_BLOCKS: DemoBlock[] = [
+  {
+    id: "standup",
+    title: "Team sync",
+    startHour: 9,
+    startMinute: 0,
+    endHour: 9,
+    endMinute: 40,
+    body: "Forty-minute standup and Acme status check. Mara flagged two open questions on pricing that you picked up later in Dia.",
+    evidence: ["Zoom · 40m", "Slack prep notes"],
+    apps: ["Slack"],
+    category: "meetings",
+    dayIndex: 2,
+  },
+  {
+    id: "acme",
+    title: "Acme Q3 proposal",
+    startHour: 9,
+    startMinute: 45,
+    endHour: 12,
+    endMinute: 30,
+    body: "Deep stretch on the Q3 proposal in Notion and Docs — the densest block of the week. Two review passes with Mara's comments in Slack, then a structure pass before lunch.",
+    evidence: ["Notion · Docs", "Slack with Mara", "2h 45m deep work"],
+    apps: ["Cursor", "Notion", "Slack"],
+    category: "development",
+    dayIndex: 2,
+  },
+  {
+    id: "lunch-drift",
+    title: "Email and LinkedIn",
+    startHour: 12,
+    startMinute: 30,
+    endHour: 13,
+    endMinute: 25,
+    body: "Lighter pass through inbox and LinkedIn after lunch before returning to the checklist.",
+    evidence: ["Spark", "LinkedIn · 55m"],
+    apps: ["Dia"],
+    category: "social",
+    dayIndex: 2,
+  },
+  {
+    id: "launch",
+    title: "Launch checklist",
+    startHour: 13,
+    startMinute: 30,
+    endHour: 15,
+    endMinute: 45,
+    body: "Continued the launch checklist in Notion — moved several vendor-dependent items forward and left three blockers for Thursday.",
+    evidence: ["Notion checklist", "2h 15m"],
+    apps: ["Notion", "Linear"],
+    category: "productivity",
+    dayIndex: 2,
+  },
+  {
+    id: "vendor",
+    title: "Vendor pricing research",
+    startHour: 16,
+    startMinute: 0,
+    endHour: 17,
+    endMinute: 30,
+    body: "Compared three pricing options in Dia and Chrome. Recommendation noted in Notion for Monday's review.",
+    evidence: ["Dia · Chrome", "Pricing tabs", "1h 30m"],
+    apps: ["Dia", "Chrome", "Notion"],
+    category: "browsing",
+    dayIndex: 2,
+  },
+];
+
+/** Extra blocks for other days in the week view (Acme sample week). */
+export const DEMO_WEEK_BLOCKS: DemoBlock[] = [
+  ...DEMO_BLOCKS,
+  {
+    id: "mon-brief",
+    title: "Acme brief outline",
+    startHour: 10,
+    startMinute: 0,
+    endHour: 12,
+    endMinute: 0,
+    body: "Started the Q3 brief in Notion.",
+    evidence: ["Notion"],
+    apps: ["Notion"],
+    category: "writing",
+    dayIndex: 0,
+  },
+  {
+    id: "mon-pricing",
+    title: "Pricing tabs",
+    startHour: 14,
+    startMinute: 0,
+    endHour: 15,
+    endMinute: 30,
+    body: "Opened vendor comparison tabs in Dia.",
+    evidence: ["Dia"],
+    apps: ["Dia"],
+    category: "research",
+    dayIndex: 0,
+  },
+  {
+    id: "tue-sync",
+    title: "Afternoon sync",
+    startHour: 13,
+    startMinute: 0,
+    endHour: 13,
+    endMinute: 40,
+    body: "40-minute sync before the checklist.",
+    evidence: ["Slack"],
+    apps: ["Slack"],
+    category: "meetings",
+    dayIndex: 1,
+  },
+  {
+    id: "tue-launch",
+    title: "Launch checklist",
+    startHour: 13,
+    startMinute: 45,
+    endHour: 15,
+    endMinute: 45,
+    body: "Deep stretch on the launch checklist.",
+    evidence: ["Notion"],
+    apps: ["Notion", "Linear"],
+    category: "productivity",
+    dayIndex: 1,
+  },
+  {
+    id: "tue-drift",
+    title: "Email and LinkedIn",
+    startHour: 15,
+    startMinute: 45,
+    endHour: 16,
+    endMinute: 15,
+    body: "Lighter afternoon drift.",
+    evidence: ["Dia"],
+    apps: ["Dia"],
+    category: "social",
+    dayIndex: 1,
+  },
+  {
+    id: "thu-deck",
+    title: "Acme walkthrough deck",
+    startHour: 14,
+    startMinute: 0,
+    endHour: 14,
+    endMinute: 45,
+    body: "Figma walkthrough for Thursday's sync.",
+    evidence: ["Figma"],
+    apps: ["Figma"],
+    category: "design",
+    dayIndex: 3,
+  },
+  {
+    id: "thu-launch",
+    title: "Launch checklist wrap",
+    startHour: 10,
+    startMinute: 0,
+    endHour: 12,
+    endMinute: 0,
+    body: "Cleared remaining launch items.",
+    evidence: ["Notion"],
+    apps: ["Notion"],
+    category: "productivity",
+    dayIndex: 3,
+  },
+  {
+    id: "fri-light",
+    title: "Weekly notes",
+    startHour: 9,
+    startMinute: 30,
+    endHour: 11,
+    endMinute: 0,
+    body: "Light Friday pass on notes and inbox.",
+    evidence: ["Notion"],
+    apps: ["Notion"],
+    category: "writing",
+    dayIndex: 4,
+  },
+  {
+    id: "mon-standup",
+    title: "Monday standup",
+    startHour: 9,
+    startMinute: 0,
+    endHour: 9,
+    endMinute: 35,
+    body: "Week kickoff sync.",
+    evidence: ["Slack"],
+    apps: ["Slack"],
+    category: "meetings",
+    dayIndex: 0,
+  },
+  {
+    id: "mon-cursor",
+    title: "Proposal draft in Cursor",
+    startHour: 12,
+    startMinute: 15,
+    endHour: 13,
+    endMinute: 30,
+    body: "Short Cursor pass on Acme sections.",
+    evidence: ["Cursor"],
+    apps: ["Cursor"],
+    category: "development",
+    dayIndex: 0,
+  },
+  {
+    id: "mon-wrap",
+    title: "Slack with Mara",
+    startHour: 16,
+    startMinute: 0,
+    endHour: 16,
+    endMinute: 45,
+    body: "Async review thread on the brief.",
+    evidence: ["Slack"],
+    apps: ["Slack"],
+    category: "communication",
+    dayIndex: 0,
+  },
+  {
+    id: "tue-morning",
+    title: "Acme proposal pass",
+    startHour: 9,
+    startMinute: 15,
+    endHour: 11,
+    endMinute: 45,
+    body: "Morning deep work on the Q3 draft.",
+    evidence: ["Notion", "Cursor"],
+    apps: ["Notion", "Cursor"],
+    category: "development",
+    dayIndex: 1,
+  },
+  {
+    id: "tue-lunch",
+    title: "Browsing competitor pages",
+    startHour: 12,
+    startMinute: 0,
+    endHour: 12,
+    endMinute: 40,
+    body: "Quick Dia pass before the sync.",
+    evidence: ["Dia"],
+    apps: ["Dia"],
+    category: "browsing",
+    dayIndex: 1,
+  },
+  {
+    id: "tue-evening",
+    title: "Competitor pages",
+    startHour: 16,
+    startMinute: 20,
+    endHour: 17,
+    endMinute: 30,
+    body: "Finished Tuesday in Dia on competitor tabs.",
+    evidence: ["Dia"],
+    apps: ["Dia"],
+    category: "research",
+    dayIndex: 1,
+  },
+  {
+    id: "thu-morning",
+    title: "Vendor follow-ups",
+    startHour: 9,
+    startMinute: 0,
+    endHour: 9,
+    endMinute: 50,
+    body: "Email follow-ups on open vendor questions.",
+    evidence: ["Dia"],
+    apps: ["Dia"],
+    category: "email",
+    dayIndex: 3,
+  },
+  {
+    id: "thu-sync",
+    title: "Acme walkthrough sync",
+    startHour: 15,
+    startMinute: 0,
+    endHour: 15,
+    endMinute: 45,
+    body: "Presented the Figma deck.",
+    evidence: ["Slack", "Figma"],
+    apps: ["Slack", "Figma"],
+    category: "meetings",
+    dayIndex: 3,
+  },
+  {
+    id: "thu-evening",
+    title: "Linear triage",
+    startHour: 16,
+    startMinute: 0,
+    endHour: 17,
+    endMinute: 15,
+    body: "Cleared launch tickets after the sync.",
+    evidence: ["Linear"],
+    apps: ["Linear"],
+    category: "productivity",
+    dayIndex: 3,
+  },
+  {
+    id: "fri-sync",
+    title: "Friday check-in",
+    startHour: 11,
+    startMinute: 15,
+    endHour: 11,
+    endMinute: 50,
+    body: "Short team check-in.",
+    evidence: ["Slack"],
+    apps: ["Slack"],
+    category: "meetings",
+    dayIndex: 4,
+  },
+  {
+    id: "fri-ship",
+    title: "Ship checklist leftovers",
+    startHour: 13,
+    startMinute: 0,
+    endHour: 15,
+    endMinute: 0,
+    body: "Closed remaining launch items before the weekend.",
+    evidence: ["Notion", "Linear"],
+    apps: ["Notion", "Linear"],
+    category: "productivity",
+    dayIndex: 4,
+  },
+  {
+    id: "fri-slack",
+    title: "Wrap-up messages",
+    startHour: 15,
+    startMinute: 15,
+    endHour: 16,
+    endMinute: 0,
+    body: "Sent status notes for Monday.",
+    evidence: ["Slack"],
+    apps: ["Slack"],
+    category: "communication",
+    dayIndex: 4,
+  },
+  {
+    id: "sat-browse",
+    title: "Light browsing",
+    startHour: 10,
+    startMinute: 0,
+    endHour: 11,
+    endMinute: 30,
+    body: "Weekend skim — nothing deep.",
+    evidence: ["Dia"],
+    apps: ["Dia"],
+    category: "browsing",
+    dayIndex: 5,
+  },
+  {
+    id: "sat-leisure",
+    title: "YouTube and reading",
+    startHour: 14,
+    startMinute: 0,
+    endHour: 16,
+    endMinute: 0,
+    body: "Leisure afternoon.",
+    evidence: ["Dia"],
+    apps: ["Dia"],
+    category: "entertainment",
+    dayIndex: 5,
+  },
+  {
+    id: "sun-light",
+    title: "Inbox skim",
+    startHour: 11,
+    startMinute: 0,
+    endHour: 11,
+    endMinute: 45,
+    body: "Quick Sunday inbox pass.",
+    evidence: ["Dia"],
+    apps: ["Dia"],
+    category: "email",
+    dayIndex: 6,
+  },
+  {
+    id: "sun-plan",
+    title: "Next-week outline",
+    startHour: 16,
+    startMinute: 0,
+    endHour: 17,
+    endMinute: 0,
+    body: "Sketched Monday priorities in Notion.",
+    evidence: ["Notion"],
+    apps: ["Notion"],
+    category: "writing",
+    dayIndex: 6,
+  },
+];
+
+export const DEMO_APPS: DemoApp[] = [
+  {
+    id: "cursor",
+    name: "Cursor",
+    category: "Development",
+    brandSrc: "/brands/vscode.ico",
+    durationLabel: "2h 10m",
+    sessionsLabel: "3 sessions",
+    narrative:
+      "Cursor carried the engineering side of the Acme stretch — drafting sections of the proposal with Agents open alongside Notion for the brief.",
+    sessions: [
+      { title: "Acme proposal draft", when: "9:50 AM – 11:40 AM" },
+      { title: "Pricing notes pass", when: "4:40 PM – 5:00 PM" },
+    ],
+  },
+  {
+    id: "notion",
+    name: "Notion",
+    category: "Productivity",
+    brandSrc: "/brands/notion.svg",
+    invertInDark: true,
+    durationLabel: "3h 40m",
+    sessionsLabel: "5 sessions",
+    narrative:
+      "Most of your Notion time sat on the Acme proposal and the launch checklist — planning under Ideas, then execution on the checklist through the afternoon.",
+    sessions: [
+      { title: "Acme Q3 proposal", when: "9:45 AM – 12:30 PM" },
+      { title: "Launch checklist", when: "1:30 PM – 3:45 PM" },
+      { title: "Vendor recommendation note", when: "5:10 PM – 5:25 PM" },
+    ],
+  },
+  {
+    id: "dia",
+    name: "Dia",
+    category: "Browsing",
+    brandSrc: "/brands/dia.png",
+    durationLabel: "1h 55m",
+    sessionsLabel: "4 sessions",
+    narrative:
+      "Dia carried the vendor pricing comparison and a few competitor tabs after the checklist. Pricing held attention longest.",
+    sessions: [
+      { title: "Vendor pricing comparison", when: "4:00 PM – 5:20 PM" },
+      { title: "Competitor pages", when: "3:50 PM – 4:00 PM" },
+    ],
+  },
+  {
+    id: "slack",
+    name: "Slack",
+    category: "Communication",
+    brandSrc: "/brands/slack.png",
+    durationLabel: "1h 05m",
+    sessionsLabel: "6 sessions",
+    narrative:
+      "Two review passes with Mara on the Acme proposal, plus standup prep. Comment threads were short but shaped the morning draft.",
+    sessions: [
+      { title: "Acme review with Mara", when: "10:40 AM – 11:05 AM" },
+      { title: "Standup prep", when: "8:50 AM – 9:00 AM" },
+    ],
+  },
+  {
+    id: "figma",
+    name: "Figma",
+    category: "Design",
+    brandSrc: "/brands/figma.svg",
+    durationLabel: "45m",
+    sessionsLabel: "1 session",
+    narrative:
+      "Thursday's walkthrough deck — stubbed in the demo memory so Acme asks still land even though today is Wednesday.",
+    sessions: [{ title: "Acme walkthrough deck", when: "Thu 2:00 PM – 2:45 PM" }],
+  },
+];
+
+/** May 2026 month grid: Mon-start, includes trailing Apr / leading Jun cells. */
+export const DEMO_MONTH_DAYS: DemoMonthDay[] = [
+  { day: 27, inMonth: false, entries: [] },
+  { day: 28, inMonth: false, entries: [] },
+  { day: 29, inMonth: false, entries: [] },
+  { day: 30, inMonth: false, entries: [] },
+  {
+    day: 1,
+    inMonth: true,
+    tracked: "5h 20m",
+    entries: [
+      { time: "9:10 AM", title: "Planning week", category: "productivity" },
+      { time: "2:00 PM", title: "Research pass", category: "research" },
+    ],
+  },
+  {
+    day: 2,
+    inMonth: true,
+    tracked: "6h 40m",
+    entries: [
+      { time: "9:00 AM", title: "Development", category: "development" },
+      { time: "1:30 PM", title: "Docs review", category: "writing" },
+    ],
+  },
+  {
+    day: 3,
+    inMonth: true,
+    tracked: "4h 10m",
+    entries: [{ time: "10:00 AM", title: "Team sync", category: "meetings" }],
+  },
+  // Remaining May days (4–31)
+  ...Array.from({ length: 28 }, (_, i) => {
+    const day = i + 4;
+    const isFocusWeek = day >= 26 && day <= 31;
+    if (!isFocusWeek) {
+      const light: DemoMonthDay = {
+        day,
+        inMonth: true,
+        tracked: day % 3 === 0 ? "3h 20m" : day % 2 === 0 ? "5h 10m" : "6h 45m",
+        entries: [
+          {
+            time: "9:15 AM",
+            title: day % 2 === 0 ? "Development" : "Writing",
+            category: day % 2 === 0 ? "development" : "writing",
+          },
+          {
+            time: "2:00 PM",
+            title: day % 3 === 0 ? "Browsing" : "Meetings",
+            category: day % 3 === 0 ? "browsing" : "meetings",
+          },
+        ],
+        more: day % 4 === 0 ? 2 : undefined,
+      };
+      return light;
+    }
+    if (day === 26) {
+      return {
+        day,
+        inMonth: true,
+        tracked: "5h 30m",
+        entries: [
+          { time: "10:00 AM", title: "Acme brief", category: "writing" as const },
+          { time: "2:00 PM", title: "Pricing tabs", category: "research" as const },
+        ],
+      };
+    }
+    if (day === 27) {
+      return {
+        day,
+        inMonth: true,
+        tracked: "4h 55m",
+        entries: [
+          { time: "1:00 PM", title: "Afternoon sync", category: "meetings" as const },
+          { time: "1:45 PM", title: "Launch checklist", category: "productivity" as const },
+        ],
+      };
+    }
+    if (day === 28) {
+      return {
+        day,
+        inMonth: true,
+        isToday: true,
+        tracked: "7h 50m",
+        entries: [
+          { time: "9:00 AM", title: "Team sync", category: "meetings" as const },
+          { time: "9:45 AM", title: "Acme Q3 proposal", category: "development" as const },
+          { time: "1:30 PM", title: "Launch checklist", category: "productivity" as const },
+        ],
+        more: 2,
+      };
+    }
+    if (day === 29) {
+      return {
+        day,
+        inMonth: true,
+        tracked: "4h 45m",
+        entries: [
+          { time: "10:00 AM", title: "Launch wrap", category: "productivity" as const },
+          { time: "2:00 PM", title: "Walkthrough deck", category: "design" as const },
+        ],
+      };
+    }
+    if (day === 30) {
+      return {
+        day,
+        inMonth: true,
+        tracked: "2h 10m",
+        entries: [
+          { time: "9:30 AM", title: "Weekly notes", category: "writing" as const },
+        ],
+      };
+    }
+    return {
+      day,
+      inMonth: true,
+      tracked: "1h 40m",
+      entries: [
+        { time: "11:00 AM", title: "Inbox catch-up", category: "email" as const },
+      ],
+    };
+  }),
+];
+
+export function blockDurationMinutes(block: DemoBlock): number {
+  return (
+    block.endHour * 60 +
+    block.endMinute -
+    (block.startHour * 60 + block.startMinute)
+  );
+}
+
+export function formatClock(hour: number, minute: number): string {
+  const period = hour >= 12 ? "PM" : "AM";
+  const h12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${h12}:${minute.toString().padStart(2, "0")} ${period}`;
+}
+
+export function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h > 0 && m > 0) return `${h}h ${m}m`;
+  if (h > 0) return `${h}h`;
+  return `${m}m`;
+}
+
+export function matchDemoAsk(input: string): DemoAsk | null {
+  const normalized = input.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const exact = DEMO_ASKS.find((ask) => ask.q.toLowerCase() === normalized);
+  if (exact) return exact;
+
+  let best: { ask: DemoAsk; score: number } | null = null;
+  for (const ask of DEMO_ASKS) {
+    let score = 0;
+    if (normalized.includes(ask.q.toLowerCase().slice(0, 24))) score += 5;
+    for (const alias of ask.aliases ?? []) {
+      if (normalized.includes(alias.toLowerCase())) score += 2;
+    }
+    if (score > 0 && (!best || score > best.score)) {
+      best = { ask, score };
+    }
+  }
+  return best && best.score >= 2 ? best.ask : null;
+}
+
+export function blockAccentStyle(category: DemoCategory, selected = false): {
+  backgroundColor: string;
+  borderColor: string;
+} {
+  const hex = CATEGORY_COLORS[category];
+  return {
+    backgroundColor: selected ? `${hex}2e` : `${hex}18`,
+    borderColor: selected ? `${hex}88` : `${hex}40`,
+  };
+}
+
+export function replyToFreeform(input: string): string {
+  const text = input.trim();
+  const lower = text.toLowerCase();
+
+  if (/^(hi|hello|hey|yo|sup|good (morning|afternoon|evening))\b/.test(lower)) {
+    const greeting = lower.startsWith("good")
+      ? text.split(/\s+/).slice(0, 2).join(" ")
+      : text.split(/\s+/)[0] ?? "Hey";
+    return `${greeting.charAt(0).toUpperCase()}${greeting.slice(1)}! You've got me — this is a demo, not the real Daylens brain. Try one of the sample questions and I'll show you how answers look.`;
+  }
+
+  if (/^(thanks|thank you|thx|ty)\b/.test(lower)) {
+    return "You're welcome! Still just a demo though — pick a starter if you want a real-looking answer.";
+  }
+
+  if (/^(how are you|how's it going|whats up|what's up)\b/.test(lower)) {
+    return "Doing great for a scripted landing-page fake. You've got me — I'm not wired to your laptop. Hit a starter ask and I'll play along.";
+  }
+
+  return "You've got me! This is a demo, not real Daylens — I only know the sample week on this page. Try one of the starter questions (or a thread on the left) and I'll answer from that memory.";
+}

--- a/apps/web/app/landing/V2Landing.tsx
+++ b/apps/web/app/landing/V2Landing.tsx
@@ -5,17 +5,13 @@ import {
   ArrowUpRight,
   Blocks,
   Check,
-  Code2,
   EyeOff,
   Layers3,
   MessageCircleMore,
   Sparkles,
 } from "lucide-react";
 import { assetPath } from "@/app/lib/basePath";
-import {
-  MAC_DOWNLOAD_HREF,
-  UNIFIED_DESKTOP_REPO_URL,
-} from "@/app/lib/platformLinks";
+import { MAC_DOWNLOAD_HREF } from "@/app/lib/platformLinks";
 import styles from "./V2Landing.module.css";
 
 const benefits = [
@@ -373,14 +369,6 @@ export function V2Landing() {
             <a href="#how">How it works</a>
             <Link href="/docs">Docs</Link>
           </nav>
-          <a
-            className={styles.githubLink}
-            href={UNIFIED_DESKTOP_REPO_URL}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <Code2 size={15} /> GitHub
-          </a>
         </div>
         <div className={styles.footerCredits}>
           <Wordmark />

--- a/apps/web/app/lib/platformLinks.ts
+++ b/apps/web/app/lib/platformLinks.ts
@@ -1,11 +1,7 @@
 import { withBasePath } from "./basePath";
 
+/** Resolves to the latest macOS installer via the release proxy. */
 export const MAC_DOWNLOAD_HREF = withBasePath("/api/download/mac");
-export const WINDOWS_DOWNLOAD_HREF =
-  process.env.NEXT_PUBLIC_DAYLENS_WINDOWS_STORE_URL?.trim() ||
-  withBasePath("/api/download/windows");
+/** Resolves to the latest Windows installer via the release proxy. */
+export const WINDOWS_DOWNLOAD_HREF = withBasePath("/api/download/windows");
 export const LINUX_STATUS_HREF = withBasePath("/linux");
-
-export const UNIFIED_DESKTOP_REPO_URL = "https://github.com/irachrist1/daylens";
-export const UNIFIED_DESKTOP_ISSUES_URL =
-  "https://github.com/irachrist1/daylens/blob/main/docs/ISSUES.md";

--- a/apps/web/app/linux/page.tsx
+++ b/apps/web/app/linux/page.tsx
@@ -3,15 +3,13 @@ import { MarketingFooter, MarketingInnerNav } from "../components/MarketingChrom
 import { MarketingCursor } from "../components/MarketingEffects";
 import {
   MAC_DOWNLOAD_HREF,
-  UNIFIED_DESKTOP_ISSUES_URL,
-  UNIFIED_DESKTOP_REPO_URL,
   WINDOWS_DOWNLOAD_HREF,
 } from "../lib/platformLinks";
 
 export const metadata = {
   title: "Linux Status — Daylens",
   description:
-    "Daylens is being built as one cross-platform product for macOS, Windows, and Linux. Linux release routing is still transitioning into the unified desktop repo.",
+    "Daylens is being built as one cross-platform product for macOS, Windows, and Linux. Public Linux installer routing is still catching up.",
 };
 
 export default function LinuxStatusPage() {
@@ -40,9 +38,8 @@ export default function LinuxStatusPage() {
             }}
           >
             Daylens is being built as one local-first, evidence-grounded product across macOS,
-            Windows, and Linux. Public Linux installer routing is still moving into the unified
-            desktop repo, so this site no longer pretends there is a direct Linux download here
-            today.
+            Windows, and Linux. Public Linux installer routing is still catching up, so this site
+            does not offer a direct Linux download today.
           </p>
         </div>
       </section>
@@ -64,9 +61,7 @@ export default function LinuxStatusPage() {
             </h2>
             <div className="lp-docs-bullets" style={{ marginBottom: "1.25rem" }}>
               <p className="lp-docs-body" style={{ margin: 0 }}>
-                The unified source of truth is the Electron desktop repo
-                <code style={{ marginLeft: 6, marginRight: 6 }}>daylens</code>, for macOS,
-                Windows, and Linux work.
+                Daylens is one cross-platform desktop product for macOS, Windows, and Linux.
               </p>
               <p className="lp-docs-body" style={{ margin: 0 }}>
                 Linux runtime and packaging work still need real-machine validation across X11 and
@@ -76,25 +71,6 @@ export default function LinuxStatusPage() {
                 macOS and Windows installs are still the direct download paths surfaced on this
                 site today.
               </p>
-            </div>
-
-            <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: "1rem" }}>
-              <a
-                href={UNIFIED_DESKTOP_REPO_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="lp-btn-primary"
-              >
-                Open the unified desktop repo
-              </a>
-              <a
-                href={UNIFIED_DESKTOP_ISSUES_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="lp-btn-ghost-dark"
-              >
-                Review launch status
-              </a>
             </div>
 
             <p className="lp-docs-body" style={{ marginBottom: "0.75rem" }}>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,32 +1,32 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import { V2Landing } from "./landing/V2Landing";
+import { HackathonLanding } from "./hackathon/components/HackathonLanding";
 import { appPath, assetPath } from "@/app/lib/basePath";
 
 export const metadata: Metadata = {
-  title: "Daylens | See your whole day",
+  title: "Daylens — Your digital life, made searchable on demand",
   description:
-    "Daylens turns the work scattered across your computer into one clear, searchable memory of what you actually got done.",
+    "Daylens watches what you do on your laptop, keeps it private, and lets you ask anything in plain language — or bring that context into the AI tools you already use.",
   openGraph: {
-    title: "Daylens | See your whole day",
+    title: "Daylens — Your digital life, made searchable on demand",
     description:
-      "Turn the work scattered across your computer into one clear, searchable memory of what you actually got done.",
+      "Ask anything about what you did on your laptop. Bring that context into the AI tools you already use. Private by default.",
     url: "/daylens",
     images: [
       {
-        url: assetPath("/hackathon/01-timeline-day.png"),
+        url: assetPath("/hackathon/02-timeline-week.png"),
         width: 1280,
         height: 800,
-        alt: "Daylens today view",
+        alt: "Daylens week view",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Daylens | See your whole day",
+    title: "Daylens — Your digital life, made searchable on demand",
     description:
-      "A local-first memory for the work you do on your computer.",
-    images: [assetPath("/hackathon/01-timeline-day.png")],
+      "Your workday, answerable — for you and the AI tools you already use.",
+    images: [assetPath("/hackathon/02-timeline-week.png")],
   },
 };
 
@@ -40,5 +40,5 @@ export default async function LandingPage({
   if (params.token && /^[0-9a-f]{32}$/i.test(params.token)) {
     redirect(appPath(`/link?token=${params.token}`));
   }
-  return <V2Landing />;
+  return <HackathonLanding />;
 }

--- a/apps/web/app/public-v2.css
+++ b/apps/web/app/public-v2.css
@@ -12,58 +12,7 @@
 }
 
 .v2-public-page *,
-.v2-site-header *,
 .v2-site-footer * { box-sizing: border-box; }
-
-.v2-site-header {
-  position: relative;
-  z-index: 50;
-  width: 100%;
-  height: 92px;
-  background: #fff;
-}
-
-.v2-site-header-inner {
-  width: min(1424px, calc(100% - 48px));
-  height: 100%;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 36px;
-}
-
-.v2-site-logo {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  width: fit-content;
-  color: #17171a;
-  font-size: 16px;
-  font-weight: 750;
-  letter-spacing: -0.04em;
-  text-decoration: none;
-}
-
-.v2-site-mark {
-  display: inline-grid;
-  grid-template-columns: repeat(3, 7px);
-  gap: 2px;
-  padding: 5px;
-  color: var(--v2-blue, #1748ff);
-  border: 1px solid currentColor;
-  border-radius: 6px;
-}
-
-.v2-site-mark span { width: 7px; height: 9px; border-radius: 2px; background: currentColor; }
-.v2-site-nav { display: flex; align-items: center; gap: 34px; }
-.v2-site-nav a { position: relative; color: #2d2e33; font-size: 14px; text-decoration: none; }
-.v2-site-nav a:hover { color: #1748ff; }
-.v2-site-nav a[aria-current="page"] { color: #1748ff; }
-.v2-site-nav a[aria-current="page"]::after { content: ""; position: absolute; left: 50%; bottom: -13px; width: 4px; height: 4px; border-radius: 50%; background: #1748ff; transform: translateX(-50%); }
-.v2-site-actions { justify-self: end; display: flex; align-items: center; gap: 10px; }
-.v2-site-source { min-height: 42px; padding: 0 16px; display: inline-flex; align-items: center; gap: 8px; color: #17171a; border: 1px solid #e7e7eb; border-radius: 999px; font-size: 13px; font-weight: 650; text-decoration: none; }
-
 
 .v2-public-page .lp-docs-nav { display: none !important; }
 
@@ -192,7 +141,8 @@
 .v2-public-page .lp-ray-release-section-title { color: #17171a; font-family: var(--font-serif), Georgia, serif; font-size: 27px; font-weight: 400; }
 .v2-public-page .lp-ray-release-link { color: #1748ff; }
 
-.v2-site-footer { width: min(1424px, calc(100% - 48px)); margin: 0 auto; padding: 100px 80px 40px; color: #17171a; border: 1px solid rgba(22,23,28,.09); border-top: 0; background-color: white; background-image: linear-gradient(rgba(59,68,180,.07) 1px, transparent 1px), linear-gradient(90deg, rgba(59,68,180,.07) 1px, transparent 1px); background-size: 72px 72px; }
+.v2-site-footer { width: 100%; margin: 0; padding: 100px 80px 40px; color: #17171a; border-top: 1px solid rgba(22,23,28,.09); background-color: white; background-image: linear-gradient(rgba(59,68,180,.07) 1px, transparent 1px), linear-gradient(90deg, rgba(59,68,180,.07) 1px, transparent 1px); background-size: 72px 72px; }
+.v2-site-footer-inner { width: min(1424px, calc(100% - 48px)); margin: 0 auto; }
 .v2-site-footer-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 40px; }
 .v2-site-footer-top nav { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 28px; }
 .v2-site-footer-top nav a { color: #6f7078; font-size: 13px; text-decoration: none; }
@@ -202,13 +152,11 @@
 .v2-site-footer.is-minimal .v2-site-footer-bottom { margin-top: 70px; }
 
 @media (max-width: 1000px) {
-  .v2-site-header-inner { grid-template-columns: 1fr auto; }
-  .v2-site-nav { display: none; }
   .v2-public-page .lp-docs-hero,
   .v2-public-page .lp-section--light,
   .v2-public-page .lp-ray-board-main,
-  .v2-public-page .lp-ray-changelog-main,
-  .v2-site-footer { width: calc(100% - 24px); }
+  .v2-public-page .lp-ray-changelog-main { width: calc(100% - 24px); }
+  .v2-site-footer-inner { width: calc(100% - 24px); }
   .v2-public-page .lp-docs-hero { padding-inline: 60px; }
   .v2-public-page .lp-docs-layout { grid-template-columns: 220px 1fr; gap: 48px; }
   .v2-public-page .lp-ray-board-header,
@@ -221,16 +169,14 @@
 }
 
 @media (max-width: 700px) {
-  .v2-site-header { height: 76px; }
-  .v2-site-header-inner { width: calc(100% - 28px); }
-  .v2-site-source { display: none; }
   .v2-public-page .lp-docs-hero { width: calc(100% - 16px); min-height: 520px; padding: 90px 30px 70px; border-radius: 28px; background-size: 42px 42px; }
   .v2-public-page .lp-docs-hero::before { inset: 20px; border-radius: 20px; }
   .v2-public-page .lp-docs-hero h1 { font-size: 58px !important; }
   .v2-public-page .lp-section--light,
   .v2-public-page .lp-ray-board-main,
-  .v2-public-page .lp-ray-changelog-main,
-  .v2-site-footer { width: calc(100% - 16px); background-size: 42px 42px; }
+  .v2-public-page .lp-ray-changelog-main { width: calc(100% - 16px); background-size: 42px 42px; }
+  .v2-site-footer { background-size: 42px 42px; }
+  .v2-site-footer-inner { width: calc(100% - 16px); }
   .v2-public-page .lp-section--light { padding: 90px 12px 120px; }
   .v2-public-page .lp-docs-layout { display: block; }
   .v2-public-page .lp-docs-sidebar { position: static; margin-bottom: 70px; }

--- a/docs/TO-DO.md
+++ b/docs/TO-DO.md
@@ -4,13 +4,13 @@ This is the one place for documentation, decision, and research work that has no
 
 ## Decisions waiting on me
 
-- [ ] Choose the first-customer wedge for positioning and connector priority. Recorded recommendation: professionals who account for their time to clients (consultants, freelancers, agency ICs) — it matches the paid job in the organizational-sharing draft and the strongest competitors' audiences. Alternatives considered: AI-forward knowledge workers wanting personal memory; keeping the broad "any individual" framing. The V2 foundations are identical under all three, so no implementation waits on this.
+- [x] Choose the first-customer wedge for positioning and connector priority. Accepted: AI-forward knowledge workers who want personal memory of their laptop day and context for the AI tools they already use — see [landing positioning](product/landing-positioning.md). Alternatives considered: professionals who account for time to clients; keeping only the broad "any individual" framing without an AI-forward lead.
 
 ## Product validation
 
 - [ ] Build the competitor matrix described in V2, angled at the chosen first-customer wedge.
 - [ ] Design and build the comparison hub and individual comparison pages for the website.
-- [ ] Rewrite the landing page around the accepted positioning, questions, and product surfaces.
+- [ ] Finish the public-site copy pass against [landing positioning](product/landing-positioning.md): remaining docs sections, roadmap/changelog marketing chrome, comparison pages, and any leftover open-source or timesheet-primary framing.
 - [ ] Define activation and retention measurements for the first recognizable day, useful retrieval, and useful agent answer.
 
 ## Documentation and developer experience

--- a/docs/product/landing-positioning.md
+++ b/docs/product/landing-positioning.md
@@ -1,0 +1,43 @@
+# Landing and marketing positioning
+
+Accepted marketing direction for the public site. Product behavior still follows [product.md](product.md).
+
+## Audience
+
+Knowledge workers who spend their day on a laptop and already use AI tools — not developers only, not freelancers only.
+
+## Promise
+
+Keep the headline:
+
+> **Your digital life, made searchable on demand.**
+
+Under it, Daylens is the private memory of what you did on this computer. You can ask about that memory in plain language, and you can bring that context into the AI tools you already use.
+
+## What the AI can do (lead with this)
+
+The site leads with capability, not with timers or status reports.
+
+Examples that speak to any knowledge worker (proofs, not the whole product):
+
+- “What did I actually get done this week?”
+- “What did I work on for Acme?”
+- “Where did Tuesday afternoon go?”
+- “What did I read before that meeting?”
+- “Draft my weekly update report from what I got done this week.”
+
+A weekly update is one useful outcome. It is not the definition of Daylens.
+
+## Surfaces to name
+
+1. **Ask in Daylens** — in-app AI over the same memory as Timeline and Apps.
+2. **Bring context into your tools** — opt-in MCP / handoff into Claude, Cursor, and similar tools.
+3. **See the day** — Timeline and Apps remain the evidence underneath the answers.
+
+## Privacy line (honest)
+
+Activity lives on the laptop in a local database. What leaves the device is what the person chooses to send to a model when they ask — not a silent cloud of their whole day. Do not claim that all AI runs entirely on-device.
+
+## Voice
+
+Simple, clear, role-agnostic — closer to Notion’s breadth than to developer-tool jargon. No “open source” pitch on the public site.


### PR DESCRIPTION
## Summary
- Makes the current product landing the default home page, with AI-forward / knowledge-worker positioning documented in `docs/product/landing-positioning.md`.
- Replaces the static hero screenshot with a scripted interactive Daylens shell (Timeline day/week/month, Apps, AI asks with the shared sample week and Excel artifact).
- Tightens marketing chrome (no public GitHub CTAs), aligns docs/linux copy, and keeps accordion asks in sync with the demo dataset.

## Test plan
- [ ] Load `/` — hero shows interactive shell on desktop; static image on mobile
- [ ] Timeline: click blocks, open Details with app icons, switch Day / Week / Month
- [ ] Apps: select Cursor / Notion / Dia and read detail
- [ ] AI: run each starter; weekly update shows spreadsheet card; freeform hello / unknown get demo replies; scroll up while streaming stays put
- [ ] Dark mode pass on shell + accordion
- [ ] Download CTAs and docs/linux pages still work without GitHub marketing links

## Docs edited
- `docs/product/landing-positioning.md` (new)
- `docs/TO-DO.md`
- `README.md`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive product showcase with Timeline, Apps, and AI views.
  - Added sample AI conversations, app activity, calendar entries, and responsive demonstrations.
  - Updated the public site to present Daylens as a private, cross-platform desktop product with optional web access.
  - Added clearer macOS and Windows download actions.

- **Documentation**
  - Refreshed documentation, product messaging, AI examples, privacy details, and roadmap links.
  - Added positioning guidance for the public website.

- **Style**
  - Updated navigation, branding, footer layout, and responsive presentation across marketing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->