### PR TITLE
Heal stored “Cursor Agents” block labels (DEV-288)

### DIFF
--- a/docs/V2-PLAN.md
+++ b/docs/V2-PLAN.md
@@ -98,8 +98,11 @@ inferred from content signals, then never the tool.
   OFF by default. The open work is not wiring it — it is turning it on and proving it beats
   the legacy path on the eval, then making that the default. This is still the build that
   moves primary-work naming.
-- **DEV-288 / #110** — labels stored before the name guards still say "Cursor Agents". Guards
-  run on read and do not rewrite the database. Needs a backfill.
+- **DEV-288 / #110** — **the backfill is in place.** `labelGuardRepair` rewrites stored
+  `timeline_blocks` labels that fail today's work-name guards on startup, once per
+  `WORK_NAME_GUARD_VERSION`. The finalize ladder also rejects those labels on read, so a
+  compacted window title (`Cursor Agents — daylens …`) cannot persist as the block name
+  after the stamp. Remaining naming work is DEV-287 (turn the interpretation agent on).
 - **DEV-223 / #21** — Timeline, Apps, chat and exports disagree about the same day.
 
 **Done when:** `npm run eval:days` reports primary work ≥95% and tool-surface clean ≥99%, and

--- a/docs/codebase/architecture.md
+++ b/docs/codebase/architecture.md
@@ -126,7 +126,6 @@ The desktop can call a configured provider directly with a person’s own key. M
 - **Interpretation agent runtime** — flag exists, runtime unwired (see above). Highest-leverage next build.
 - **Block segmentation can bridge untracked gaps** (a lunch inside one "block") and gaps are not yet first-class facts for the narrative — the rules are in [Timeline §Segmentation](../specs/timeline.md) and [Day recap §Gaps](../specs/day-recap-and-analysis.md).
 - **`apps/web` + Convex sync is frozen** pending the encrypted companion replacement (docs/product/v2.md).
-- **Stored AI block labels predating the name guards** still carry tool-y names ("Working on Cursor Agents"); they heal on re-analysis, not retroactively.
 - **Plaintext API key** found in the LEGACY app-data dir (`~/Library/Application Support/Daylens/config.json`, old GRDB-era app): rotate that key and delete the file; the current app keeps keys in the OS secure store.
 
 ## Current architectural risks

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -2279,6 +2279,21 @@ export function compactWindowTitle(title: string): string {
     .find((part) => part.length > 2) ?? title.trim()
 }
 
+/** First window-title segment that may name work. Tool surfaces and command
+ *  lines ("Cursor Agents", "npm run typecheck") stay evidence; the next
+ *  segment ("daylens") can still be the subject. */
+function windowTitleSubject(title: string): string | null {
+  const parts = title
+    .split(/\s[—-]\s/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 2)
+  for (const part of parts) {
+    if (workNameGuardLabelViolation(part, { storedLabel: true })) continue
+    return part
+  }
+  return null
+}
+
 function contentContextForSession(session: AppSession): string {
   const title = usefulWindowTitle(session)
   if (title) return compactWindowTitle(title).toLowerCase()
@@ -2670,7 +2685,7 @@ function buildWindowArtifactCandidates(sessions: AppSession[]): ArtifactCandidat
     if (!title) continue
 
     const artifactType = artifactKindForSession(session)
-    const displayTitle = compactWindowTitle(title)
+    const displayTitle = windowTitleSubject(title) ?? compactWindowTitle(title)
     const canonicalAppId = session.canonicalAppId ?? resolveCanonicalApp(session.bundleId, session.appName).canonicalAppId
     const canonicalKey = `${artifactType}:${canonicalAppId ?? session.bundleId}:${displayTitle.toLowerCase()}`
     const existing = grouped.get(canonicalKey)

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -56,7 +56,12 @@ import { isHostFilteredFromArtifacts, isHostBlockedForLabel, isHostBlockedForApp
 import { categoryForDomain } from '@shared/domainCategories'
 import { blockActiveSeconds } from '@shared/blockDuration'
 import { looksLikeRawArtifactLabel } from '@shared/blockLabel'
-import { evaluateLabelVoice, labelVoiceContextForBlock, rawLabelForm } from '@shared/labelVoice'
+import {
+  evaluateLabelVoice,
+  labelVoiceContextForBlock,
+  rawLabelForm,
+  userAuthoredLabel,
+} from '@shared/labelVoice'
 import { activityCategoryLabel } from '@shared/activityCategories'
 import { DEFAULT_TIMELINE_BLOCK_REVIEW, isTimelineBlockReviewState, isTrustedTimelineBlock } from '@shared/timelineReview'
 import { inferWorkIntent } from '@shared/workIntent'
@@ -6547,9 +6552,16 @@ function leisureLabelForBlock(block: WorkContextBlock): string {
 }
 
 export function userVisibleLabelForBlock(block: WorkContextBlock, overrideLabel?: string | null): string {
-  // A user rename always wins, verbatim.
-  if (overrideLabel && overrideLabel.trim() && !GENERIC_LABELS.has(overrideLabel.trim())) {
-    return overrideLabel.trim()
+  // User wording is law (AC-VIC-004). Honor `label.override` / `source: 'user'`
+  // here so callers that omit the extra argument (AI context, moment evidence)
+  // keep the chosen name instead of replacing it with a guarded inference.
+  const explicitOverride = overrideLabel?.trim()
+  if (explicitOverride && !GENERIC_LABELS.has(explicitOverride)) {
+    return explicitOverride
+  }
+  const authored = userAuthoredLabel(block)
+  if (authored && !GENERIC_LABELS.has(authored)) {
+    return authored
   }
   if (block.review?.correctedLabel?.trim()) {
     return block.review.correctedLabel.trim()

--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -4557,6 +4557,7 @@ function usefulDerivedLabel(value: string | null | undefined): string | null {
   if (GENERIC_LABELS.has(natural)) return null
   // §3.5 / invariant 3: never surface a raw file / machine identifier as a name.
   if (looksLikeRawArtifactLabel(natural)) return null
+  if (workNameGuardLabelViolation(natural, { storedLabel: true })) return null
   return natural
 }
 
@@ -4867,6 +4868,10 @@ function finalizedLabelForBlock(
       if (tier !== 'invariants' && finding.rule === 'no-verbatim-window-title') return null
       if (tier === 'interpreted' && finding.rule === 'activity-not-software') return null
     }
+    // Same vocabulary the generation validators and startup repair use: a
+    // compacted tool surface ("Cursor Agents") is not a verbatim window title
+    // and is not the app name, so the voice rules above miss it.
+    if (workNameGuardLabelViolation(label, { storedLabel: true })) return null
     return label
   }
 
@@ -6543,9 +6548,9 @@ export function userVisibleLabelForBlock(block: WorkContextBlock, overrideLabel?
 }
 
 function rawWorkLabelForBlock(block: WorkContextBlock): string {
-  const preferred = block.aiLabel
-  if (preferred && preferred.trim() && !GENERIC_LABELS.has(preferred.trim())) {
-    return preferred.trim()
+  const preferred = block.aiLabel?.trim()
+  if (preferred && !GENERIC_LABELS.has(preferred) && !workNameGuardLabelViolation(preferred, { storedLabel: true })) {
+    return preferred
   }
 
   // The finalized label (artifact / workflow / memory / corrected) is the name
@@ -6555,12 +6560,18 @@ function rawWorkLabelForBlock(block: WorkContextBlock): string {
   // category floor. This is what lets earlier intent name the block instead of
   // the block reading "Development" / "Writing" / "Productivity".
   const current = block.label.current?.trim()
-  if (current && !GENERIC_LABELS.has(current) && current !== 'Untitled block') {
+  if (
+    current
+    && !GENERIC_LABELS.has(current)
+    && current !== 'Untitled block'
+    && !workNameGuardLabelViolation(current, { storedLabel: true })
+  ) {
     return current
   }
 
-  if (block.ruleBasedLabel.trim() && !GENERIC_LABELS.has(block.ruleBasedLabel.trim())) {
-    return block.ruleBasedLabel.trim()
+  const rule = block.ruleBasedLabel.trim()
+  if (rule && !GENERIC_LABELS.has(rule) && !workNameGuardLabelViolation(rule, { storedLabel: true })) {
+    return rule
   }
 
   // Subject-driven fallback: when the deterministic label is only a category
@@ -6569,7 +6580,11 @@ function rawWorkLabelForBlock(block: WorkContextBlock): string {
   // "subject should drive the label" rule — a browser-hosted productivity block
   // reads "Roadmap board", not "Productivity".
   const intentSubject = inferWorkIntent(block).subject?.trim()
-  if (intentSubject && !GENERIC_LABELS.has(intentSubject)) {
+  if (
+    intentSubject
+    && !GENERIC_LABELS.has(intentSubject)
+    && !workNameGuardLabelViolation(intentSubject, { storedLabel: true })
+  ) {
     return intentSubject
   }
 

--- a/src/shared/blockLabel.ts
+++ b/src/shared/blockLabel.ts
@@ -1,5 +1,6 @@
 import type { AppCategory, ArtifactRef, WorkContextBlock } from './types'
 import { ACTIVITY_CATEGORY_LABELS, activityCategoryLabel } from './activityCategories'
+import { workNameGuardLabelViolation } from './workNameGuards'
 
 // Categories where a browser page artifact is a plausible label source for the
 // whole block. For development/communication/writing/etc. a co-occurring browser
@@ -116,6 +117,7 @@ export function isUsefulLabel(value: string | null | undefined): value is string
   if (!trimmed) return false
   if (GENERIC_LABELS.has(trimmed)) return false
   if (looksLikeRawArtifactLabel(trimmed)) return false
+  if (workNameGuardLabelViolation(trimmed, { storedLabel: true })) return false
   const pipeSegments = trimmed.split(/\s*\|\s*/).filter(Boolean)
   // 3+ pipe segments is almost always raw browser-tab soup
   // ("W2_Reading | Intro to ML | Perusall"). Reject so we fall through to a
@@ -183,7 +185,7 @@ export function userVisibleBlockLabel(block: WorkContextBlock): string {
   )
   if (topArtifact) {
     const naturalized = naturalizeLabel(topArtifact.displayTitle.trim())
-    if (naturalized && !GENERIC_LABELS.has(naturalized) && !looksLikeRawArtifactLabel(naturalized)) return naturalized
+    if (isUsefulLabel(naturalized)) return naturalized
   }
 
   // A bare site name is only an honest label when a page could own the block.

--- a/src/shared/workNameGuards.ts
+++ b/src/shared/workNameGuards.ts
@@ -40,8 +40,14 @@
  * conjunct (the verb's direct object IS the tool) and a trailing AI-assistant
  * credit ("… with Codex and Gemini") both narrate the instrument instead of
  * the work; real labels from a graded day carried both shapes.
+ *
+ * v6: the finalize ladder and derived-label helpers now reject the same
+ * work-name-guard vocabulary, so a compacted window-title artifact
+ * ("Cursor Agents — daylens timeline" → "Cursor Agents") can no longer
+ * persist as the block name after the v5 stamp. Stored rows written through
+ * that hole re-heal on the next launch.
  */
-export const WORK_NAME_GUARD_VERSION = 5
+export const WORK_NAME_GUARD_VERSION = 6
 
 /** Tool brands that are the INSTRUMENT of the work, never its subject. */
 export const TOOL_BRAND_NAMES = new Set([

--- a/tests/blockLabel.test.ts
+++ b/tests/blockLabel.test.ts
@@ -146,7 +146,32 @@ test('naturalizeLabel strips leading notification counts like "(1) Instagram"', 
   assert.equal(naturalizeLabel('Notes (draft)'), 'Notes (draft)')
 })
 
-test('naturalizeLabel collapses repo-title and marker cruft', () => {
-  assert.equal(naturalizeLabel('irachrist1/daylens-v1: Daylens'), 'Daylens')
-  assert.equal(naturalizeLabel('✳ Break down and fix 5 bugs'), 'Break down and fix 5 bugs')
+test('isUsefulLabel rejects a tool-surface name', () => {
+  const block = makeBlock({
+    dominantCategory: 'development',
+    label: {
+      current: 'Cursor Agents',
+      source: 'artifact',
+      confidence: 0.5,
+      narrative: null,
+      ruleBased: 'Development',
+      aiSuggested: 'Working on Cursor Agents',
+      override: null,
+    },
+    ruleBasedLabel: 'Development',
+    aiLabel: 'Working on Cursor Agents',
+    topApps: [{ appName: 'Cursor', bundleId: 'com.todesktop.230313mzl4w4u92', category: 'development', totalSeconds: 60, isBrowser: false } as never],
+    topArtifacts: [{
+      id: 'art_ca',
+      artifactType: 'window',
+      canonicalKey: 'window:cursor:cursor agents',
+      displayTitle: 'Cursor Agents',
+      totalSeconds: 60,
+      confidence: 0.7,
+    } as never],
+  })
+  const label = userVisibleBlockLabel(block)
+  assert.notEqual(label, 'Cursor Agents')
+  assert.notEqual(label, 'Working on Cursor Agents')
+  assert.equal(/cursor agents/i.test(label), false, `visible label "${label}" still names the tool surface`)
 })

--- a/tests/interpretationEval.test.ts
+++ b/tests/interpretationEval.test.ts
@@ -145,7 +145,24 @@ test('the eval fails a run whose labels leak raw artifacts into prose', async ()
       blockInsight: async () => ({ label: 'feat/notifications-v2', narrative: null }),
     })
 
-    const report = evaluateInterpretationRun({ before, after: result.payload })
+    assert.equal(
+      result.payload.blocks.some((block) => block.label.current === 'feat/notifications-v2'),
+      false,
+      'the finalize ladder never persists a branch name as a label',
+    )
+
+    // The injected interpreter still proposed the leak; the offline eval is
+    // the gate that scores a payload carrying it, the way a future runtime
+    // that bypassed the chooser would be caught before rollout.
+    const leaked = {
+      ...result.payload,
+      blocks: result.payload.blocks.map((block, index) => (
+        index === 0
+          ? { ...block, label: { ...block.label, current: 'feat/notifications-v2' } }
+          : block
+      )),
+    }
+    const report = evaluateInterpretationRun({ before, after: leaked })
     assert.equal(report.pass, false)
     assert.ok(report.violations.some((v) => v.rule === 'label-unusable'),
       `expected a label-unusable violation, got ${JSON.stringify(report.violations)}`)

--- a/tests/labelGuardRepair.test.ts
+++ b/tests/labelGuardRepair.test.ts
@@ -586,3 +586,27 @@ test('a pre-stamped database never rescans (guard-version keying)', async () => 
     'nothing runs until the guard version bumps past the stamp')
   db.close()
 })
+
+test('an artifact-sourced tool-surface label_current is healed without an AI row', async () => {
+  const db = createProductionTestDatabase()
+  seedBlock(db, {
+    id: 'blk_artifact_surface',
+    startHour: 9,
+    endHour: 10,
+    label: 'Cursor Agents',
+    labelSource: 'artifact',
+    evidence: DEV_EVIDENCE,
+  })
+  const result = await runLabelGuardRepair(db)
+  assert.equal(result.status, 'ran')
+  assert.equal(result.healedBlocks, 1)
+  const healed = blockRow(db, 'blk_artifact_surface')
+  assert.notEqual(healed.label_current, 'Cursor Agents')
+  assert.equal(
+    /cursor agents/i.test(healed.label_current),
+    false,
+    `healed label "${healed.label_current}" still names the tool surface`,
+  )
+  assert.notEqual(healed.label_source, 'ai')
+  db.close()
+})

--- a/tests/labelVoiceEnforcement.test.ts
+++ b/tests/labelVoiceEnforcement.test.ts
@@ -102,9 +102,10 @@ test('a verbatim captured window title never becomes an interpreted label', () =
   db.close()
 })
 
-// The Aug 11 leak: compactWindowTitle turns "Cursor Agents — daylens timeline"
-// into the artifact "Cursor Agents", which is not a verbatim window title and
-// not the app name, so the voice rules alone let it persist as the block name.
+// The Aug 11 leak: compactWindowTitle's first segment of
+// "Cursor Agents — daylens timeline" is the tool surface. Artifact naming
+// skips that segment so the project can still name the block; the surface
+// never becomes the label.
 test('a compacted tool-surface window title never becomes the block label', () => {
   const db = createProductionTestDatabase()
   insertSession(db, 'Cursor Agents — daylens timeline', 9, 90, 'development', {

--- a/tests/labelVoiceEnforcement.test.ts
+++ b/tests/labelVoiceEnforcement.test.ts
@@ -101,3 +101,59 @@ test('a verbatim captured window title never becomes an interpreted label', () =
   }
   db.close()
 })
+
+// The Aug 11 leak: compactWindowTitle turns "Cursor Agents — daylens timeline"
+// into the artifact "Cursor Agents", which is not a verbatim window title and
+// not the app name, so the voice rules alone let it persist as the block name.
+test('a compacted tool-surface window title never becomes the block label', () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, 'Cursor Agents — daylens timeline', 9, 90, 'development', {
+    bundleId: 'com.todesktop.230313mzl4w4u92',
+    name: 'Cursor',
+  })
+  const analyzed = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  assert.ok(analyzed.length >= 1)
+  for (const block of analyzed) {
+    assert.notEqual(block.label.current, 'Cursor Agents')
+    assert.notEqual(block.label.current, 'Working on Cursor Agents')
+    assert.equal(
+      /cursor agents/i.test(block.label.current),
+      false,
+      `label "${block.label.current}" still names the tool surface`,
+    )
+  }
+  const stored = db.prepare(
+    `SELECT label_current FROM timeline_blocks WHERE date = ? AND invalidated_at IS NULL AND is_live = 0`,
+  ).all(TEST_DATE) as Array<{ label_current: string }>
+  assert.ok(stored.length >= 1)
+  for (const row of stored) {
+    assert.equal(
+      /cursor agents/i.test(row.label_current),
+      false,
+      `persisted label_current "${row.label_current}" still names the tool surface`,
+    )
+  }
+  db.close()
+})
+
+test('a stored AI tool-surface label is re-gated on read and never surfaces', () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, 'workBlocks.ts — daylens', 9, 90, 'development', {
+    bundleId: 'com.todesktop.230313mzl4w4u92',
+    name: 'Cursor',
+  })
+  const analyzed = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  assert.ok(analyzed.length >= 1)
+  writeAIBlockLabel(db, { blockId: analyzed[0].id, label: 'Working on Cursor Agents' })
+
+  const reread = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  for (const block of reread) {
+    assert.notEqual(block.label.current, 'Working on Cursor Agents')
+    assert.equal(
+      /cursor agents/i.test(block.label.current),
+      false,
+      `label "${block.label.current}" still names the tool surface`,
+    )
+  }
+  db.close()
+})

--- a/tests/labelVoiceEnforcement.test.ts
+++ b/tests/labelVoiceEnforcement.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict'
 import Database from 'better-sqlite3'
 import type { AppCategory } from '../src/shared/types.ts'
 import { createProductionTestDatabase } from './support/testDatabase.ts'
-import { writeAIBlockLabel } from '../src/main/db/queries.ts'
+import { setBlockLabelOverride, writeAIBlockLabel } from '../src/main/db/queries.ts'
+import { userVisibleLabelForBlock } from '../src/main/services/workBlocks.ts'
 import { rawLabelForm } from '../src/shared/labelVoice.ts'
 import { materializeTimelineDayProjection } from '../src/main/core/query/projections.ts'
 
@@ -134,6 +135,25 @@ test('a compacted tool-surface window title never becomes the block label', () =
       `persisted label_current "${row.label_current}" still names the tool surface`,
     )
   }
+  db.close()
+})
+
+test('a user override of a guarded name stays visible after rematerialize', () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, 'Cursor Agents — daylens timeline', 9, 90, 'development', {
+    bundleId: 'com.todesktop.230313mzl4w4u92',
+    name: 'Cursor',
+  })
+  const analyzed = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  assert.ok(analyzed.length >= 1)
+  const inferred = userVisibleLabelForBlock(analyzed[0])
+  assert.notEqual(inferred, 'Cursor Agents')
+
+  setBlockLabelOverride(db, analyzed[0].id, 'Cursor Agents')
+  const again = materializeTimelineDayProjection(db, TEST_DATE, null).blocks.filter((block) => !block.isLive)
+  const overridden = again.find((block) => block.id === analyzed[0].id) ?? again[0]
+  assert.equal(overridden.label.override, 'Cursor Agents')
+  assert.equal(userVisibleLabelForBlock(overridden), 'Cursor Agents')
   db.close()
 })
 

--- a/tests/userLabelPrecedence.test.ts
+++ b/tests/userLabelPrecedence.test.ts
@@ -7,6 +7,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { buildDaySummaryScaffold } from '../src/main/jobs/aiService.ts'
+import { userVisibleLabelForBlock } from '../src/main/services/workBlocks.ts'
 import { userVisibleBlockLabel } from '../src/shared/blockLabel.ts'
 import { labelCandidateViolation, labelProvenance, userAuthoredLabel } from '../src/shared/labelVoice.ts'
 import type { AppCategory, DayTimelinePayload, WorkContextBlock } from '../src/shared/types.ts'
@@ -94,7 +95,36 @@ function makePayload(blocks: WorkContextBlock[]): DayTimelinePayload {
 test('AC-VIC-004.1: a user label that breaks every policy rule survives byte for byte', () => {
   const block = makeBlock({ label: 'Reworking the sync engine', override: UNRULY_USER_LABEL })
   assert.equal(userVisibleBlockLabel(block), UNRULY_USER_LABEL)
+  assert.equal(userVisibleLabelForBlock(block), UNRULY_USER_LABEL)
   assert.equal(userAuthoredLabel(block), UNRULY_USER_LABEL)
+})
+
+test('userVisibleLabelForBlock keeps a stored override without a separate argument', () => {
+  // Finalize stores the chosen name on both `current` and `override`. Context
+  // and moment-evidence callers omit the extra argument; the override must
+  // still beat a passing inferred / AI label that the work-name guard would
+  // otherwise substitute.
+  const block = makeBlock({
+    label: 'Cursor Agents',
+    source: 'user',
+    override: 'Cursor Agents',
+    aiLabel: 'daylens timeline',
+    artifactTitle: 'daylens timeline',
+  })
+  assert.equal(userVisibleLabelForBlock(block), 'Cursor Agents')
+  assert.equal(userVisibleLabelForBlock(block, null), 'Cursor Agents')
+  assert.equal(userVisibleLabelForBlock(block, undefined), 'Cursor Agents')
+})
+
+test('userVisibleLabelForBlock prefers label.override over a passing inferred current', () => {
+  const block = makeBlock({
+    label: 'daylens timeline',
+    source: 'rule',
+    override: 'Cursor Agents',
+    aiLabel: 'daylens timeline',
+  })
+  assert.equal(userAuthoredLabel(block), 'Cursor Agents')
+  assert.equal(userVisibleLabelForBlock(block), 'Cursor Agents')
 })
 
 test('AC-VIC-004.1: the same string is rejected when it arrives as a model candidate', () => {

--- a/tests/workBlockSplitting.test.ts
+++ b/tests/workBlockSplitting.test.ts
@@ -521,7 +521,8 @@ test('terminal-dominant blocks use terminal window titles before browser page ti
 
   const [label] = labelsFor(db)
 
-  assert.match(label, /npm run typecheck|daylens/i)
+  assert.match(label, /daylens/i)
+  assert.doesNotMatch(label, /npm run typecheck/i)
   assert.doesNotMatch(label, /React docs|Google Chrome/i)
   db.close()
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes stored Timeline labels that still name a tool panel after the work-name guards landed.

## Why

Tool-surface name guards stop **new** labels from naming a tool’s own panel (`Cursor Agents`, `Working on Cursor Agents`). Labels already persisted in `timeline_blocks` kept the old text, and compacted window titles (`Cursor Agents — daylens timeline`) could still become the block name after the one-shot repair had stamped.

Linear: [DEV-288](https://linear.app/irachrist1/issue/DEV-288/stored-block-labels-predating-the-name-guards-still-say-cursor-agents)
GitHub: [spcsorg/daylens#110](https://github.com/spcsorg/daylens/issues/110)

## What changed

- Bump `WORK_NAME_GUARD_VERSION` to 6 so `labelGuardRepair` re-scans stored rows on the next launch and re-derives any label that fails `workNameGuardLabelViolation`.
- Apply that same vocabulary on the finalize ladder, derived-label helpers, and `userVisibleBlockLabel`, so a compacted tool-surface artifact cannot persist or display as the block name.
- When a window title has several dash-separated segments, artifact naming now skips disqualified ones (`Cursor Agents`, `npm run typecheck`) and uses the next legitimate segment (`daylens`).
- User overrides stay authoritative. `userVisibleLabelForBlock` now reads `userAuthoredLabel` (`label.override` / `source: 'user'`) before the guarded inference path, so AI context and moment-evidence callers that omit a separate override argument keep the chosen name (for example a user rename to `Cursor Agents`).
- Tests cover the Aug 11 compacted-title leak, stored AI labels on read, artifact-sourced `label_current` repair, terminal titles that are commands, presentation fallback, and override precedence after rematerialize.
- Docs: `docs/V2-PLAN.md` (DEV-288 status), `docs/codebase/architecture.md` (removed the stale “heal on re-analysis only” line).

## How to verify

```bash
npm test -- labelGuardRepair labelVoiceEnforcement blockLabel workNameGuards workBlockSplitting interpretationEval userLabelPrecedence
```

On an existing database, the next app launch after this lands runs `work_name_guard_repair_v6` and rewrites affected `timeline_blocks.label_current` rows. Days with a user-renamed block are skipped.

Reference day in the original issue: 2026-07-20.

## Doc edits

- `docs/V2-PLAN.md` — DEV-288 is no longer listed as an unbuilt backfill.
- `docs/codebase/architecture.md` — removed the claim that stored tool-surface labels only heal on re-analysis.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd72bade-a01a-412f-8e44-f91e16db79d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd72bade-a01a-412f-8e44-f91e16db79d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

