### PR TITLE
Paint the AI tab before CLI and billing probes finish

### DIFF
--- a/src/renderer/lib/aiSeed.ts
+++ b/src/renderer/lib/aiSeed.ts
@@ -22,12 +22,13 @@ export function consumePendingChatSeed(): string | null {
   return value
 }
 
-/** The AI tab's access gate starts unresolved on every mount (settings and
- *  hasApiKey are null until the provider resource loads) and the tab renders
- *  a loading gate with no composer. Consuming the one-shot stash then would
- *  destroy the seed before anything could send or show it, so this consumes
- *  only once the gate has resolved; until then the stash survives untouched
- *  for a later effect run. */
+/** The AI tab's access verdict starts unresolved on every mount (settings and
+ *  hasApiKey are null until the provider resource loads). Seeding has to choose
+ *  between sending the prompt and pre-filling it, and with no verdict there is
+ *  nothing to choose on, so consuming the one-shot stash then would destroy the
+ *  seed before anything could send or show it. This consumes only once the
+ *  verdict resolves; until then the stash survives untouched for a later effect
+ *  run. */
 export function consumePendingChatSeedWhenReady(
   settings: unknown,
   hasApiKey: boolean | null,

--- a/src/renderer/lib/aiTabAccess.ts
+++ b/src/renderer/lib/aiTabAccess.ts
@@ -1,0 +1,36 @@
+/** Unresolved access keeps the chat up; only a resolved `false` shows Connect AI. */
+export function isAiChatVisible(hasApiKey: boolean | null): boolean {
+  return hasApiKey !== false
+}
+
+export function isAiProviderPending(settings: unknown, hasApiKey: boolean | null): boolean {
+  return settings == null || hasApiKey == null
+}
+
+const queuedComposerPrompts: string[] = []
+
+export function enqueueComposerPrompt(text: string): void {
+  queuedComposerPrompts.push(text)
+}
+
+export function peekQueuedComposerPrompt(): string | undefined {
+  return queuedComposerPrompts[0]
+}
+
+export function takeQueuedComposerPrompt(): string | undefined {
+  return queuedComposerPrompts.shift()
+}
+
+export function hasQueuedComposerPrompts(): boolean {
+  return queuedComposerPrompts.length > 0
+}
+
+export function drainQueuedComposerPrompts(): string {
+  const joined = queuedComposerPrompts.join('\n\n')
+  queuedComposerPrompts.length = 0
+  return joined
+}
+
+export function resetQueuedComposerPrompts(): void {
+  queuedComposerPrompts.length = 0
+}

--- a/src/renderer/lib/aiTabAccess.ts
+++ b/src/renderer/lib/aiTabAccess.ts
@@ -7,28 +7,60 @@ export function isAiProviderPending(settings: unknown, hasApiKey: boolean | null
   return settings == null || hasApiKey == null
 }
 
-const queuedComposerPrompts: string[] = []
-
-export function enqueueComposerPrompt(text: string): void {
-  queuedComposerPrompts.push(text)
+/** A failed probe with no remembered snapshot blocks the column; a failure
+ *  after a remount still shows Retry, but keeps the last working chat up. */
+export function providerProbeFailureKind(
+  loadError: string | null,
+  initialLoading: boolean,
+  providerPending: boolean,
+): 'none' | 'blocking' | 'banner' {
+  if (!loadError || initialLoading) return 'none'
+  return providerPending ? 'blocking' : 'banner'
 }
 
-export function peekQueuedComposerPrompt(): string | undefined {
-  return queuedComposerPrompts[0]
+export type QueuedComposerPrompt = {
+  text: string
+  threadId: number | null
 }
 
-export function takeQueuedComposerPrompt(): string | undefined {
-  return queuedComposerPrompts.shift()
+const queuedComposerPrompts: QueuedComposerPrompt[] = []
+
+export function enqueueComposerPrompt(text: string, threadId: number | null): void {
+  queuedComposerPrompts.push({ text, threadId })
 }
 
-export function hasQueuedComposerPrompts(): boolean {
-  return queuedComposerPrompts.length > 0
+export function peekQueuedComposerPrompt(threadId: number | null): QueuedComposerPrompt | undefined {
+  return queuedComposerPrompts.find((prompt) => prompt.threadId === threadId)
 }
 
-export function drainQueuedComposerPrompts(): string {
-  const joined = queuedComposerPrompts.join('\n\n')
-  queuedComposerPrompts.length = 0
-  return joined
+export function takeQueuedComposerPrompt(threadId: number | null): QueuedComposerPrompt | undefined {
+  const index = queuedComposerPrompts.findIndex((prompt) => prompt.threadId === threadId)
+  if (index < 0) return undefined
+  return queuedComposerPrompts.splice(index, 1)[0]
+}
+
+export function hasQueuedComposerPrompts(threadId: number | null): boolean {
+  return queuedComposerPrompts.some((prompt) => prompt.threadId === threadId)
+}
+
+export function readQueuedComposerPrompts(threadId: number | null): string {
+  return queuedComposerPrompts
+    .filter((prompt) => prompt.threadId === threadId)
+    .map((prompt) => prompt.text)
+    .join('\n\n')
+}
+
+export function reassignQueuedComposerPrompts(fromThreadId: number | null, toThreadId: number): void {
+  for (const prompt of queuedComposerPrompts) {
+    if (prompt.threadId === fromThreadId) prompt.threadId = toThreadId
+  }
+}
+
+export function replaceQueuedComposerPrompts(threadId: number | null, text: string): void {
+  for (let index = queuedComposerPrompts.length - 1; index >= 0; index -= 1) {
+    if (queuedComposerPrompts[index]?.threadId === threadId) queuedComposerPrompts.splice(index, 1)
+  }
+  if (text.trim()) enqueueComposerPrompt(text, threadId)
 }
 
 export function resetQueuedComposerPrompts(): void {

--- a/src/renderer/views/insights/AICompose.tsx
+++ b/src/renderer/views/insights/AICompose.tsx
@@ -10,7 +10,7 @@ export interface AIComposeHandle {
 }
 
 interface AIComposeProps {
-  onSubmit: (text: string) => void
+  onSubmit: (text: string) => boolean
   loading: boolean
   // While loading, the send button becomes Stop and calls this — it aborts
   // the in-flight provider request, not just the spinner.
@@ -20,6 +20,8 @@ interface AIComposeProps {
   // which discards the turn.
   onPause?: () => void
   placeholder?: string
+  initialValue?: string
+  onValueChange?: (text: string) => void
   variant?: 'docked' | 'starter'
 }
 
@@ -67,10 +69,11 @@ function serializeEditor(el: HTMLElement): string {
 }
 
 function AIComposeImpl(
-  { onSubmit, loading, onCancel, onPause, placeholder, variant = 'docked' }: AIComposeProps,
+  { onSubmit, loading, onCancel, onPause, placeholder, initialValue = '', onValueChange, variant = 'docked' }: AIComposeProps,
   ref: ForwardedRef<AIComposeHandle>,
 ) {
   const editorRef = useRef<HTMLDivElement>(null)
+  const initialValueRef = useRef(initialValue)
   const [empty, setEmpty] = useState(true)
   const [menu, setMenu] = useState<MenuState | null>(null)
   const [menuIndex, setMenuIndex] = useState(0)
@@ -100,7 +103,10 @@ function AIComposeImpl(
     setValue: setEditorValue,
   }), [setEditorValue])
 
-  useEffect(() => { editorRef.current?.focus() }, [])
+  useEffect(() => {
+    if (initialValueRef.current) setEditorValue(initialValueRef.current)
+    else editorRef.current?.focus()
+  }, [setEditorValue])
 
   const loadEntities = useCallback(() => {
     if (entitiesLoadedRef.current) return
@@ -152,6 +158,7 @@ function AIComposeImpl(
     const isEmpty = serialized.replace(/\u00A0/g, '').trim() === '' && editor.querySelector('.dl-mention') == null
     setEmpty(isEmpty)
     editor.dataset.empty = isEmpty ? 'true' : 'false'
+    onValueChange?.(serialized)
 
     // Detect an active `/` (whole-input) or `@` (token-initial) trigger.
     const selection = window.getSelection()
@@ -184,7 +191,7 @@ function AIComposeImpl(
     }
     setMenu(null)
     triggerRangeRef.current = null
-  }, [loadEntities, menu])
+  }, [loadEntities, menu, onValueChange])
 
   const selectSlash = useCallback((cmd: SlashCommand) => {
     const editor = editorRef.current
@@ -233,14 +240,15 @@ function AIComposeImpl(
     if (!editor) return
     const text = serializeEditor(editor).replace(/\u00A0/g, ' ').trim()
     if (!text || loading) return
-    onSubmit(text)
+    if (!onSubmit(text)) return
     editor.innerHTML = ''
     editor.dataset.empty = 'true'
     setEmpty(true)
+    onValueChange?.('')
     setMenu(null)
     triggerRangeRef.current = null
     editor.focus()
-  }, [loading, onSubmit])
+  }, [loading, onSubmit, onValueChange])
 
   const onKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     if (menu && menuItemCount > 0) {

--- a/src/renderer/views/insights/AIWorkspace.tsx
+++ b/src/renderer/views/insights/AIWorkspace.tsx
@@ -16,12 +16,14 @@ import ConnectAI from '../../components/ConnectAI'
 import { ContextPacketInspector } from '../../components/ContextPacketInspector'
 import { consumePendingChatSeedWhenReady } from '../../lib/aiSeed'
 import {
-  drainQueuedComposerPrompts,
   enqueueComposerPrompt,
   hasQueuedComposerPrompts,
   isAiChatVisible,
   isAiProviderPending,
   peekQueuedComposerPrompt,
+  providerProbeFailureKind,
+  readQueuedComposerPrompts,
+  replaceQueuedComposerPrompts,
   takeQueuedComposerPrompt,
 } from '../../lib/aiTabAccess'
 import { AICompose, type AIComposeHandle } from './AICompose'
@@ -269,29 +271,37 @@ export default function AIWorkspace() {
   }, [onNewChat])
 
   // The composer paints before the provider verdict lands. Keep every early
-  // submission across tab remounts, then dispatch them in order once access is
-  // known. handleSend serializes them through its loading guard.
+  // submission with the conversation that owned it, then dispatch once access
+  // is known. handleSend serializes them through its loading guard.
   const flushQueuedPrompt = useCallback(() => {
     if (providerPending || !hasApiKey || loading) return
-    const next = peekQueuedComposerPrompt()
+    const next = peekQueuedComposerPrompt(activeThreadId)
     if (next == null) return
-    if (submitMessage(next)) takeQueuedComposerPrompt()
-  }, [providerPending, hasApiKey, loading, submitMessage])
+    if (submitMessage(next.text)) takeQueuedComposerPrompt(activeThreadId)
+  }, [providerPending, hasApiKey, loading, activeThreadId, submitMessage])
   const onComposerSubmit = useCallback((text: string) => {
-    if (providerPending || hasQueuedComposerPrompts()) {
-      enqueueComposerPrompt(text)
-      return
-    }
-    if (!submitMessage(text)) enqueueComposerPrompt(text)
-  }, [providerPending, submitMessage])
-  useEffect(() => {
     if (hasApiKey === false) {
-      const queued = drainQueuedComposerPrompts()
-      if (queued) composerRef.current?.setValue(queued)
-    } else {
-      flushQueuedPrompt()
+      replaceQueuedComposerPrompts(activeThreadId, text)
+      return false
     }
-  }, [hasApiKey, flushQueuedPrompt])
+    if (hasApiKey !== true || hasQueuedComposerPrompts(activeThreadId)) {
+      enqueueComposerPrompt(text, activeThreadId)
+      return true
+    }
+    if (submitMessage(text)) return true
+    enqueueComposerPrompt(text, activeThreadId)
+    return true
+  }, [hasApiKey, activeThreadId, submitMessage])
+  useEffect(() => {
+    flushQueuedPrompt()
+  }, [flushQueuedPrompt])
+  const [deniedDraft, setDeniedDraft] = useState('')
+  useEffect(() => {
+    setDeniedDraft(hasApiKey === false ? readQueuedComposerPrompts(activeThreadId) : '')
+  }, [hasApiKey, activeThreadId])
+  const preserveQueuedDraft = useCallback((text: string) => {
+    if (hasApiKey === false) replaceQueuedComposerPrompts(activeThreadId, text)
+  }, [hasApiKey, activeThreadId])
 
   // Seed a chat from another view (e.g. Settings → Memory → "Chat about your
   // memory"). Always start a NEW thread, then SEND the seed as its first
@@ -308,7 +318,8 @@ export default function AIWorkspace() {
       if (hasApiKey) {
         submitMessage(prompt)
       } else {
-        composerRef.current?.setValue(prompt)
+        enqueueComposerPrompt(prompt, null)
+        setDeniedDraft(readQueuedComposerPrompts(null))
       }
       composerRef.current?.focus()
     })
@@ -478,7 +489,7 @@ export default function AIWorkspace() {
   // this screen waits for it: the shell, the header and the composer paint on
   // the first frame and the pieces that genuinely need the verdict fill in when
   // it arrives.
-  const providerFailed = providerPending && Boolean(loadError) && !initialLoading
+  const probeFailure = providerProbeFailureKind(loadError, initialLoading, providerPending)
 
   const activeChatProvider = settings ? (settings.aiChatProvider ?? settings.aiProvider) : null
   const providerMeta = activeChatProvider ? AI_PROVIDER_META[activeChatProvider] : null
@@ -625,7 +636,15 @@ export default function AIWorkspace() {
       {/* ── Conversation ──────────────────────────────────────────────────── */}
       <div style={{ flex: 1, overflowY: 'auto' }}>
         <div style={{ maxWidth: 760, margin: '0 auto', width: '100%', padding: '28px 24px 24px', minHeight: '100%', display: 'flex', flexDirection: 'column' }}>
-          {providerFailed ? (
+          {probeFailure === 'banner' && (
+            <div role="alert" style={{ marginBottom: 16, padding: '10px 12px', borderRadius: 8, background: 'var(--color-surface-high)', color: 'var(--color-text-secondary)', fontSize: 12.5, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+              <span>Couldn't refresh AI settings. {loadError}</span>
+              <button type="button" onClick={() => { void refreshProvider() }} style={{ padding: '5px 10px', borderRadius: 7, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12, fontWeight: 600, cursor: 'pointer', flexShrink: 0 }}>
+                Retry
+              </button>
+            </div>
+          )}
+          {probeFailure === 'blocking' ? (
             <div style={{ margin: 'auto 0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
               <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', textAlign: 'center', maxWidth: 360 }}>
                 Couldn't load AI settings. {loadError}
@@ -642,6 +661,21 @@ export default function AIWorkspace() {
                 hasSavedAccess={false}
                 onConnected={() => { void refreshProvider() }}
               />
+              {deniedDraft && (
+                <div style={{ width: '100%', maxWidth: 620, margin: '20px auto 0', textAlign: 'left' }}>
+                  <AICompose
+                    key={activeThreadId ?? 'new'}
+                    ref={composerRef}
+                    onSubmit={onComposerSubmit}
+                    onCancel={cancelGeneration}
+                    onPause={pauseGeneration}
+                    loading={loading}
+                    initialValue={deniedDraft}
+                    onValueChange={preserveQueuedDraft}
+                    placeholder="Your message is saved while you connect AI"
+                  />
+                </div>
+              )}
               {isCliProvider && cliMissing && providerMeta && (
                 <div style={{ marginTop: 12, fontSize: 12.5, lineHeight: 1.6, color: 'var(--color-text-tertiary)' }}>
                   {providerMeta.label} is selected right now, but it is not installed on this machine yet.
@@ -750,7 +784,7 @@ export default function AIWorkspace() {
       </div>
 
       {/* ── Docked composer ───────────────────────────────────────────────── */}
-      {chatVisible && !providerFailed && (hasMessages || threadLoading) && (
+      {chatVisible && probeFailure !== 'blocking' && (hasMessages || threadLoading) && (
         <div style={{ flexShrink: 0, padding: '12px 24px 20px' }}>
           <div style={{ maxWidth: 760, margin: '0 auto' }}>
             <AICompose ref={composerRef} onSubmit={onComposerSubmit} onCancel={cancelGeneration} onPause={pauseGeneration} loading={loading} />

--- a/src/renderer/views/insights/AIWorkspace.tsx
+++ b/src/renderer/views/insights/AIWorkspace.tsx
@@ -15,6 +15,15 @@ import {
 import ConnectAI from '../../components/ConnectAI'
 import { ContextPacketInspector } from '../../components/ContextPacketInspector'
 import { consumePendingChatSeedWhenReady } from '../../lib/aiSeed'
+import {
+  drainQueuedComposerPrompts,
+  enqueueComposerPrompt,
+  hasQueuedComposerPrompts,
+  isAiChatVisible,
+  isAiProviderPending,
+  peekQueuedComposerPrompt,
+  takeQueuedComposerPrompt,
+} from '../../lib/aiTabAccess'
 import { AICompose, type AIComposeHandle } from './AICompose'
 import { ConversationSidebar } from './ConversationSidebar'
 import { MessageList } from './MessageList'
@@ -96,6 +105,8 @@ export default function AIWorkspace() {
     providerAvailability,
     analyticsContext,
   } = chat
+  const providerPending = isAiProviderPending(settings, hasApiKey)
+  const chatVisible = isAiChatVisible(hasApiKey)
 
   const bottomRef = useRef<HTMLDivElement>(null)
   const composerRef = useRef<AIComposeHandle>(null)
@@ -257,6 +268,31 @@ export default function AIWorkspace() {
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [onNewChat])
 
+  // The composer paints before the provider verdict lands. Keep every early
+  // submission across tab remounts, then dispatch them in order once access is
+  // known. handleSend serializes them through its loading guard.
+  const flushQueuedPrompt = useCallback(() => {
+    if (providerPending || !hasApiKey || loading) return
+    const next = peekQueuedComposerPrompt()
+    if (next == null) return
+    if (submitMessage(next)) takeQueuedComposerPrompt()
+  }, [providerPending, hasApiKey, loading, submitMessage])
+  const onComposerSubmit = useCallback((text: string) => {
+    if (providerPending || hasQueuedComposerPrompts()) {
+      enqueueComposerPrompt(text)
+      return
+    }
+    if (!submitMessage(text)) enqueueComposerPrompt(text)
+  }, [providerPending, submitMessage])
+  useEffect(() => {
+    if (hasApiKey === false) {
+      const queued = drainQueuedComposerPrompts()
+      if (queued) composerRef.current?.setValue(queued)
+    } else {
+      flushQueuedPrompt()
+    }
+  }, [hasApiKey, flushQueuedPrompt])
+
   // Seed a chat from another view (e.g. Settings → Memory → "Chat about your
   // memory"). Always start a NEW thread, then SEND the seed as its first
   // message so the person lands in a conversation that has visibly started
@@ -281,10 +317,10 @@ export default function AIWorkspace() {
   // This view mounts only after navigation, so a seed queued before navigate
   // (Settings stashes it, then navigates here) is read on mount. The old
   // event-only path fired before this listener existed and dropped the prompt.
-  // Consumption waits for the access gate: on a fresh mount settings/hasApiKey
-  // are still null and the loading gate renders with no composer, so consuming
-  // then would destroy the seed for everyone. The one-shot stash means the
-  // effect firing again after the gate resolves cannot double-send.
+  // Consumption waits for the access verdict: seedChat has to choose between
+  // sending and pre-filling, and until settings/hasApiKey resolve there is no
+  // verdict to choose on — consuming then would destroy the seed. The one-shot
+  // stash means the effect firing again after it resolves cannot double-send.
   useEffect(() => {
     const pending = consumePendingChatSeedWhenReady(settings, hasApiKey)
     if (pending) seedChat(pending)
@@ -325,24 +361,28 @@ export default function AIWorkspace() {
   // (message actions when a message is focused, plus chat actions). The palette
   // renders them under "Actions for this message" and "Chat".
   useEffect(() => {
-    if (!hasApiKey) { clearCommandSurfaceActions(); return }
+    if (hasApiKey === false) { clearCommandSurfaceActions(); return }
     const list: CommandSurfaceAction[] = []
     const target = latestAssistant
     const small = (node: ReactNode) => node
     if (target) {
       list.push({ id: 'msg-copy', group: 'message', label: 'Copy response', accelerator: accel('C', true), icon: small(<Copy size={15} strokeWidth={1.8} />), perform: () => handleCopy(target.message.id, target.message.content, target.message.answerKind) })
-      list.push({ id: 'msg-regenerate', group: 'message', label: 'Regenerate', accelerator: accel('R'), icon: small(<RefreshCw size={15} strokeWidth={1.8} />), perform: () => handleRetry(target.index, target.message) })
-      alternateProviders.forEach((alt, i) => {
-        list.push({ id: `msg-regen-${alt.provider}`, group: 'message', label: `Regenerate with ${alt.label}`, hint: 'Switch provider and rerun', accelerator: i === 0 ? accel('R', true) : undefined, icon: small(<RefreshCw size={15} strokeWidth={1.8} />), perform: () => switchProviderAndRetry(target.message, alt.provider) })
-      })
+      if (!providerPending) {
+        list.push({ id: 'msg-regenerate', group: 'message', label: 'Regenerate', accelerator: accel('R'), icon: small(<RefreshCw size={15} strokeWidth={1.8} />), perform: () => handleRetry(target.index, target.message) })
+        alternateProviders.forEach((alt, i) => {
+          list.push({ id: `msg-regen-${alt.provider}`, group: 'message', label: `Regenerate with ${alt.label}`, hint: 'Switch provider and rerun', accelerator: i === 0 ? accel('R', true) : undefined, icon: small(<RefreshCw size={15} strokeWidth={1.8} />), perform: () => switchProviderAndRetry(target.message, alt.provider) })
+        })
+      }
       list.push({ id: 'msg-good', group: 'message', label: 'Good response', accelerator: accel('=', true), icon: small(<ThumbsUp size={15} strokeWidth={1.8} />), perform: () => handleRate(target.message, target.message.rating === 'up' ? null : 'up') })
       list.push({ id: 'msg-bad', group: 'message', label: 'Bad response', accelerator: accel('-', true), icon: small(<ThumbsDown size={15} strokeWidth={1.8} />), perform: () => handleRate(target.message, target.message.rating === 'down' ? null : 'down') })
-      for (const transform of ANSWER_TRANSFORMS) {
-        list.push({ id: `msg-transform-${transform.kind}`, group: 'message', label: transform.label, hint: 'Transform the answer', icon: small(<Wand2 size={15} strokeWidth={1.8} />), perform: () => transformAnswer(transform.kind) })
+      if (!providerPending) {
+        for (const transform of ANSWER_TRANSFORMS) {
+          list.push({ id: `msg-transform-${transform.kind}`, group: 'message', label: transform.label, hint: 'Transform the answer', icon: small(<Wand2 size={15} strokeWidth={1.8} />), perform: () => transformAnswer(transform.kind) })
+        }
       }
     }
     list.push({ id: 'chat-new', group: 'chat', label: 'New chat', accelerator: accel('N'), icon: small(<IconNewChat />), perform: onNewChat })
-    list.push({ id: 'chat-model', group: 'chat', label: 'Change model…', hint: 'Pick the model for this chat', icon: small(<SlidersHorizontal size={15} strokeWidth={1.8} />), perform: () => setModelSelectorOpen(true) })
+    if (!providerPending) list.push({ id: 'chat-model', group: 'chat', label: 'Change model…', hint: 'Pick the model for this chat', icon: small(<SlidersHorizontal size={15} strokeWidth={1.8} />), perform: () => setModelSelectorOpen(true) })
     if (messages.length > 0) {
       list.push({ id: 'chat-copy-all', group: 'chat', label: 'Copy chat', hint: 'Copy the whole conversation', icon: small(<Copy size={15} strokeWidth={1.8} />), perform: () => copyChat() })
     }
@@ -351,7 +391,7 @@ export default function AIWorkspace() {
       list.push({ id: 'chat-settings', group: 'chat', label: 'Chat settings…', icon: small(<SlidersHorizontal size={15} strokeWidth={1.8} />), perform: () => setSettingsOpen(true) })
     }
     setCommandSurfaceActions(list)
-  }, [hasApiKey, latestAssistant, alternateProviders, accel, handleCopy, handleRetry, handleRate, switchProviderAndRetry, transformAnswer, onNewChat, copyChat, activeThreadId, messages.length, startHeaderRename])
+  }, [providerPending, hasApiKey, latestAssistant, alternateProviders, accel, handleCopy, handleRetry, handleRate, switchProviderAndRetry, transformAnswer, onNewChat, copyChat, activeThreadId, messages.length, startHeaderRename])
 
   // Drop our actions when the AI view unmounts so the palette doesn't show stale
   // chat actions from another tab.
@@ -359,16 +399,17 @@ export default function AIWorkspace() {
 
   // Direct accelerators on the focused message (⌘R, ⇧⌘C, etc.). ⌘K is owned by
   // the app shell (App.tsx) — it always opens the one palette, never a chat.
-  const accelStateRef = useRef({ hasApiKey, latestAssistant, alternateProviders, handleCopy, handleRetry, handleRate, switchProviderAndRetry })
-  accelStateRef.current = { hasApiKey, latestAssistant, alternateProviders, handleCopy, handleRetry, handleRate, switchProviderAndRetry }
+  const accelStateRef = useRef({ providerPending, hasApiKey, latestAssistant, alternateProviders, handleCopy, handleRetry, handleRate, switchProviderAndRetry })
+  accelStateRef.current = { providerPending, hasApiKey, latestAssistant, alternateProviders, handleCopy, handleRetry, handleRate, switchProviderAndRetry }
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       const state = accelStateRef.current
-      if (!state.hasApiKey) return
+      if (state.hasApiKey === false) return
       if (!(event.metaKey || event.ctrlKey) || event.altKey) return
       const key = event.key.toLowerCase()
       const target = state.latestAssistant
+      if (state.providerPending && (!event.shiftKey || key !== 'c')) return
       if (!event.shiftKey && key === 'r') { if (target) { event.preventDefault(); void state.handleRetry(target.index, target.message) } return }
       if (event.shiftKey && key === 'r') {
         if (target) {
@@ -432,35 +473,25 @@ export default function AIWorkspace() {
     }
   }, [activeThreadId, threadSettings.instructions, refreshProvider])
 
-  // ── Load gate ──────────────────────────────────────────────────────────────
-  if (settings == null || hasApiKey == null) {
-    if (loadError && !initialLoading) {
-      return (
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12, height: '100%', padding: 24 }}>
-          <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', textAlign: 'center', maxWidth: 360 }}>
-            Couldn't load AI settings. {loadError}
-          </p>
-          <button type="button" onClick={() => { void refreshProvider() }} style={{ padding: '7px 14px', borderRadius: 8, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12.5, fontWeight: 600, cursor: 'pointer' }}>
-            Retry
-          </button>
-        </div>
-      )
-    }
-    return (
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-        <p style={{ fontSize: 13, color: 'var(--color-text-tertiary)' }}>Loading AI…</p>
-      </div>
-    )
-  }
+  // The probe behind `settings` / `hasApiKey` reads settings, detects keys and
+  // CLI tools and asks the billing service, so it can take seconds. Nothing on
+  // this screen waits for it: the shell, the header and the composer paint on
+  // the first frame and the pieces that genuinely need the verdict fill in when
+  // it arrives.
+  const providerFailed = providerPending && Boolean(loadError) && !initialLoading
 
-  const activeChatProvider = settings.aiChatProvider ?? settings.aiProvider
-  const providerMeta = AI_PROVIDER_META[activeChatProvider]
-  const modelLabel = providerMeta.models.find((m) => m.id === activeModel)?.label ?? activeModel ?? providerMeta.shortLabel
+  const activeChatProvider = settings ? (settings.aiChatProvider ?? settings.aiProvider) : null
+  const providerMeta = activeChatProvider ? AI_PROVIDER_META[activeChatProvider] : null
+  const modelLabel = providerMeta
+    ? providerMeta.models.find((m) => m.id === activeModel)?.label ?? activeModel ?? providerMeta.shortLabel
+    : null
   // D4: when this thread overrides the model, the subline shows THAT model.
   const overrideActive = Boolean(threadSettings.provider && threadSettings.model)
-  const displayProviderMeta = AI_PROVIDER_META[overrideActive ? threadSettings.provider! : activeChatProvider]
+  const displayProviderMeta = overrideActive ? AI_PROVIDER_META[threadSettings.provider!] : providerMeta
   const displayModelId = overrideActive ? threadSettings.model! : activeModel
-  const displayModelLabel = displayProviderMeta.models.find((m) => m.id === displayModelId)?.label ?? displayModelId ?? displayProviderMeta.shortLabel
+  const displayModelLabel = displayProviderMeta
+    ? displayProviderMeta.models.find((m) => m.id === displayModelId)?.label ?? displayModelId ?? displayProviderMeta.shortLabel
+    : null
   const cliTool = activeChatProvider === 'claude-cli'
     ? 'claude'
     : activeChatProvider === 'chatgpt-cli'
@@ -479,7 +510,7 @@ export default function AIWorkspace() {
     <div style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
       {/* ── D1: time-grouped, searchable conversation list with Archive.
             FB4: always mounted, width-animated so open/close slides smoothly. ── */}
-      {hasApiKey && (
+      {chatVisible && (
         <div
           style={{
             flexShrink: 0,
@@ -503,7 +534,7 @@ export default function AIWorkspace() {
       {/* ── Top bar: sidebar toggle + thread title + model subline (U2/D2/FB8),
             ⌘K (opens the one palette), chat settings, new chat. ── */}
       <header style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 12, padding: '12px 24px', borderBottom: '1px solid var(--color-border-ghost)' }}>
-        {hasApiKey && (
+        {chatVisible && (
           <button
             type="button"
             onClick={toggleSidebar}
@@ -543,7 +574,7 @@ export default function AIWorkspace() {
               {activeThreadLabel ?? 'New chat'}
             </button>
           )}
-          {hasApiKey && (
+          {hasApiKey && displayProviderMeta && (
             <button
               type="button"
               onClick={() => setModelSelectorOpen(true)}
@@ -569,7 +600,7 @@ export default function AIWorkspace() {
           <span style={{ display: 'inline-flex', color: 'var(--color-text-tertiary)' }}><IconSparkleSearch /></span>
           <span style={{ fontSize: 11.5, fontWeight: 600, letterSpacing: '0.02em' }}>{isMac ? '⌘K' : 'Ctrl K'}</span>
         </button>
-        {activeThreadId != null && !managedAccess && (
+        {activeThreadId != null && !managedAccess && providerMeta && (
           <button
             type="button"
             onClick={() => setSettingsOpen(true)}
@@ -594,7 +625,16 @@ export default function AIWorkspace() {
       {/* ── Conversation ──────────────────────────────────────────────────── */}
       <div style={{ flex: 1, overflowY: 'auto' }}>
         <div style={{ maxWidth: 760, margin: '0 auto', width: '100%', padding: '28px 24px 24px', minHeight: '100%', display: 'flex', flexDirection: 'column' }}>
-          {!hasApiKey ? (
+          {providerFailed ? (
+            <div style={{ margin: 'auto 0', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+              <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', textAlign: 'center', maxWidth: 360 }}>
+                Couldn't load AI settings. {loadError}
+              </p>
+              <button type="button" onClick={() => { void refreshProvider() }} style={{ padding: '7px 14px', borderRadius: 8, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12.5, fontWeight: 600, cursor: 'pointer' }}>
+                Retry
+              </button>
+            </div>
+          ) : settings && hasApiKey === false ? (
             <div style={{ margin: 'auto 0' }}>
               <ConnectAI
                 variant="hero"
@@ -602,7 +642,7 @@ export default function AIWorkspace() {
                 hasSavedAccess={false}
                 onConnected={() => { void refreshProvider() }}
               />
-              {isCliProvider && cliMissing && (
+              {isCliProvider && cliMissing && providerMeta && (
                 <div style={{ marginTop: 12, fontSize: 12.5, lineHeight: 1.6, color: 'var(--color-text-tertiary)' }}>
                   {providerMeta.label} is selected right now, but it is not installed on this machine yet.
                 </div>
@@ -624,6 +664,7 @@ export default function AIWorkspace() {
                 onErrorRetry={handleErrorRetry}
                 onSwitchProvider={switchProviderAndRetry}
                 onTransform={transformAnswer}
+                providerActionsDisabled={providerPending}
                 onMessageAction={handleMessageAction}
                 onCommitActionWidget={commitActionWidget}
                 onUndoActionWidget={undoActionWidget}
@@ -674,7 +715,7 @@ export default function AIWorkspace() {
                 </p>
               </div>
               <div style={{ width: '100%', maxWidth: 620, marginTop: 4, textAlign: 'left' }}>
-                <AICompose ref={composerRef} onSubmit={submitMessage} onCancel={cancelGeneration} onPause={pauseGeneration} loading={loading} variant="starter" placeholder="Ask anything" />
+                <AICompose ref={composerRef} onSubmit={onComposerSubmit} onCancel={cancelGeneration} onPause={pauseGeneration} loading={loading} variant="starter" placeholder="Ask anything" />
               </div>
               <div style={{ width: '100%', maxWidth: 620, textAlign: 'left' }}>
                 {starterPrompts.map((suggestion, index) => (
@@ -709,15 +750,15 @@ export default function AIWorkspace() {
       </div>
 
       {/* ── Docked composer ───────────────────────────────────────────────── */}
-      {hasApiKey && (hasMessages || threadLoading) && (
+      {chatVisible && !providerFailed && (hasMessages || threadLoading) && (
         <div style={{ flexShrink: 0, padding: '12px 24px 20px' }}>
           <div style={{ maxWidth: 760, margin: '0 auto' }}>
-            <AICompose ref={composerRef} onSubmit={submitMessage} onCancel={cancelGeneration} onPause={pauseGeneration} loading={loading} />
+            <AICompose ref={composerRef} onSubmit={onComposerSubmit} onCancel={cancelGeneration} onPause={pauseGeneration} loading={loading} />
           </div>
         </div>
       )}
       </div>
-      {modelSelectorOpen && (
+      {modelSelectorOpen && providerMeta && displayProviderMeta && (
         <ModelSelector
           sources={modelSources}
           costs={modelCosts}
@@ -730,7 +771,7 @@ export default function AIWorkspace() {
           onClose={() => setModelSelectorOpen(false)}
         />
       )}
-      {settingsOpen && activeThreadId != null && !managedAccess && (
+      {settingsOpen && activeThreadId != null && !managedAccess && providerMeta && (
         <ThreadSettingsPanel
           threadId={activeThreadId}
           initial={threadSettings}

--- a/src/renderer/views/insights/MessageList.tsx
+++ b/src/renderer/views/insights/MessageList.tsx
@@ -82,6 +82,7 @@ export interface MessageListProps {
   onErrorRetry: (message: ThreadMessage) => void
   onSwitchProvider: (message: ThreadMessage, provider: AIProviderMode) => void
   onTransform: (kind: AnswerTransform) => void
+  providerActionsDisabled?: boolean
   onMessageAction: (messageId: string | number, action: AIMessageAction, options?: { reviewNote?: string }) => void
   onCommitActionWidget: (widget: AIActionWidget) => void
   onUndoActionWidget: (proposalId: string, undo: AIActionUndo) => void
@@ -107,21 +108,23 @@ export interface MessageListProps {
 // "Turn into…" — post-answer transforms on the latest answer. Each runs a
 // real model call that rewrites THIS answer's grounded content into the chosen
 // form (see request.transform); the menu is a small hover-light popover.
-function TransformMenu({ onTransform }: { onTransform: (kind: AnswerTransform) => void }) {
+function TransformMenu({ onTransform, disabled = false }: { onTransform: (kind: AnswerTransform) => void; disabled?: boolean }) {
   const [open, setOpen] = useState(false)
+  const menuOpen = open && !disabled
   return (
     <div style={{ position: 'relative', display: 'inline-flex' }}>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
         aria-haspopup="menu"
-        aria-expanded={open}
+        aria-expanded={menuOpen}
         title="Turn this answer into…"
-        style={{ height: 30, padding: '0 10px', borderRadius: 999, border: '1px solid var(--color-border-ghost)', background: open ? 'var(--color-accent-dim)' : 'transparent', color: 'var(--color-text-secondary)', cursor: 'pointer', fontSize: 12, fontWeight: 600 }}
+        style={{ height: 30, padding: '0 10px', borderRadius: 999, border: '1px solid var(--color-border-ghost)', background: menuOpen ? 'var(--color-accent-dim)' : 'transparent', color: 'var(--color-text-secondary)', cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.6 : 1, fontSize: 12, fontWeight: 600 }}
       >
         Turn into…
       </button>
-      {open && (
+      {menuOpen && (
         <>
           <div style={{ position: 'fixed', inset: 0, zIndex: 19 }} onClick={() => setOpen(false)} />
           <div role="menu" style={{ position: 'absolute', bottom: 'calc(100% + 6px)', left: 0, zIndex: 20, minWidth: 180, background: 'var(--color-surface)', border: '1px solid var(--color-border-ghost)', borderRadius: 10, boxShadow: '0 8px 24px rgba(0,0,0,0.16)', padding: 5 }}>
@@ -178,6 +181,7 @@ function MessageListImpl({
   onErrorRetry,
   onSwitchProvider,
   onTransform,
+  providerActionsDisabled = false,
   onMessageAction,
   onCommitActionWidget,
   onUndoActionWidget,
@@ -278,8 +282,8 @@ function MessageListImpl({
                     <button
                       type="button"
                       onClick={() => onResumePaused?.(message)}
-                      disabled={!message.pausedInfo?.checkpointId || !onResumePaused}
-                      style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 13px', borderRadius: 9, border: 'none', background: 'var(--gradient-primary)', color: 'var(--color-primary-contrast)', fontSize: 12.5, fontWeight: 700, cursor: message.pausedInfo?.checkpointId ? 'pointer' : 'default', opacity: message.pausedInfo?.checkpointId ? 1 : 0.6 }}
+                      disabled={providerActionsDisabled || !message.pausedInfo?.checkpointId || !onResumePaused}
+                      style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '6px 13px', borderRadius: 9, border: 'none', background: 'var(--gradient-primary)', color: 'var(--color-primary-contrast)', fontSize: 12.5, fontWeight: 700, cursor: !providerActionsDisabled && message.pausedInfo?.checkpointId ? 'pointer' : 'default', opacity: !providerActionsDisabled && message.pausedInfo?.checkpointId ? 1 : 0.6 }}
                     >
                       Resume
                     </button>
@@ -303,7 +307,8 @@ function MessageListImpl({
                   <button
                     type="button"
                     onClick={() => onErrorRetry(message)}
-                    style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '5px 11px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12, fontWeight: 700, cursor: 'pointer' }}
+                    disabled={providerActionsDisabled}
+                    style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '5px 11px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12, fontWeight: 700, cursor: providerActionsDisabled ? 'default' : 'pointer', opacity: providerActionsDisabled ? 0.6 : 1 }}
                   >
                     <IconRetry /> Retry
                   </button>
@@ -318,7 +323,8 @@ function MessageListImpl({
                     <button
                       type="button"
                       onClick={() => onErrorRetry(message)}
-                      style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 14px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12.5, fontWeight: 700, cursor: 'pointer' }}
+                      disabled={providerActionsDisabled}
+                      style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 14px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12.5, fontWeight: 700, cursor: providerActionsDisabled ? 'default' : 'pointer', opacity: providerActionsDisabled ? 0.6 : 1 }}
                     >
                       <IconRetry /> Retry
                     </button>
@@ -329,7 +335,8 @@ function MessageListImpl({
                         key={alt.provider}
                         type="button"
                         onClick={() => onSwitchProvider(message, alt.provider)}
-                        style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 14px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12.5, fontWeight: 700, cursor: 'pointer' }}
+                        disabled={providerActionsDisabled}
+                        style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '7px 14px', borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 12.5, fontWeight: 700, cursor: providerActionsDisabled ? 'default' : 'pointer', opacity: providerActionsDisabled ? 0.6 : 1 }}
                       >
                         Try on {alt.label}
                       </button>
@@ -540,11 +547,12 @@ function MessageListImpl({
                         pulseNonce={actionFeedback[actionFeedbackKey(message.id, 'retry')]?.pulseNonce ?? 0}
                         reducedMotion={reducedMotion}
                         onClick={() => onRetry(index, message)}
+                        disabled={providerActionsDisabled}
                       >
                         <IconRetry />
                       </IconActionButton>
                     )}
-                    {message.id === latestCompletedAssistantId && <TransformMenu onTransform={onTransform} />}
+                    {message.id === latestCompletedAssistantId && <TransformMenu onTransform={onTransform} disabled={providerActionsDisabled} />}
                   </div>
                 </>
               )}

--- a/src/renderer/views/insights/icons.tsx
+++ b/src/renderer/views/insights/icons.tsx
@@ -168,6 +168,7 @@ export function IconActionButton({
   tone = 'neutral',
   pulseNonce = 0,
   reducedMotion = false,
+  disabled = false,
   onClick,
   children,
 }: {
@@ -178,6 +179,7 @@ export function IconActionButton({
   tone?: 'neutral' | 'positive' | 'negative'
   pulseNonce?: number
   reducedMotion?: boolean
+  disabled?: boolean
   onClick: () => void
   children: ReactNode
 }) {
@@ -202,6 +204,7 @@ export function IconActionButton({
   return (
     <button
       onClick={onClick}
+      disabled={disabled}
       onPointerDown={() => setPressed(true)}
       onPointerUp={() => setPressed(false)}
       onPointerLeave={() => setPressed(false)}
@@ -220,6 +223,8 @@ export function IconActionButton({
         color: textColor,
         background,
         borderColor,
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.6 : 1,
         transform: reducedMotion ? undefined : pressed ? 'scale(0.92)' : undefined,
         animation: !reducedMotion && pulseName
           ? `${pulseName} 200ms cubic-bezier(0.2, 0.9, 0.2, 1.15)`

--- a/src/renderer/views/insights/useAIChat.ts
+++ b/src/renderer/views/insights/useAIChat.ts
@@ -17,6 +17,7 @@ import type {
   AgentTurnWaitKind,
 } from '@shared/types'
 import { useProjectionResource } from '../../hooks/useProjectionResource'
+import { reassignQueuedComposerPrompts } from '../../lib/aiTabAccess'
 import { track } from '../../lib/analytics'
 import { ipc } from '../../lib/ipc'
 import { AI_PROVIDER_META, getSelectedModel } from '../../lib/aiProvider'
@@ -622,6 +623,7 @@ export function useAIChat() {
         setActiveThreadId(response.threadId)
         setIsNewChatDraft(false)
         rememberedThreadId = response.threadId
+        reassignQueuedComposerPrompts(requestThreadId, response.threadId)
       }
       void refreshThreadList()
     } catch (error) {

--- a/src/renderer/views/insights/useAIChat.ts
+++ b/src/renderer/views/insights/useAIChat.ts
@@ -68,6 +68,20 @@ function firstActiveThreadId(rows: AIThreadSummary[]): number | null {
 // `null` = you were on a new chat (stay empty).
 let rememberedThreadId: number | null | undefined = undefined
 
+type ProviderSnapshot = {
+  settings: AppSettings
+  cliTools: { claude: string | null; chatgpt: string | null; gemini: string | null; codex: string | null }
+  hasProviderAccess: boolean
+  providerAvailability: Partial<Record<AIProviderMode, boolean>>
+  activeFocusSession: FocusSession | null
+  billingAccess: BillingAccessSnapshot
+}
+
+// The provider probe re-runs on every mount. Its slowest leg is a billing
+// network fetch (15s abort). Remember the last verdict so a tab switch does
+// not drop the view back to "provider unknown" for as long as that call takes.
+let lastProviderSnapshot: ProviderSnapshot | null = null
+
 type SendOptions = {
   contextOverride?: ThreadMessage['contextSnapshot']
   trigger?: 'freeform' | 'suggested' | 'retry' | 'resume'
@@ -153,16 +167,7 @@ export function useAIChat() {
   // pulled on mount — those are the expensive projections the perf map flags.
   // CLI detection (which spawns child processes) only runs when a CLI provider
   // is actually selected.
-  const providerResource = useProjectionResource<{
-    settings: AppSettings
-    cliTools: { claude: string | null; chatgpt: string | null; gemini: string | null; codex: string | null }
-    hasProviderAccess: boolean
-    // Per-provider key/tool availability, so the error card can offer a
-    // concrete one-tap switch on a hard wall.
-    providerAvailability: Partial<Record<AIProviderMode, boolean>>
-    activeFocusSession: FocusSession | null
-    billingAccess: BillingAccessSnapshot
-  }>({
+  const providerResource = useProjectionResource<ProviderSnapshot>({
     scope: 'insights',
     load: async () => {
       const currentSettings = await ipc.settings.get()
@@ -207,11 +212,16 @@ export function useAIChat() {
     dependencies: [],
   })
 
-  const settings = providerResource.data?.settings ?? null
-  const cliTools = providerResource.data?.cliTools ?? null
-  const hasApiKey = providerResource.data ? providerResource.data.hasProviderAccess : null
-  const activeFocusSession = providerResource.data?.activeFocusSession ?? null
-  const billingAccess = providerResource.data?.billingAccess ?? null
+  const providerData = providerResource.data ?? lastProviderSnapshot
+  useEffect(() => {
+    if (providerResource.data) lastProviderSnapshot = providerResource.data
+  }, [providerResource.data])
+
+  const settings = providerData?.settings ?? null
+  const cliTools = providerData?.cliTools ?? null
+  const hasApiKey = providerData ? providerData.hasProviderAccess : null
+  const activeFocusSession = providerData?.activeFocusSession ?? null
+  const billingAccess = providerData?.billingAccess ?? null
   // `refresh` is stable across renders (useProjectionResource memoizes it), so
   // handlers can depend on it without churning their own identity each render.
   const refreshProvider = providerResource.refresh
@@ -229,7 +239,7 @@ export function useAIChat() {
 
   // Other configured providers we can offer as a one-tap switch when the
   // selected one hits a hard wall (quota/credit/auth). Never auto-routed.
-  const providerAvailability = providerResource.data?.providerAvailability ?? {}
+  const providerAvailability = providerData?.providerAvailability ?? {}
   const alternateProviders = useMemo<AltProvider[]>(() => {
     if (!activeProvider) return []
     return SWITCHABLE_PROVIDERS
@@ -677,7 +687,11 @@ export function useAIChat() {
   // trigger should be `loading`, not a fresh callback identity each render.
   const handleSendRef = useRef(handleSend)
   handleSendRef.current = handleSend
-  const submitMessage = useCallback((text: string) => { void handleSendRef.current(text) }, [])
+  const submitMessage = useCallback((text: string) => {
+    if (loadingRef.current) return false
+    void handleSendRef.current(text)
+    return true
+  }, [])
 
   // Stop aborts the in-flight provider request in the main process
   // (ai:cancel-message → AbortController → SDK abort) and flips the pending
@@ -1068,8 +1082,9 @@ export function useAIChat() {
     agentQuestion,
     turnPhase,
     latestCompletedAssistantId,
-    // resource status (for the load gate + ConnectAI refresh)
-    initialLoading: providerResource.loading && !providerResource.data,
+    // resource status (for the error card + ConnectAI refresh). A remembered
+    // verdict counts as data, so remounts are not treated as a first load.
+    initialLoading: providerResource.loading && !providerData,
     loadError: providerResource.error,
     refreshProvider,
     // actions

--- a/src/renderer/views/insights/useAIChat.ts
+++ b/src/renderer/views/insights/useAIChat.ts
@@ -619,11 +619,11 @@ export function useAIChat() {
         responseThreadId: response.threadId,
         navigationVersionAtSend: navigationVersion,
         navigationVersionNow: navigationVersionRef.current,
-      })) {
+      }) && response.threadId != null) {
+        reassignQueuedComposerPrompts(requestThreadId, response.threadId)
         setActiveThreadId(response.threadId)
         setIsNewChatDraft(false)
         rememberedThreadId = response.threadId
-        reassignQueuedComposerPrompts(requestThreadId, response.threadId)
       }
       void refreshThreadList()
     } catch (error) {

--- a/tests/aiSeed.test.ts
+++ b/tests/aiSeed.test.ts
@@ -24,9 +24,9 @@ test('whitespace-only seeds never trigger a send', () => {
   assert.equal(consumePendingChatSeed(), null)
 })
 
-// The AI tab's consuming effect runs on every render of the access gate:
-// first while settings/hasApiKey are still null (loading gate, no composer),
-// then again once they resolve. The seed must survive the unresolved runs and
+// The AI tab's consuming effect runs on every render: first while
+// settings/hasApiKey are still null (the access verdict has not landed), then
+// again once they resolve. The seed must survive the unresolved runs and
 // be delivered exactly once after resolution. This drives the same function
 // the component effect calls, across the same state sequence a fresh mount
 // produces.

--- a/tests/aiTabAccess.test.ts
+++ b/tests/aiTabAccess.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  drainQueuedComposerPrompts,
+  enqueueComposerPrompt,
+  hasQueuedComposerPrompts,
+  isAiChatVisible,
+  isAiProviderPending,
+  peekQueuedComposerPrompt,
+  resetQueuedComposerPrompts,
+  takeQueuedComposerPrompt,
+} from '../src/renderer/lib/aiTabAccess.ts'
+
+test('unresolved access keeps the chat visible', () => {
+  assert.equal(isAiChatVisible(null), true)
+  assert.equal(isAiChatVisible(true), true)
+  assert.equal(isAiChatVisible(false), false)
+})
+
+test('the provider verdict is pending until both settings and access resolve', () => {
+  assert.equal(isAiProviderPending(null, null), true)
+  assert.equal(isAiProviderPending({ aiProvider: 'anthropic' }, null), true)
+  assert.equal(isAiProviderPending(null, true), true)
+  assert.equal(isAiProviderPending({ aiProvider: 'anthropic' }, true), false)
+  assert.equal(isAiProviderPending({ aiProvider: 'anthropic' }, false), false)
+})
+
+test('early composer submissions queue in order and drain on deny', () => {
+  resetQueuedComposerPrompts()
+  enqueueComposerPrompt('first')
+  enqueueComposerPrompt('second')
+  assert.equal(hasQueuedComposerPrompts(), true)
+  assert.equal(peekQueuedComposerPrompt(), 'first')
+  assert.equal(takeQueuedComposerPrompt(), 'first')
+  assert.equal(peekQueuedComposerPrompt(), 'second')
+  assert.equal(drainQueuedComposerPrompts(), 'second')
+  assert.equal(hasQueuedComposerPrompts(), false)
+  assert.equal(drainQueuedComposerPrompts(), '')
+})

--- a/tests/aiTabAccess.test.ts
+++ b/tests/aiTabAccess.test.ts
@@ -1,12 +1,15 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  drainQueuedComposerPrompts,
   enqueueComposerPrompt,
   hasQueuedComposerPrompts,
   isAiChatVisible,
   isAiProviderPending,
   peekQueuedComposerPrompt,
+  providerProbeFailureKind,
+  readQueuedComposerPrompts,
+  reassignQueuedComposerPrompts,
+  replaceQueuedComposerPrompts,
   resetQueuedComposerPrompts,
   takeQueuedComposerPrompt,
 } from '../src/renderer/lib/aiTabAccess.ts'
@@ -25,15 +28,45 @@ test('the provider verdict is pending until both settings and access resolve', (
   assert.equal(isAiProviderPending({ aiProvider: 'anthropic' }, false), false)
 })
 
-test('early composer submissions queue in order and drain on deny', () => {
+test('early composer submissions stay with their originating conversation', () => {
   resetQueuedComposerPrompts()
-  enqueueComposerPrompt('first')
-  enqueueComposerPrompt('second')
-  assert.equal(hasQueuedComposerPrompts(), true)
-  assert.equal(peekQueuedComposerPrompt(), 'first')
-  assert.equal(takeQueuedComposerPrompt(), 'first')
-  assert.equal(peekQueuedComposerPrompt(), 'second')
-  assert.equal(drainQueuedComposerPrompts(), 'second')
-  assert.equal(hasQueuedComposerPrompts(), false)
-  assert.equal(drainQueuedComposerPrompts(), '')
+  enqueueComposerPrompt('first', 1)
+  enqueueComposerPrompt('new chat', null)
+  enqueueComposerPrompt('second', 1)
+  assert.equal(hasQueuedComposerPrompts(1), true)
+  assert.deepEqual(peekQueuedComposerPrompt(1), { text: 'first', threadId: 1 })
+  assert.deepEqual(takeQueuedComposerPrompt(1), { text: 'first', threadId: 1 })
+  assert.deepEqual(peekQueuedComposerPrompt(null), { text: 'new chat', threadId: null })
+  assert.equal(readQueuedComposerPrompts(1), 'second')
+  assert.equal(readQueuedComposerPrompts(null), 'new chat')
+  reassignQueuedComposerPrompts(null, 3)
+  assert.equal(readQueuedComposerPrompts(null), '')
+  assert.equal(readQueuedComposerPrompts(3), 'new chat')
+})
+
+test('flushing one conversation does not take prompts queued on another', () => {
+  resetQueuedComposerPrompts()
+  enqueueComposerPrompt('keep me', 1)
+  enqueueComposerPrompt('send me', 2)
+  assert.deepEqual(takeQueuedComposerPrompt(2), { text: 'send me', threadId: 2 })
+  assert.deepEqual(peekQueuedComposerPrompt(1), { text: 'keep me', threadId: 1 })
+  assert.equal(hasQueuedComposerPrompts(2), false)
+})
+
+test('denied composer drafts remain recoverable and editable', () => {
+  resetQueuedComposerPrompts()
+  enqueueComposerPrompt('original', 1)
+  enqueueComposerPrompt('other chat', 2)
+  replaceQueuedComposerPrompts(1, 'edited draft')
+  assert.equal(readQueuedComposerPrompts(1), 'edited draft')
+  assert.equal(readQueuedComposerPrompts(2), 'other chat')
+  replaceQueuedComposerPrompts(1, '')
+  assert.equal(hasQueuedComposerPrompts(1), false)
+})
+
+test('a remount with a remembered provider snapshot still surfaces probe failures', () => {
+  assert.equal(providerProbeFailureKind('Provider failed', false, false), 'banner')
+  assert.equal(providerProbeFailureKind('Provider failed', false, true), 'blocking')
+  assert.equal(providerProbeFailureKind('Provider failed', true, false), 'none')
+  assert.equal(providerProbeFailureKind(null, false, false), 'none')
 })

--- a/tests/aiTabFirstPaint.test.ts
+++ b/tests/aiTabFirstPaint.test.ts
@@ -1,0 +1,35 @@
+// The AI tab used to return a centred "Loading AI…" paragraph while its
+// provider probe ran — settings, key/CLI detection and a billing call — so
+// every open blanked the whole screen, input included, for as long as the
+// slowest of those took. These pin the shape that replaced it: paint the
+// workspace first, fill in the provider verdict when it lands.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = path.resolve(import.meta.dirname, '..')
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8')
+}
+
+const workspace = readSource('src/renderer/views/insights/AIWorkspace.tsx')
+const chatHook = readSource('src/renderer/views/insights/useAIChat.ts')
+
+test('the AI tab renders no screen that waits for the provider probe', () => {
+  assert.doesNotMatch(workspace, /Loading AI/)
+  assert.doesNotMatch(workspace, /if \(settings == null \|\| hasApiKey == null\)/)
+})
+
+test('the chat surfaces stay up while the provider verdict is unresolved', () => {
+  assert.match(workspace, /const chatVisible = isAiChatVisible\(hasApiKey\)/)
+  assert.match(workspace, /const providerPending = isAiProviderPending\(settings, hasApiKey\)/)
+  assert.match(workspace, /settings && hasApiKey === false/)
+  assert.match(workspace, /onSubmit=\{onComposerSubmit\}/)
+})
+
+test('the provider verdict survives a remount, so reopening the tab never starts blank', () => {
+  assert.match(chatHook, /let lastProviderSnapshot: ProviderSnapshot \| null = null/)
+  assert.match(chatHook, /providerResource\.data \?\? lastProviderSnapshot/)
+})

--- a/tests/aiTabFirstPaint.test.ts
+++ b/tests/aiTabFirstPaint.test.ts
@@ -43,6 +43,7 @@ test('a queued prompt stays on its conversation and survives a denied-access Con
   assert.match(workspace, /onValueChange=\{preserveQueuedDraft\}/)
   assert.match(workspace, /return false/)
   assert.match(chatHook, /reassignQueuedComposerPrompts\(requestThreadId, response\.threadId\)/)
+  assert.match(chatHook, /response\.threadId != null/)
   assert.doesNotMatch(workspace, /drainQueuedComposerPrompts/)
   assert.doesNotMatch(workspace, /enqueueComposerPrompt\(text\)/)
 })

--- a/tests/aiTabFirstPaint.test.ts
+++ b/tests/aiTabFirstPaint.test.ts
@@ -33,3 +33,24 @@ test('the provider verdict survives a remount, so reopening the tab never starts
   assert.match(chatHook, /let lastProviderSnapshot: ProviderSnapshot \| null = null/)
   assert.match(chatHook, /providerResource\.data \?\? lastProviderSnapshot/)
 })
+
+test('a queued prompt stays on its conversation and survives a denied-access Connect AI swap', () => {
+  assert.match(workspace, /enqueueComposerPrompt\(text, activeThreadId\)/)
+  assert.match(workspace, /peekQueuedComposerPrompt\(activeThreadId\)/)
+  assert.match(workspace, /takeQueuedComposerPrompt\(activeThreadId\)/)
+  assert.match(workspace, /deniedDraft/)
+  assert.match(workspace, /initialValue=\{deniedDraft\}/)
+  assert.match(workspace, /onValueChange=\{preserveQueuedDraft\}/)
+  assert.match(workspace, /return false/)
+  assert.match(chatHook, /reassignQueuedComposerPrompts\(requestThreadId, response\.threadId\)/)
+  assert.doesNotMatch(workspace, /drainQueuedComposerPrompts/)
+  assert.doesNotMatch(workspace, /enqueueComposerPrompt\(text\)/)
+})
+
+test('a remounted provider probe failure still shows Retry', () => {
+  assert.match(workspace, /providerProbeFailureKind\(loadError, initialLoading, providerPending\)/)
+  assert.match(workspace, /probeFailure === 'banner'/)
+  assert.match(workspace, /probeFailure === 'blocking'/)
+  assert.match(workspace, /Couldn't refresh AI settings/)
+  assert.doesNotMatch(workspace, /providerPending && loadError && !initialLoading/)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [DEV-243](https://linear.app/irachrist1/issue/DEV-243/ai-tab-shows-loading-ai-on-a-blank-screen-every-open). Related: [spcsorg/daylens#65](https://github.com/spcsorg/daylens/issues/65).

## Problem

The AI tab showed a blank "Loading AI…" screen on every open, and sometimes stuck there. `AIWorkspace` returned early whenever `settings` or `hasApiKey` were still null — no header, no conversation, no composer.

Those values come from one `useProjectionResource` load that waits for settings, keytar reads, optional CLI detection (child processes), and `ipc.billing.getAccess()` together. The billing call is the long pole: a network fetch with a 15s abort. The AI route also unmounts on navigation, so every open restarted from `data === null` and blanked again.

None of that is needed to draw the chat. Threads and messages come from a local SQLite read on an independent path.

## Change

- Shell, sidebar, header, and composer paint on the first frame.
- Unresolved access keeps the chat up (`hasApiKey !== false`). Connect AI appears only after the probe actually denies access, so the tab does not flash the connect prompt at everyone.
- A send typed before the verdict lands is queued against that conversation and dispatched once access is known. Switching chats before the verdict lands cannot flush the prompt into a different thread. Adopting a draft thread reassigns any queued prompts to the persisted id.
- When access is denied, Connect AI keeps an editable composer with the queued text. Submit does not clear the editor, so the draft is not lost when the Connect AI panel replaces the docked composer.
- `useAIChat` remembers the session's last provider verdict across remounts (`lastProviderSnapshot`, same module-level pattern as `rememberedThreadId`), so reopening shows the chat it was showing a moment ago.
- A remount that still has that snapshot but whose new probe failed shows a Retry banner over the last working chat, instead of hiding the failure because `providerPending` is already false.
- Provider-dependent actions (regenerate, transform, retry, model picker) stay disabled until the verdict is ready.

## Greptile P1s (all valid)

1. Denied drafts disappear — queued text was drained into a composer that Connect AI had already unmounted. Fixed by keeping the queue and rendering `AICompose` next to Connect AI.
2. Queued prompts change chats — the queue stored only text. Fixed by storing `{ text, threadId }` and flushing/peeking per conversation.
3. Remount failures stay hidden — remembered settings made `providerPending` false, which gated the error card. Fixed with `providerProbeFailureKind`: blocking on first load, banner after a snapshot remount.

## Tests

- `tests/aiTabAccess.test.ts` — visibility/pending helpers, thread-scoped queue, denied-draft replace, remount probe-failure kinds
- `tests/aiTabFirstPaint.test.ts` — no "Loading AI" screen, chat stays up while unresolved, verdict survives remount, denied-draft composer, Retry not gated on `providerPending`

## Verification

- `npm test -- aiTabFirstPaint aiTabAccess aiSeed` — 3 files, 16 pass
- `node scripts/run-tests.mjs aiActions aiModelSources` — 2 files, 17 pass
- `npm run typecheck` — clean
- eslint on changed files — 0 errors (1 pre-existing `react-hooks/exhaustive-deps` warning on `providerAvailability`)

## How to verify

- Open the AI tab repeatedly — it appears instantly every time.
- No "Loading AI…" blank screen, no sticking.
- A question typed on first open is sent once access resolves, not dropped.
- A question typed before access resolves, then switching chats, stays on the original conversation.
- With no provider configured, Connect AI appears after the probe with any queued draft still in the composer.
- After leaving and returning to the AI tab, a failed provider refresh still shows Retry.

## Doc edits

None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5d73b70-348d-48a0-a209-4753418aa052?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5d73b70-348d-48a0-a209-4753418aa052&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI chat now renders immediately while provider access is being checked.
  * Composer messages are queued and sent once access is confirmed.
  * If access is unavailable, queued messages are returned to the composer.
  * Provider-dependent actions are disabled until access status is resolved.
  * AI provider status is preserved when switching tabs or remounting.

* **Bug Fixes**
  * Prevented the AI workspace from reverting to an unnecessary loading state during access checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->