### PR TITLE
DEV-244: Chat tool activity is a Worked-for line, not a wall of files

### DIFF
--- a/docs/codebase/architecture.md
+++ b/docs/codebase/architecture.md
@@ -95,7 +95,7 @@ The desktop AI surface sends a typed request over IPC to the main process. `src/
 - **Tier 2 (cheap, permission-carded):** `read_file`/`list_dir`/`search_files` (deny-by-default grants, disclosure ledger), read-only `git`, `discover_repositories`.
 - **Tier 3 (expensive, consent-gated):** `capture_screen` — one downscaled still of the active display via the screen-context frame source; pixels go to the model as an image part and are never stored; the mandatory `reason` appears in the activity trail. Gated on the Screen context experiment toggle + OS permission; refuses honestly otherwise. (Added 2026-07-26.)
 
-Plus: context packets with an inspector ("what the AI saw"), grounding verification with one corrective retry, clarifying questions, pause/resume checkpoints, previewed/undoable corrections, confirmed-memory proposals, user-configured MCP servers.
+Plus: context packets with a sources inspector, grounding verification with one corrective retry, clarifying questions, pause/resume checkpoints, previewed/undoable corrections, confirmed-memory proposals, user-configured MCP servers.
 
 Agent tools read Daylens data through existing services and queries. A tool should expose a product-level fact or explicit command, not raw tables or a second definition of time and attribution. Provider choice, retries, streaming, cancellation, and rate limits belong to agent infrastructure. Recorded activity remains product data rather than model output. The tier model and its policy gate are specified in [agent runtime and context](../specs/agent-runtime-and-context.md).
 

--- a/src/main/agent/chatAgent.ts
+++ b/src/main/agent/chatAgent.ts
@@ -195,6 +195,8 @@ export interface ChatAgentResult {
   /** Verified packet citations in the answer, in display order — every entry
    *  resolves to an item in the recorded packet. */
   citations: PacketCitation[]
+  /** Wall-clock length of the agent turn, for the collapsed "Worked for" line. */
+  durationMs: number
   /** Evidence coverage for this answer's factual claims (REQ-AIA-002). Every
    *  field is derived from THIS exchange only — the turn's packet, its tool
    *  results, and its computed facts — so inspecting it can never surface
@@ -248,6 +250,7 @@ export async function runChatAgentTurn(
   history: Array<{ role: 'user' | 'assistant'; content: string }>,
   deps: ChatAgentDeps,
 ): Promise<ChatAgentResult> {
+  const turnStartedAt = Date.now()
   const now = deps.now ?? new Date()
   const artifacts: AIMessageArtifact[] = []
   const toolTrace: AgentToolTraceEntry[] = []
@@ -718,6 +721,7 @@ export async function runChatAgentTurn(
       groundingRetried,
       contextPacketId: contextPacket && contextPacketRecorded ? contextPacket.id : null,
       citations,
+      durationMs: Math.max(0, Date.now() - turnStartedAt),
       evidence: {
         deterministicFacts,
         deterministicRepairs: enforcement.repairs,

--- a/src/main/ipc/ai.handlers.ts
+++ b/src/main/ipc/ai.handlers.ts
@@ -96,7 +96,7 @@ export function registerAIHandlers(): void {
     return listContextPackets(getDb(), payload)
   })
 
-  // DEV-183: the read-only inspection behind "What the AI saw" — the recorded
+  // DEV-183: the read-only inspection behind Sources for this answer — the recorded
   // packet grouped per kind, with plain-language omissions and each item
   // checked against the evidence backing it today. Null when no packet was
   // recorded for the reference; the renderer states that honestly.

--- a/src/main/jobs/aiService.ts
+++ b/src/main/jobs/aiService.ts
@@ -171,6 +171,7 @@ interface AnswerEnvelope {
     fileDisclosures?: import('@shared/types').AIMessageFileDisclosure[]
     contextPacketId?: string | null
     citations?: import('@shared/types').AIMessageCitation[]
+    durationMs?: number | null
   }
   suggestedFollowUps: FollowUpSuggestion[]
   actions?: AIMessageAction[]
@@ -3820,6 +3821,7 @@ async function sendMessageInner(payload: AIChatSendRequest, options: SendMessage
       fileDisclosures: agentResult.fileDisclosures,
       contextPacketId: agentResult.contextPacketId,
       citations: agentResult.citations,
+      durationMs: agentResult.durationMs,
     },
   })
   // Bind the recorded packet to the persisted assistant message (DEV-182), so

--- a/src/main/services/contextPacket.ts
+++ b/src/main/services/contextPacket.ts
@@ -58,7 +58,7 @@ import {
 
 /** Bump when the assembly rules change; part of every packet and fingerprint,
  *  so two packets are only comparable under the same policy. */
-export const CONTEXT_POLICY_VERSION = 3
+export const CONTEXT_POLICY_VERSION = 4
 
 export type ContextItemKind =
   | 'day_fact'
@@ -485,7 +485,7 @@ const SOCIAL_WORDS = new Set([
 ])
 
 const DAY_FACT_RE =
-  /\b(today|yesterday|tomorrow|this week|last week|this month|last month|\d+\s+days?\s+ago|last\s+\d+\s+days|timeline|how (?:much|long)|what did i (?:do|work)|how was my day|this morning|this afternoon|tonight|hours?\b|spend|spent)\b/i
+  /\b(?:today|yesterday|tomorrow|this week|last week|this month|last month|\d+\s+days?\s+ago|last\s+\d+\s+days|timeline|how (?:much|long)|what did i (?:do|work)|how(?:'s|s)? (?:my |the )?day|how (?:was|did|is|goes|went) (?:my |the )?day|(?:show|tell|recap|summar(?:y|ise|ize)|review|walk)(?: me)?(?: through)? (?:my |the )?day|this morning|this afternoon|tonight|hours?\b|spend|spent)\b/i
 
 /** Greetings and chitchat attach almost nothing. A real question still can. */
 export function questionAttachesRetrieval(question: string): boolean {
@@ -519,14 +519,25 @@ const GENERIC_FILE_BODY_TOKENS = new Set([
   'read', 'reading', 'about',
 ])
 
-function fileMatchesQuestion(basename: string, derived: string, tokens: string[]): boolean {
+function tokenHaystack(text: string): string[] {
+  return text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
+}
+
+function tokenInHaystack(token: string, haystack: string[]): boolean {
+  return haystack.includes(token)
+}
+
+/** A granted file joins the packet when a question token is a whole word in
+ *  its basename, or a distinctive token is a whole word in the extracted
+ *  text. Substring hits ("art" in "started", "log" in "catalog") do not count. */
+export function fileMatchesQuestion(basename: string, derived: string, tokens: string[]): boolean {
   if (tokens.length === 0) return false
-  const nameHaystack = basename.toLowerCase()
-  if (tokens.some((token) => nameHaystack.includes(token))) return true
+  const nameTokens = tokenHaystack(basename)
+  if (tokens.some((token) => tokenInHaystack(token, nameTokens))) return true
   const distinctive = tokens.filter((token) => !GENERIC_FILE_BODY_TOKENS.has(token))
   if (distinctive.length === 0) return false
-  const body = derived.toLowerCase()
-  return distinctive.some((token) => body.includes(token))
+  const bodyTokens = tokenHaystack(derived)
+  return distinctive.some((token) => tokenInHaystack(token, bodyTokens))
 }
 
 function fmtClock(ms: number): string {

--- a/src/main/services/contextPacket.ts
+++ b/src/main/services/contextPacket.ts
@@ -58,7 +58,7 @@ import {
 
 /** Bump when the assembly rules change; part of every packet and fingerprint,
  *  so two packets are only comparable under the same policy. */
-export const CONTEXT_POLICY_VERSION = 2
+export const CONTEXT_POLICY_VERSION = 3
 
 export type ContextItemKind =
   | 'day_fact'
@@ -475,6 +475,60 @@ function questionTokens(question: string): string[] {
   ]
 }
 
+const SOCIAL_WORDS = new Set([
+  'hi', 'hey', 'hello', 'thanks', 'thank', 'thx', 'ok', 'okay', 'yes', 'no',
+  'sure', 'cool', 'great', 'please', 'sorry', 'yo', 'sup', 'gm', 'cheers',
+  'bye', 'goodbye', 'good', 'morning', 'afternoon', 'evening', 'how', 'are',
+  'you', 'your', 'im', 'i', 'it', 'its', 'going', 'whats', 'up', 'there',
+  'fine', 'well', 'yeah', 'yup', 'nah', 'wow', 'nice', 'awesome', 'lol',
+  'haha', 'really', 'just', 'so', 'much', 'here',
+])
+
+const DAY_FACT_RE =
+  /\b(today|yesterday|tomorrow|this week|last week|this month|last month|\d+\s+days?\s+ago|last\s+\d+\s+days|timeline|how (?:much|long)|what did i (?:do|work)|how was my day|this morning|this afternoon|tonight|hours?\b|spend|spent)\b/i
+
+/** Greetings and chitchat attach almost nothing. A real question still can. */
+export function questionAttachesRetrieval(question: string): boolean {
+  const tokens = question
+    .toLowerCase()
+    .split(/[^a-z0-9']+/)
+    .map((token) => token.replace(/'/g, ''))
+    .filter(Boolean)
+  if (tokens.length === 0) return false
+  if (tokens.every((token) => token.length < 3 || SOCIAL_WORDS.has(token))) return false
+  return true
+}
+
+/** Today's timeline dump belongs on day questions, not on every message. */
+export function questionAttachesDayFacts(
+  question: string,
+  timeRange: ResolvedContextTimeRange,
+): boolean {
+  if (!questionAttachesRetrieval(question)) return false
+  if (timeRange.resolution !== 'default') return true
+  return DAY_FACT_RE.test(question)
+}
+
+const GENERIC_FILE_BODY_TOKENS = new Set([
+  'meeting', 'meetings', 'notes', 'note', 'work', 'working', 'document',
+  'documents', 'file', 'files', 'today', 'yesterday', 'project', 'projects',
+  'draft', 'article', 'articles', 'page', 'pages', 'time', 'day', 'week',
+  'personal', 'daily', 'journal', 'vault', 'transcript', 'transcripts',
+  'call', 'calls', 'chat', 'discussion', 'update', 'updates', 'plan',
+  'planning', 'task', 'tasks', 'todo', 'idea', 'ideas', 'write', 'writing',
+  'read', 'reading', 'about',
+])
+
+function fileMatchesQuestion(basename: string, derived: string, tokens: string[]): boolean {
+  if (tokens.length === 0) return false
+  const nameHaystack = basename.toLowerCase()
+  if (tokens.some((token) => nameHaystack.includes(token))) return true
+  const distinctive = tokens.filter((token) => !GENERIC_FILE_BODY_TOKENS.has(token))
+  if (distinctive.length === 0) return false
+  const body = derived.toLowerCase()
+  return distinctive.some((token) => body.includes(token))
+}
+
 function fmtClock(ms: number): string {
   const value = new Date(ms)
   return `${String(value.getHours()).padStart(2, '0')}:${String(value.getMinutes()).padStart(2, '0')}`
@@ -887,15 +941,17 @@ function fileExcerptItems(
     if (tokens.length === 0) return { items, omittedHighSensitivity }
     // Only unrevoked model_readable grants may disclose content, and only when
     // the grant already carries locally extracted text — the packet never
-    // reads a file the person did not make model-readable.
+    // reads a file the person did not make model-readable. A file joins the
+    // packet when its name matches the question, or a distinctive (not generic)
+    // token appears in the extracted text — not because "meeting" appears in
+    // an unrelated Obsidian note.
     const grants = listFileAccessGrants(db)
       .filter((grant) => grant.state === 'model_readable' && grant.derived_text)
       .sort((a, b) => a.path.localeCompare(b.path))
     for (const grant of grants) {
       if (items.length >= MAX_FILE_EXCERPTS) break
       const derived = grant.derived_text ?? ''
-      const haystack = `${path.basename(grant.path)} ${derived}`.toLowerCase()
-      if (!tokens.some((token) => haystack.includes(token))) continue
+      if (!fileMatchesQuestion(path.basename(grant.path), derived, tokens)) continue
       const sensitivity = classifyFileSensitivity(grant.path)
       // High-sensitivity content requires the explicit flag on the covering
       // grant (spec §File and document access) — same rule as the read tools.
@@ -1168,14 +1224,18 @@ export async function buildContextPacket(
   const dates = timeRange.dates
   const contextBudget = resolveContextBudget(input.contextBudget, dates.length)
   const explicitScope = timeRange.resolution !== 'default'
+  const attachRetrieval = questionAttachesRetrieval(question)
+  const attachDayFacts = questionAttachesDayFacts(question, timeRange)
 
   // Keep the queried days' projections current so retrieval reads the same
   // corrected facts Timeline shows (cheap fingerprint check when unchanged).
-  for (const date of dates) {
-    try {
-      ensureDayMemoryIndexed(db, date)
-    } catch (error) {
-      console.warn('[contextPacket] day index refresh failed', date, error)
+  if (attachDayFacts) {
+    for (const date of dates) {
+      try {
+        ensureDayMemoryIndexed(db, date)
+      } catch (error) {
+        console.warn('[contextPacket] day index refresh failed', date, error)
+      }
     }
   }
 
@@ -1187,24 +1247,40 @@ export async function buildContextPacket(
     ? { ...input.filters, startDate: dates[0], endDate: dates[dates.length - 1] }
     : { ...input.filters }
 
-  const dayResults = dates.map((date) => dayFactItems(db, date, input.dayPayloads?.[date]))
-  const dayFacts = [
-    ...dayResults.flatMap((result) => result.items),
-    ...dates.flatMap((date) => connectedActivityDayItems(db, date)),
-  ]
-  const conflicts = [
-    ...dayResults.flatMap((result) => result.conflicts),
-    ...dates.flatMap((date) => pageCoverageConflicts(db, date)),
-  ].sort((a, b) => a.identity.localeCompare(b.identity))
-  const gaps = dates.flatMap((date) => dayGaps(db, date))
-  const permissions = consultedPermissions(db)
-  const corrected = correctedFactItems(db, question)
-  const { items: entities, entityIds } = entityItems(db, question)
-  const exact = exactSearchItems(db, question, searchScope)
+  const dayResults = attachDayFacts
+    ? dates.map((date) => dayFactItems(db, date, input.dayPayloads?.[date]))
+    : []
+  const dayFacts = attachDayFacts
+    ? [
+        ...dayResults.flatMap((result) => result.items),
+        ...dates.flatMap((date) => connectedActivityDayItems(db, date)),
+      ]
+    : []
+  const conflicts = attachDayFacts
+    ? [
+        ...dayResults.flatMap((result) => result.conflicts),
+        ...dates.flatMap((date) => pageCoverageConflicts(db, date)),
+      ].sort((a, b) => a.identity.localeCompare(b.identity))
+    : []
+  const gaps = attachDayFacts ? dates.flatMap((date) => dayGaps(db, date)) : []
+  const permissions = attachRetrieval ? consultedPermissions(db) : []
+  const corrected = attachRetrieval ? correctedFactItems(db, question) : []
+  const { items: entities, entityIds } = attachRetrieval
+    ? entityItems(db, question)
+    : { items: [] as ContextPacketItem[], entityIds: [] as string[] }
+  const exact = attachRetrieval
+    ? exactSearchItems(db, question, searchScope)
+    : { items: [] as ContextPacketItem[], omittedHighSensitivity: 0 }
   const exactIdentities = new Set(exact.items.map((item) => item.identity))
-  const semantic = await semanticSearchItems(db, question, searchScope, exactIdentities)
-  const files = fileExcerptItems(db, question, contextBudget.maxFileExcerptChars)
-  const transcripts = granolaTranscriptItems(db, question, dates, contextBudget.maxFileExcerptChars)
+  const semantic = attachRetrieval
+    ? await semanticSearchItems(db, question, searchScope, exactIdentities)
+    : []
+  const files = attachRetrieval
+    ? fileExcerptItems(db, question, contextBudget.maxFileExcerptChars)
+    : { items: [] as ContextPacketItem[], omittedHighSensitivity: 0 }
+  const transcripts = attachRetrieval
+    ? granolaTranscriptItems(db, question, dates, contextBudget.maxFileExcerptChars)
+    : []
 
   // One identity appears once: a connected day fact and an exact-search hit
   // can both name the same memory record, and a citation must resolve to a

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -695,7 +695,7 @@ const api = {
       ipcRenderer.invoke(IPC.CONTEXT_PACKETS.GET_FOR_MESSAGE, messageId),
     list: (payload: { limit?: number; exchangeKind?: 'chat' | 'day_analysis'; scopeKey?: string } = {}) =>
       ipcRenderer.invoke(IPC.CONTEXT_PACKETS.LIST, payload),
-    // DEV-183: the read-only "What the AI saw" inspection for one exchange —
+    // DEV-183: the read-only sources inspection for one exchange —
     // by packet id, or by the assistant message the packet is bound to.
     inspect: (payload: { packetId?: string | null; messageId?: number | null }): Promise<ContextPacketInspection | null> =>
       ipcRenderer.invoke(IPC.CONTEXT_PACKETS.INSPECT, payload),

--- a/src/renderer/components/ContextPacketInspector.tsx
+++ b/src/renderer/components/ContextPacketInspector.tsx
@@ -1,4 +1,4 @@
-// "What the AI saw" (DEV-183, agent-runtime-and-context.md §Context
+// Sources for this answer (DEV-183, agent-runtime-and-context.md §Context
 // inspection): the read-only view of the recorded context packet behind one
 // AI exchange. Everything shown is re-read from the local disclosure ledger —
 // nothing here calls a model, and nothing here can be edited. The view is
@@ -146,7 +146,7 @@ export function ContextPacketInspector({ packetId, messageId, onClose }: Context
   return (
     <div
       role="dialog"
-      aria-label="What the AI saw"
+      aria-label="Sources for this answer"
       style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.55)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100, padding: 24 }}
       onClick={(event) => { if (event.target === event.currentTarget) onClose() }}
     >
@@ -154,7 +154,7 @@ export function ContextPacketInspector({ packetId, messageId, onClose }: Context
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, padding: '18px 20px 12px' }}>
           <div style={{ display: 'grid', gap: 3, flex: 1, minWidth: 0 }}>
             <span style={{ fontSize: 15.5, fontWeight: 700, letterSpacing: '-0.01em', color: 'var(--color-text-primary)' }}>
-              What the AI saw
+              Sources for this answer
             </span>
             <span style={{ ...quietTextStyle, fontSize: 11.5 }}>
               The exact context recorded for this exchange, before the request left this device. Read-only.

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -3465,7 +3465,7 @@ export default function Settings({ initialSettings = null }: { initialSettings?:
             <SuppliedMemorySection reloadToken={suppliedReloadToken} />
 
             {/* DEV-183: the recorded-context browser — every AI exchange's
-                packet, openable into the read-only "What the AI saw" view. */}
+                packet, openable into the read-only sources inspector. */}
             <div style={{ marginTop: 14, padding: '14px 18px', borderRadius: 14, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface-low)' }}>
               <ContextPacketSection />
             </div>

--- a/src/renderer/views/insights/AIWorkspace.tsx
+++ b/src/renderer/views/insights/AIWorkspace.tsx
@@ -112,9 +112,9 @@ export default function AIWorkspace() {
     })
   }, [])
 
-  // "What the AI saw" (DEV-183): which exchange's recorded context packet the
-  // inspector is open on. Opened from the citation chips or the per-answer
-  // affordance; the inspector itself is read-only.
+  // DEV-183: which exchange's recorded context packet the inspector is open on.
+  // Opened from the citation chips or the per-answer affordance; the inspector
+  // itself is read-only.
   const [inspectTarget, setInspectTarget] = useState<{ packetId: string | null; messageId: number | null } | null>(null)
   const openPacketInspector = useCallback((message: ThreadMessage) => {
     setInspectTarget({

--- a/src/renderer/views/insights/ActivityTrail.tsx
+++ b/src/renderer/views/insights/ActivityTrail.tsx
@@ -13,6 +13,7 @@ import {
   collapseTrail,
   liveTrailRows,
   shortToolChip,
+  showSettledActivity,
   stepsFromToolTrace,
   summarizeAgentTurn,
   formatWorkedDuration,
@@ -162,7 +163,7 @@ const pillStyle: React.CSSProperties = {
 /**
  * The settled trail on a completed answer: a collapsed "Worked for…" line
  * that expands into one-line tool narration and inline tool-status chips.
- * Renders nothing for a greeting that did no visible work.
+ * A recorded packet still shows Sources when the turn left no trail rows.
  */
 export function SettledActivityTrail({
   message,
@@ -181,21 +182,24 @@ export function SettledActivityTrail({
   const steps = stepsFromToolTrace(agent.toolTrace)
   const summary = summarizeAgentTurn(agent)
   const worked = summary?.label ?? ''
-  const hasVisibleWork = steps.length > 0 || (summary?.citationCount ?? 0) > 0
-  if (!hasVisibleWork) return null
+  const citationCount = summary?.citationCount ?? 0
+  const hasVisibleWork = steps.length > 0 || citationCount > 0
+  if (!showSettledActivity({ hasSteps: steps.length > 0, citationCount, canInspect })) return null
   const chips = summary?.toolsConsulted ?? []
   return (
     <div style={{ display: 'grid', gap: 8, marginTop: 12 }}>
       <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 6 }}>
-        <button
-          type="button"
-          onClick={() => setShowSteps((value) => !value)}
-          aria-expanded={showSteps}
-          title={showSteps ? 'Hide the steps this answer took' : 'Show the steps this answer took'}
-          style={{ ...pillStyle, cursor: 'pointer', color: 'var(--color-text-secondary)' }}
-        >
-          {showSteps ? '▾' : '▸'} {worked || 'Worked'}
-        </button>
+        {hasVisibleWork && (
+          <button
+            type="button"
+            onClick={() => setShowSteps((value) => !value)}
+            aria-expanded={showSteps}
+            title={showSteps ? 'Hide the steps this answer took' : 'Show the steps this answer took'}
+            style={{ ...pillStyle, cursor: 'pointer', color: 'var(--color-text-secondary)' }}
+          >
+            {showSteps ? '▾' : '▸'} {worked || 'Worked'}
+          </button>
+        )}
         {showSteps && chips.map((consulted) => (
           <span key={consulted.tool} style={pillStyle}>{shortToolChip(consulted.tool)}</span>
         ))}

--- a/src/renderer/views/insights/ActivityTrail.tsx
+++ b/src/renderer/views/insights/ActivityTrail.tsx
@@ -1,19 +1,21 @@
 // The live activity trail on AI answers: while a turn runs, a calm stack of
 // human one-liners under the question — one in-progress row, finished rows
 // check-marked, failures stated plainly. When the turn settles, completed
-// answers show a quiet summary ("Used 4 sources · 1 file") next to the
-// existing "What the AI saw" pill; both open the context-packet inspector.
-// Persisted answers reconstruct the same trail from their tool trace.
+// answers collapse to a Codex-style "Worked for Xm Ys" line that expands on
+// demand into the same narration plus inline tool-status chips. The sources
+// inspector opens from a Sources chip, not a file-chip wall.
 //
 // Labels arrive pre-built from the whitelist in shared/agentTrail — this file
 // renders them and must never reach into tool inputs or outputs itself.
-import { useState, useSyncExternalStore } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import type { AIAgentStep } from '@shared/types'
 import {
   collapseTrail,
   liveTrailRows,
+  shortToolChip,
   stepsFromToolTrace,
   summarizeAgentTurn,
+  formatWorkedDuration,
 } from '@shared/agentTrail'
 import { getStreamingStatus, getStreamingSteps, subscribeStreaming } from './streamingStore'
 import type { ThreadMessage } from './types'
@@ -87,6 +89,17 @@ function TrailStack({ steps, reducedMotion }: { steps: AIAgentStep[]; reducedMot
   )
 }
 
+function useElapsedMs(active: boolean): number {
+  const startedAtRef = useRef(Date.now())
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!active) return
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [active])
+  return Math.max(0, now - startedAtRef.current)
+}
+
 /**
  * The trail under an in-flight answer. Subscribes to the streaming store per
  * message (same pattern as <StreamingMessage>), so step arrivals re-render
@@ -104,9 +117,13 @@ export function LiveActivityTrail({ messageId, reducedMotion }: { messageId: str
     () => '',
   )
   const rows = liveTrailRows(steps, status)
+  const elapsedMs = useElapsedMs(rows.length > 0)
   if (rows.length === 0) return null
   return (
-    <div style={{ marginBottom: 10 }}>
+    <div style={{ marginBottom: 10, display: 'grid', gap: 6 }}>
+      <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-text-tertiary)' }}>
+        {elapsedMs >= 1000 ? `Working · ${formatWorkedDuration(elapsedMs)}` : 'Working…'}
+      </div>
       <TrailStack steps={rows} reducedMotion={reducedMotion} />
     </div>
   )
@@ -143,10 +160,9 @@ const pillStyle: React.CSSProperties = {
 }
 
 /**
- * The settled trail on a completed answer: a summary pill whose counts come
- * from the same aggregation the inspector uses, an expandable static trail
- * reconstructed from the persisted tool trace, and the existing
- * "What the AI saw" pill. Renders nothing for non-agent answers.
+ * The settled trail on a completed answer: a collapsed "Worked for…" line
+ * that expands into one-line tool narration and inline tool-status chips.
+ * Renders nothing for a greeting that did no visible work.
  */
 export function SettledActivityTrail({
   message,
@@ -164,39 +180,33 @@ export function SettledActivityTrail({
   if (!agent) return null
   const steps = stepsFromToolTrace(agent.toolTrace)
   const summary = summarizeAgentTurn(agent)
-  if (steps.length === 0 && !summary?.label && !canInspect) return null
+  const worked = summary?.label ?? ''
+  const hasVisibleWork = steps.length > 0 || (summary?.citationCount ?? 0) > 0
+  if (!hasVisibleWork) return null
+  const chips = summary?.toolsConsulted ?? []
   return (
     <div style={{ display: 'grid', gap: 8, marginTop: 12 }}>
       <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 6 }}>
-        {steps.length > 0 && (
-          <button
-            type="button"
-            onClick={() => setShowSteps((value) => !value)}
-            aria-expanded={showSteps}
-            title={showSteps ? 'Hide the steps this answer took' : 'Show the steps this answer took'}
-            style={{ ...pillStyle, cursor: 'pointer' }}
-          >
-            {showSteps ? '▾' : '▸'} {steps.length} step{steps.length === 1 ? '' : 's'}
-          </button>
-        )}
-        {summary?.label && (
-          <button
-            type="button"
-            onClick={canInspect ? onInspect : () => setShowSteps((value) => !value)}
-            title={canInspect ? 'Open everything the AI was shown for this answer' : 'Show the steps this answer took'}
-            style={{ ...pillStyle, color: 'var(--color-text-secondary)', cursor: 'pointer' }}
-          >
-            {summary.label}
-          </button>
-        )}
+        <button
+          type="button"
+          onClick={() => setShowSteps((value) => !value)}
+          aria-expanded={showSteps}
+          title={showSteps ? 'Hide the steps this answer took' : 'Show the steps this answer took'}
+          style={{ ...pillStyle, cursor: 'pointer', color: 'var(--color-text-secondary)' }}
+        >
+          {showSteps ? '▾' : '▸'} {worked || 'Worked'}
+        </button>
+        {showSteps && chips.map((consulted) => (
+          <span key={consulted.tool} style={pillStyle}>{shortToolChip(consulted.tool)}</span>
+        ))}
         {canInspect && (
           <button
             type="button"
             onClick={onInspect}
-            title="Open the recorded context packet for this answer"
+            title="Open the recorded sources for this answer"
             style={{ ...pillStyle, cursor: 'pointer' }}
           >
-            What the AI saw
+            Sources
           </button>
         )}
       </div>

--- a/src/renderer/views/insights/MessageList.tsx
+++ b/src/renderer/views/insights/MessageList.tsx
@@ -1,6 +1,7 @@
 import { memo, useState } from 'react'
 import type { AIActionUndo, AIActionWidget, AIMessageAction, AIProviderMode, FocusSession } from '@shared/types'
 import type { AIProviderErrorCode } from '@shared/aiProviderError'
+import { citationDisplayTitle } from '@shared/citationDisplay'
 import { ipc } from '../../lib/ipc'
 import { MarkdownMessage } from './markdown'
 import { MentionText } from './mentions'
@@ -87,8 +88,7 @@ export interface MessageListProps {
   onUndoActionWidget: (proposalId: string, undo: AIActionUndo) => void
   onDismissActionWidget: (widget: AIActionWidget) => void
   onFollowUpClick: (message: ThreadMessage, suggestionText: string, source: string) => void
-  // "What the AI saw" (DEV-183): opens the read-only context-packet inspector
-  // for the exchange behind this assistant message.
+  // Opens the read-only context-packet inspector for this exchange.
   onInspectPacket?: (message: ThreadMessage) => void
   // DEV-200: resume / discard a paused turn's row.
   onResumePaused?: (message: ThreadMessage) => void
@@ -436,56 +436,29 @@ function MessageListImpl({
                   )}
 
                   {(message.agent?.citations?.length ?? 0) > 0 && (
-                    // Packet citations (DEV-182): each chip is one recorded
-                    // context-packet item the answer's superscripts point at.
-                    // Clicking a chip opens the full inspector (DEV-183) on
-                    // this exchange's packet.
                     <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 6, marginTop: 12 }}>
-                      <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', fontWeight: 600 }}>From your day record</span>
+                      <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', fontWeight: 600 }}>Sources</span>
                       {message.agent?.citations?.map((citation) => (
                         <button
                           key={`${message.id}:cite:${citation.marker}`}
                           type="button"
                           onClick={canInspect(message) ? () => onInspectPacket?.(message) : undefined}
-                          title={`${citation.statement}\n${citation.identity}\n${canInspect(message) ? 'Click to see everything the AI was shown' : "Recorded in this answer's context packet"}`}
+                          title={`${citationDisplayTitle(citation)}\n${canInspect(message) ? 'Click to inspect recorded sources' : "Recorded in this answer's context packet"}`}
                           style={{ fontSize: 11, padding: '2px 8px', borderRadius: 999, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface-low)', color: 'var(--color-text-secondary)', maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', cursor: canInspect(message) ? 'pointer' : 'default' }}
                         >
-                          {citation.marker} · {citation.statement}
+                          {citation.marker} · {citationDisplayTitle(citation)}
                         </button>
                       ))}
                     </div>
                   )}
 
                   {message.agent != null && (
-                    // The settled trail (issue #25) + "What the AI saw"
-                    // (DEV-183): the answer's quiet summary and step list,
-                    // reconstructed from the persisted tool trace, next to
-                    // the recorded context-packet pill. Read-only; works
-                    // with no model configured.
                     <SettledActivityTrail
                       message={message}
                       canInspect={canInspect(message)}
                       onInspect={() => onInspectPacket?.(message)}
                       reducedMotion={reducedMotion}
                     />
-                  )}
-
-                  {(message.agent?.fileDisclosures?.length ?? 0) > 0 && (
-                    <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 6, marginTop: 12 }}>
-                      <span style={{ fontSize: 11, color: 'var(--color-text-tertiary)', fontWeight: 600 }}>Files opened</span>
-                      {message.agent?.fileDisclosures?.map((disclosure) => (
-                        // The chip stays human — just the file name. The
-                        // audit detail (path, version, byte range) lives in
-                        // the tooltip and the Settings access log, not inline.
-                        <span
-                          key={`${message.id}:${disclosure.path}:${disclosure.excerptStart}`}
-                          title={`${disclosure.path}\nversion ${disclosure.versionFingerprint}\nbytes ${disclosure.excerptStart}–${disclosure.excerptEnd}\nLogged in Settings → Agent file access`}
-                          style={{ fontSize: 11, padding: '2px 8px', borderRadius: 999, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface-low)', color: 'var(--color-text-secondary)' }}
-                        >
-                          {disclosure.name}
-                        </span>
-                      ))}
-                    </div>
                   )}
 
                   {message.id === latestCompletedAssistantId && message.state === 'complete' && (message.suggestedFollowUps?.length ?? 0) >= 2 && (

--- a/src/renderer/views/settings/ContextPacketSection.tsx
+++ b/src/renderer/views/settings/ContextPacketSection.tsx
@@ -1,4 +1,4 @@
-// Settings → Memory → "What the AI has seen" (DEV-183): the browser over the
+// Settings → Memory → recorded sources (DEV-183): the browser over the
 // recorded context-packet ledger. Every AI exchange that assembled context is
 // listed — question, when, how much, where it went — and any row opens the
 // same read-only inspector the chat answers use. Works with no model
@@ -41,7 +41,7 @@ export function ContextPacketSection() {
 
   return (
     <div style={{ display: 'grid', gap: 8 }}>
-      <span style={{ fontSize: 13, fontWeight: 650, color: 'var(--color-text-primary)' }}>What the AI has seen</span>
+      <span style={{ fontSize: 13, fontWeight: 650, color: 'var(--color-text-primary)' }}>Recorded sources</span>
       <span style={{ fontSize: 12, color: 'var(--color-text-tertiary)', lineHeight: 1.55 }}>
         Every AI answer starts from a recorded context packet — the exact facts, search hits, and file
         excerpts selected for that question, written down before anything leaves this device. Open any

--- a/src/shared/agentTrail.ts
+++ b/src/shared/agentTrail.ts
@@ -239,6 +239,16 @@ const TOOL_CHIP_LABELS: Record<string, string> = {
   forget_memory: 'Forget',
 }
 
+/** Settled trail (or a lone Sources chip) when the turn did visible work
+ *  or a recorded packet can be inspected. */
+export function showSettledActivity(input: {
+  hasSteps: boolean
+  citationCount: number
+  canInspect: boolean
+}): boolean {
+  return input.hasSteps || input.citationCount > 0 || input.canInspect
+}
+
 /** Short inline chip for a consulted tool — a status, not a file path. */
 export function shortToolChip(tool: string): string {
   if (tool.startsWith('mcp_')) return 'Connected source'

--- a/src/shared/agentTrail.ts
+++ b/src/shared/agentTrail.ts
@@ -181,28 +181,85 @@ export interface AgentTurnSummary {
   /** Distinct files whose contents were disclosed this turn. */
   fileCount: number
   citationCount: number
-  /** Quiet settle line, e.g. "Used 4 sources · 1 file". Empty when the turn
-   *  touched nothing worth summarizing. */
+  durationMs: number | null
+  /** Collapsed Codex-style line, e.g. "Worked for 12s". Empty when the turn
+   *  did no visible work. */
   label: string
+}
+
+/** Compact duration for the collapsed "Worked for Xm Ys" line. */
+export function formatWorkedDuration(durationMs: number): string {
+  const totalSeconds = Math.max(1, Math.round(durationMs / 1000))
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  if (minutes > 0) return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`
+  return `${seconds}s`
+}
+
+/** Collapsed settle line. Duration wins when recorded; otherwise "Worked" if
+ *  tools ran. A greeting with no tools and no duration stays blank. */
+export function workedSummaryLabel(
+  durationMs: number | null | undefined,
+  hasWork: boolean,
+): string {
+  if (typeof durationMs === 'number' && durationMs > 0) {
+    return `Worked for ${formatWorkedDuration(durationMs)}`
+  }
+  return hasWork ? 'Worked' : ''
+}
+
+const TOOL_CHIP_LABELS: Record<string, string> = {
+  get_moment: 'Moment',
+  get_time_chunks: 'Intervals',
+  get_day_overview: 'Day',
+  search_history: 'Search',
+  list_page_visits: 'Pages',
+  get_app_usage: 'App time',
+  get_week_summary: 'Week',
+  get_calendar_events: 'Calendar',
+  get_git_activity: 'Commits',
+  read_meeting_notes: 'Meetings',
+  get_attribution: 'Attribution',
+  list_clients: 'Clients',
+  discover_repositories: 'Repos',
+  search_files: 'Files',
+  git: 'Git',
+  read_file: 'Read',
+  list_dir: 'Folder',
+  create_artifact: 'File',
+  export_week_excel: 'Excel',
+  capture_screen: 'Screen',
+  run_command: 'Command',
+  ask_user: 'Question',
+  propose_memory: 'Memory',
+  propose_correction: 'Correction',
+  undo_correction: 'Undo',
+  forget_memory: 'Forget',
+}
+
+/** Short inline chip for a consulted tool — a status, not a file path. */
+export function shortToolChip(tool: string): string {
+  if (tool.startsWith('mcp_')) return 'Connected source'
+  return TOOL_CHIP_LABELS[tool] ?? tool.replace(/[_-]+/g, ' ')
 }
 
 export function summarizeAgentTurn(agent: {
   toolTrace?: AgentToolTraceEntryLike[]
   fileDisclosures?: Array<Pick<AIMessageFileDisclosure, 'path'>>
   citations?: AIMessageCitation[]
+  durationMs?: number | null
 } | null | undefined): AgentTurnSummary | null {
   if (!agent) return null
   const toolsConsulted = aggregateToolsConsulted(agent.toolTrace) ?? []
   const sourceCount = toolsConsulted.filter((consulted) => !NON_SOURCE_TOOLS.has(consulted.tool)).length
   const fileCount = new Set((agent.fileDisclosures ?? []).map((disclosure) => disclosure.path)).size
   const citationCount = agent.citations?.length ?? 0
-  const parts: string[] = []
-  if (sourceCount > 0) parts.push(`${sourceCount} source${sourceCount === 1 ? '' : 's'}`)
-  if (fileCount > 0) parts.push(`${fileCount} file${fileCount === 1 ? '' : 's'}`)
-  const label = parts.length > 0
-    ? `Used ${parts.join(' · ')}`
-    : citationCount > 0
-      ? 'Answered from your day record'
-      : ''
-  return { toolsConsulted, sourceCount, fileCount, citationCount, label }
+  const durationMs = typeof agent.durationMs === 'number' && Number.isFinite(agent.durationMs)
+    ? Math.max(0, agent.durationMs)
+    : null
+  const hasWork = toolsConsulted.length > 0 || fileCount > 0 || citationCount > 0
+  const label = workedSummaryLabel(durationMs, hasWork)
+  return { toolsConsulted, sourceCount, fileCount, citationCount, durationMs, label }
 }

--- a/src/shared/citationDisplay.ts
+++ b/src/shared/citationDisplay.ts
@@ -1,0 +1,42 @@
+// Citation chips must read as titles a person would recognize — never a
+// kebab-case filename with a hash suffix, and never the excerpt that rides
+// the recorded statement after the colon.
+import type { AIMessageCitation } from './types'
+
+const HASH_SUFFIX_RE = /[-_][a-f0-9]{6,}$/i
+const EXTENSION_RE = /\.[a-z0-9]{1,8}$/i
+
+function basenameFromIdentity(identity: string): string {
+  const path = identity.startsWith('file:') ? identity.slice('file:'.length) : identity
+  const parts = path.split(/[/\\]/)
+  return parts[parts.length - 1] ?? path
+}
+
+function titleFromFilename(filename: string): string {
+  let name = filename.trim()
+  name = name.replace(EXTENSION_RE, '')
+  name = name.replace(HASH_SUFFIX_RE, '')
+  name = name.replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim()
+  if (!name) return filename
+  if (name === name.toLowerCase() || name === name.toUpperCase()) {
+    return name
+      .split(' ')
+      .map((word) => (word ? `${word[0].toUpperCase()}${word.slice(1).toLowerCase()}` : word))
+      .join(' ')
+  }
+  return name
+}
+
+/** Compact label for one packet citation in the chat sources row. */
+export function citationDisplayTitle(citation: Pick<AIMessageCitation, 'identity' | 'kind' | 'statement'>): string {
+  const statement = citation.statement.trim()
+  if (citation.kind === 'file_excerpt' || citation.identity.startsWith('file:') || citation.identity.startsWith('transcript:')) {
+    const beforeColon = statement.includes(':') ? statement.slice(0, statement.indexOf(':')).trim() : ''
+    const raw = beforeColon || basenameFromIdentity(citation.identity)
+    const titled = titleFromFilename(raw)
+    if (titled) return titled
+  }
+  const firstLine = statement.split(/\n/)[0]?.trim() ?? ''
+  const cut = firstLine.search(/\s[—–-]\s/)
+  return cut > 12 ? firstLine.slice(0, cut) : firstLine
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1058,7 +1058,7 @@ export interface AIMessageCitation {
 }
 
 // ─── Context packet inspection (DEV-183) ─────────────────────────────────────
-// The renderer-facing shape of "what the AI saw" for one exchange: the
+// The renderer-facing shape of the sources inspector for one exchange: the
 // recorded packet re-read from the local ledger, grouped per kind, with each
 // item checked against the evidence that backs it today. Read-only — the
 // inspector shows the record, it never edits it.
@@ -1170,6 +1170,8 @@ export interface AIThreadMessageMetadata {
     contextPacketId?: string | null
     /** Verified packet citations in the answer, in display order. */
     citations?: AIMessageCitation[]
+    /** Wall-clock length of the agent turn, for the collapsed "Worked for" line. */
+    durationMs?: number | null
   }
   answerKind?: AIAnswerKind | null
   suggestedFollowUps?: FollowUpSuggestion[]
@@ -3221,7 +3223,7 @@ export const IPC = {
     GET: 'context-packets:get',
     GET_FOR_MESSAGE: 'context-packets:get-for-message',
     LIST: 'context-packets:list',
-    // DEV-183: the assembled read-only inspection behind "What the AI saw" —
+    // DEV-183: the assembled read-only inspection behind Sources for this answer —
     // the recorded packet grouped per kind, with omissions in plain language
     // and each item checked against the evidence backing it today.
     INSPECT: 'context-packets:inspect',

--- a/tests/activityTrail.test.ts
+++ b/tests/activityTrail.test.ts
@@ -11,6 +11,7 @@ import {
   formatWorkedDuration,
   liveTrailRows,
   shortToolChip,
+  showSettledActivity,
   statusForTool,
   stepsFromToolTrace,
   summarizeAgentTurn,
@@ -313,6 +314,13 @@ test('summary label degrades honestly when the turn touched less', () => {
 
   const nothing = summarizeAgentTurn({ toolTrace: [], fileDisclosures: [], citations: [] })
   assert.equal(nothing?.label, '')
+})
+
+test('a recorded packet still shows Sources when the turn left no trail or citations', () => {
+  assert.equal(showSettledActivity({ hasSteps: false, citationCount: 0, canInspect: true }), true)
+  assert.equal(showSettledActivity({ hasSteps: false, citationCount: 0, canInspect: false }), false)
+  assert.equal(showSettledActivity({ hasSteps: true, citationCount: 0, canInspect: false }), true)
+  assert.equal(showSettledActivity({ hasSteps: false, citationCount: 2, canInspect: false }), true)
 })
 
 test('formatWorkedDuration matches the Codex Xm Ys line', () => {

--- a/tests/activityTrail.test.ts
+++ b/tests/activityTrail.test.ts
@@ -8,7 +8,9 @@ import { createProductionTestDatabase } from './support/testDatabase.ts'
 import {
   aggregateToolsConsulted,
   collapseTrail,
+  formatWorkedDuration,
   liveTrailRows,
+  shortToolChip,
   statusForTool,
   stepsFromToolTrace,
   summarizeAgentTurn,
@@ -227,14 +229,15 @@ test('export_week_excel builds a file — it is consulted but not counted as a s
     ],
     fileDisclosures: [],
     citations: [],
+    durationMs: 12_000,
   })
   assert.equal(summary?.sourceCount, 1)
-  assert.equal(summary?.label, 'Used 1 source')
+  assert.equal(summary?.label, 'Worked for 12s')
   // Still listed among tools consulted, so the inspector shows the call.
   assert.deepEqual(summary?.toolsConsulted.map((t) => t.tool), ['get_week_summary', 'export_week_excel'])
 })
 
-test('the settle summary reads "Used N sources · M files" and counts match the inspector aggregation', () => {
+test('the settle summary is a collapsed Worked-for line and counts match the inspector aggregation', () => {
   const toolTrace = [
     { tool: 'get_day_overview', input: { date: '2026-07-06' }, output: '{}' },
     { tool: 'search_history', input: { query: 'coursera' }, output: '{}' },
@@ -250,13 +253,16 @@ test('the settle summary reads "Used N sources · M files" and counts match the 
       { path: '/home/u/roadmap.md' },
     ],
     citations: [],
+    durationMs: 64_000,
   }
   const summary = summarizeAgentTurn(agent)
   assert.ok(summary)
   // ask_user interacts with the person; it is consulted but not a source.
   assert.equal(summary.sourceCount, 4)
   assert.equal(summary.fileCount, 1)
-  assert.equal(summary.label, 'Used 4 sources · 1 file')
+  assert.equal(summary.label, 'Worked for 1m 4s')
+  assert.equal(shortToolChip('read_meeting_notes'), 'Meetings')
+  assert.equal(shortToolChip('mcp_notion_search'), 'Connected source')
 
   // Consistency with the inspector: the summary derives from the SAME
   // aggregation the inspector's tools-consulted list uses on the persisted
@@ -282,23 +288,38 @@ test('summary label degrades honestly when the turn touched less', () => {
   assert.equal(summarizeAgentTurn(null), null)
   assert.equal(summarizeAgentTurn(undefined), null)
 
-  const filesOnly = summarizeAgentTurn({ toolTrace: [], fileDisclosures: [{ path: '/a' }], citations: [] })
-  assert.equal(filesOnly?.label, 'Used 1 file')
+  const filesOnly = summarizeAgentTurn({
+    toolTrace: [],
+    fileDisclosures: [{ path: '/a' }],
+    citations: [],
+    durationMs: 900,
+  })
+  assert.equal(filesOnly?.label, 'Worked for 1s')
 
   const oneSource = summarizeAgentTurn({
     toolTrace: [{ tool: 'get_week_summary', input: {}, output: '{}' }],
     fileDisclosures: [],
     citations: [],
   })
-  assert.equal(oneSource?.label, 'Used 1 source')
+  assert.equal(oneSource?.label, 'Worked')
 
   const packetOnly = summarizeAgentTurn({
     toolTrace: [],
     fileDisclosures: [],
     citations: [{ marker: 1, identity: 'block:1', kind: 'day_fact', statement: 'x' }],
+    durationMs: 2_400,
   })
-  assert.equal(packetOnly?.label, 'Answered from your day record')
+  assert.equal(packetOnly?.label, 'Worked for 2s')
 
   const nothing = summarizeAgentTurn({ toolTrace: [], fileDisclosures: [], citations: [] })
   assert.equal(nothing?.label, '')
+})
+
+test('formatWorkedDuration matches the Codex Xm Ys line', () => {
+  assert.equal(formatWorkedDuration(400), '1s')
+  assert.equal(formatWorkedDuration(12_000), '12s')
+  assert.equal(formatWorkedDuration(60_000), '1m')
+  assert.equal(formatWorkedDuration(65_000), '1m 5s')
+  assert.equal(formatWorkedDuration(3_600_000), '1h')
+  assert.equal(formatWorkedDuration(3_720_000), '1h 2m')
 })

--- a/tests/citationDisplay.test.ts
+++ b/tests/citationDisplay.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { citationDisplayTitle } from '../src/shared/citationDisplay.ts'
+
+test('file citations read as titles, not kebab-case filenames with hashes', () => {
+  assert.equal(
+    citationDisplayTitle({
+      identity: 'file:/Users/me/Obsidian/prompts-are-technical-debt-7f3a9c.md',
+      kind: 'file_excerpt',
+      statement: 'prompts-are-technical-debt-7f3a9c.md: The essay argues prompts rot like code.',
+    }),
+    'Prompts Are Technical Debt',
+  )
+  assert.equal(
+    citationDisplayTitle({
+      identity: 'file:/home/person/notes/Launch Plan.md',
+      kind: 'file_excerpt',
+      statement: 'Launch Plan.md: three tiers, annual billing.',
+    }),
+    'Launch Plan',
+  )
+  assert.equal(
+    citationDisplayTitle({
+      identity: 'transcript:granola:abc',
+      kind: 'file_excerpt',
+      statement: 'Granola transcript of "ACME kickoff": We decided to ship Friday.',
+    }),
+    'Granola transcript of "ACME kickoff"',
+  )
+})
+
+test('day-fact citations keep the human statement, not the identity', () => {
+  assert.equal(
+    citationDisplayTitle({
+      identity: 'block:42',
+      kind: 'day_fact',
+      statement: '09:00–11:14 Daylens Wrapped (Cursor)',
+    }),
+    '09:00–11:14 Daylens Wrapped (Cursor)',
+  )
+})

--- a/tests/contextPacket.test.ts
+++ b/tests/contextPacket.test.ts
@@ -151,13 +151,13 @@ test('a Granola question does not attach unrelated Obsidian files that merely me
     path: '/home/person/Obsidian/personal-essay-7f3a9c.md',
     state: 'model_readable',
   })
-  storeDerivedText(unrelated.id, 'A diary entry about a meeting with friends and some notes.')
+  storeDerivedText(db, unrelated.id, 'A diary entry about a meeting with friends and some notes.')
   const related = addFileAccessGrant(db, {
     scopeKind: 'file',
     path: '/home/person/notes/granola-kickoff.md',
     state: 'model_readable',
   })
-  storeDerivedText(related.id, 'Agenda for the Granola kickoff.')
+  storeDerivedText(db, related.id, 'Agenda for the Granola kickoff.')
 
   const packet = await buildContextPacket(db, {
     purpose: 'answer',

--- a/tests/contextPacket.test.ts
+++ b/tests/contextPacket.test.ts
@@ -54,6 +54,7 @@ import {
   getContextPacketById,
   getContextPacketForMessage,
   listContextPackets,
+  fileMatchesQuestion,
   questionAttachesDayFacts,
   questionAttachesRetrieval,
   renderContextPacketForPrompt,
@@ -116,7 +117,19 @@ test('greetings skip retrieval; day dumps need a day question or an explicit ran
   assert.equal(questionAttachesDayFacts('what did we decide in the granola meeting', today), false)
   assert.equal(questionAttachesDayFacts('retrieval planner', today), false)
   assert.equal(questionAttachesDayFacts('what did I do today', today), true)
+  assert.equal(questionAttachesDayFacts('How did my day go?', today), true)
+  assert.equal(questionAttachesDayFacts('show me my day', today), true)
+  assert.equal(questionAttachesDayFacts("how's my day", today), true)
   assert.equal(questionAttachesDayFacts('retrieval planner', asked), true)
+})
+
+test('file matching requires a whole token, not a substring', () => {
+  assert.equal(fileMatchesQuestion('started-writing.md', 'I started writing.', ['art']), false)
+  assert.equal(fileMatchesQuestion('product-catalog.md', 'a catalog of widgets', ['log']), false)
+  assert.equal(fileMatchesQuestion('runtime-notes.md', 'runtime errors', ['run']), false)
+  assert.equal(fileMatchesQuestion('error-log.md', 'the log from deploy', ['log']), true)
+  assert.equal(fileMatchesQuestion('modern-art.md', 'notes on modern art', ['art']), true)
+  assert.equal(fileMatchesQuestion('granola-kickoff.md', 'Agenda for the Granola kickoff.', ['granola']), true)
 })
 
 test('a greeting attaches almost no context even on a busy day with granted files', async () => {
@@ -168,6 +181,58 @@ test('a Granola question does not attach unrelated Obsidian files that merely me
   const files = packet.items.filter((item) => item.kind === 'file_excerpt')
   assert.equal(files.length, 1)
   assert.equal(files[0]?.identity, 'file:/home/person/notes/granola-kickoff.md')
+  db.close()
+})
+
+test('everyday day questions attach today’s timeline facts', async () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, 'Refactoring the retrieval planner', 9, 0, 45)
+  indexMemoryForDay(db, DATE)
+  const dayNow = new Date(2026, 3, 22, 18, 0, 0, 0)
+  for (const question of ['How did my day go?', 'show me my day']) {
+    const packet = await buildContextPacket(db, {
+      purpose: 'answer',
+      question,
+      now: dayNow,
+      destination: DESTINATION,
+    })
+    assert.ok(
+      packet.items.some((item) => item.kind === 'day_fact' || item.kind === 'search_exact'),
+      `"${question}" still receives the day’s facts`,
+    )
+    assert.ok(packet.gaps.length > 0 || packet.items.length > 0)
+  }
+  db.close()
+})
+
+test('short question tokens do not fill the file-excerpt budget with substring hits', async () => {
+  const db = createProductionTestDatabase()
+  const decoys = [
+    ['/home/person/notes/aaa-started.md', 'I started writing this morning.'],
+    ['/home/person/notes/bbb-started.md', 'We started the catalog later.'],
+    ['/home/person/notes/ccc-catalog.md', 'A catalog of runtime notes.'],
+    ['/home/person/notes/ddd-runtime.md', 'runtime setup after we started.'],
+    ['/home/person/notes/eee-started.md', 'started another catalog page.'],
+  ] as const
+  for (const [path, text] of decoys) {
+    const grant = addFileAccessGrant(db, { scopeKind: 'file', path, state: 'model_readable' })
+    storeDerivedText(db, grant.id, text)
+  }
+  const relevant = addFileAccessGrant(db, {
+    scopeKind: 'file',
+    path: '/home/person/notes/fff-art.md',
+    state: 'model_readable',
+  })
+  storeDerivedText(db, relevant.id, 'Notes on the art of retrieval.')
+
+  const packet = await buildContextPacket(db, {
+    purpose: 'answer',
+    question: 'the art log',
+    now: NOW,
+    destination: DESTINATION,
+  })
+  const files = packet.items.filter((item) => item.kind === 'file_excerpt')
+  assert.deepEqual(files.map((item) => item.identity), ['file:/home/person/notes/fff-art.md'])
   db.close()
 })
 

--- a/tests/contextPacket.test.ts
+++ b/tests/contextPacket.test.ts
@@ -54,6 +54,8 @@ import {
   getContextPacketById,
   getContextPacketForMessage,
   listContextPackets,
+  questionAttachesDayFacts,
+  questionAttachesRetrieval,
   renderContextPacketForPrompt,
   resolveContextDates,
   CONTEXT_POLICY_VERSION,
@@ -103,6 +105,89 @@ test('resolveContextDates: explicit ISO dates and "yesterday" resolve determinis
   assert.deepEqual(resolveContextDates('what did I do', NOW), ['2026-04-23'])
 })
 
+test('greetings skip retrieval; day dumps need a day question or an explicit range', () => {
+  assert.equal(questionAttachesRetrieval('hi'), false)
+  assert.equal(questionAttachesRetrieval('hello there'), false)
+  assert.equal(questionAttachesRetrieval('thanks'), false)
+  assert.equal(questionAttachesRetrieval('what did we decide in the granola meeting'), true)
+  const today = { startDate: '2026-04-23', endDate: '2026-04-23', dates: ['2026-04-23'], resolution: 'default' as const }
+  const asked = { startDate: '2026-04-22', endDate: '2026-04-22', dates: ['2026-04-22'], resolution: 'explicit' as const }
+  assert.equal(questionAttachesDayFacts('hi', today), false)
+  assert.equal(questionAttachesDayFacts('what did we decide in the granola meeting', today), false)
+  assert.equal(questionAttachesDayFacts('retrieval planner', today), false)
+  assert.equal(questionAttachesDayFacts('what did I do today', today), true)
+  assert.equal(questionAttachesDayFacts('retrieval planner', asked), true)
+})
+
+test('a greeting attaches almost no context even on a busy day with granted files', async () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, 'Refactoring the retrieval planner', 9, 0, 45)
+  insertSession(db, 'Reading an Obsidian essay about meetings', 14, 0, 30)
+  indexMemoryForDay(db, DATE)
+  const grant = addFileAccessGrant(db, {
+    scopeKind: 'file',
+    path: '/home/person/Obsidian/personal-essay-7f3a9c.md',
+    state: 'model_readable',
+  })
+  storeDerivedText(db, grant.id, 'A long personal journal about meetings, granola breakfasts, and notes from last week.')
+
+  const packet = await buildContextPacket(db, {
+    purpose: 'answer',
+    question: 'hi',
+    now: NOW,
+    destination: DESTINATION,
+  })
+  assert.equal(packet.items.length, 0, 'hi does not dump the day, search hits, or files')
+  assert.deepEqual(packet.gaps, [])
+  assert.deepEqual(packet.conflicts, [])
+  assert.deepEqual(packet.permissions, [])
+  db.close()
+})
+
+test('a Granola question does not attach unrelated Obsidian files that merely mention meetings', async () => {
+  const db = createProductionTestDatabase()
+  const unrelated = addFileAccessGrant(db, {
+    scopeKind: 'file',
+    path: '/home/person/Obsidian/personal-essay-7f3a9c.md',
+    state: 'model_readable',
+  })
+  storeDerivedText(unrelated.id, 'A diary entry about a meeting with friends and some notes.')
+  const related = addFileAccessGrant(db, {
+    scopeKind: 'file',
+    path: '/home/person/notes/granola-kickoff.md',
+    state: 'model_readable',
+  })
+  storeDerivedText(related.id, 'Agenda for the Granola kickoff.')
+
+  const packet = await buildContextPacket(db, {
+    purpose: 'answer',
+    question: 'what did we decide in the granola meeting',
+    now: NOW,
+    destination: DESTINATION,
+  })
+  const files = packet.items.filter((item) => item.kind === 'file_excerpt')
+  assert.equal(files.length, 1)
+  assert.equal(files[0]?.identity, 'file:/home/person/notes/granola-kickoff.md')
+  db.close()
+})
+
+test('a day question still attaches timeline facts for the asked day', async () => {
+  const db = createProductionTestDatabase()
+  insertSession(db, 'Refactoring the retrieval planner', 9, 0, 45)
+  indexMemoryForDay(db, DATE)
+  const packet = await buildContextPacket(db, {
+    purpose: 'answer',
+    question: 'what happened on 2026-04-22',
+    now: NOW,
+    destination: DESTINATION,
+  })
+  assert.ok(
+    packet.items.some((item) => item.kind === 'day_fact' || item.kind === 'search_exact'),
+    'a day question still receives the day’s facts',
+  )
+  db.close()
+})
+
 test('the same question against the same day state assembles the same packet (modulo id and timestamp)', async () => {
   const db = createProductionTestDatabase()
   insertSession(db, 'Refactoring the retrieval planner', 9, 0, 45)
@@ -144,9 +229,9 @@ test('the same question against the same day state assembles the same packet (mo
     assert.ok(['standard', 'personal', 'high'].includes(item.sensitivity))
   }
 
-  // Honest absence: the requested day has no focus events, so the packet says
-  // so as a typed gap instead of letting silence read as inactivity.
-  assert.ok(first.gaps.some((gap) => gap.kind === 'no-capture'), 'a signal-free day is a recorded gap')
+  // A search question does not dump today's timeline or its capture gaps.
+  assert.deepEqual(first.gaps, [])
+  assert.ok(!first.items.some((item) => item.kind === 'day_fact'))
 
   // Day state change ⇒ different packet.
   insertSession(db, 'Sketching the retrieval planner ranker', 16, 0, 20)

--- a/tests/contextPacketInspection.test.ts
+++ b/tests/contextPacketInspection.test.ts
@@ -469,7 +469,7 @@ test('an empty exchange inspects honestly: every group empty, zero items, record
   const db = createProductionTestDatabase()
   const packet = await buildContextPacket(db, {
     purpose: 'answer',
-    question: 'anything at all',
+    question: 'what did I do',
     now: NOW,
     destination: DESTINATION,
   })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes Linear [DEV-244](https://linear.app/irachrist1/issue/DEV-244/chat-tool-activity-is-a-wall-of-files-instead-of-a-clean-summary). Related: spcsorg/daylens#66. Mirrors [spcsorg/daylens#323](https://github.com/spcsorg/daylens/pull/323).

Chat tool activity was a wall of every touched file — including unrelated Obsidian notes on a Granola question — under “what the AI saw.” The full context packet rode every message, including “hi.” Citations showed kebab-case filenames with hashes.

This copies the Codex collapsed-summary pattern (`12-reference-codex/` is not in this repo; the issue text is the source).

## What changed

1. **Settled trail** — completed answers collapse to “Worked for 12s” / “Worked for 1m 4s” (or “Worked” when duration was not recorded). Expanding shows the existing one-line tool narration plus short tool-status chips (`Day`, `Meetings`, …), not file paths. Live turns show “Working…” / “Working · 12s”.
2. **Context packet scales with the question** — policy version 4. Greetings and chitchat attach nothing. Today’s timeline dump joins everyday day questions (“How did my day go?”, “show me my day”) or an explicit time range. File excerpts match whole tokens in the basename or a distinctive body word — not substrings (“art” in “started”) and not generic words like “meeting” in an unrelated note.
3. **Citations** — chips use human titles (`Prompts Are Technical Debt`), not `prompts-are-technical-debt-7f3a9c.md`. The “Files opened” chip wall is gone. The inspector and settings copy say **Sources for this answer** / **Recorded sources**. The phrase “what the AI saw” is retired. **Sources** stays available whenever a packet was recorded, even if the turn left no tool-trace rows or citations.

## Doc edits

- `docs/codebase/architecture.md` — inspector described as a sources inspector; dropped (“what the AI saw”).

## Greptile P1s (spcsorg/daylens#323)

All three findings were valid and are fixed on this branch:

1. Everyday day questions now attach today’s facts/gaps.
2. File matching is whole-token, so short terms cannot fill the five-excerpt budget.
3. Sources renders when `canInspect` is true even with an empty trail.

## How to verify

- Send **hi** on a busy day with granted files: the recorded packet has almost no items; no file-chip wall; no “what the AI saw.”
- Ask **How did my day go?** or **show me my day**: the packet includes today’s timeline facts; a tidy collapsed **Worked for…** line expands into tool narration and status chips; **Sources** opens the inspector.
- Ask a Granola/meeting question: unrelated Obsidian notes that merely mention “meeting” stay out of the packet. Short tokens like “art” / “log” do not pull `started` / `catalog` files.

Automated coverage: `tests/activityTrail.test.ts`, `tests/citationDisplay.test.ts`, `tests/contextPacket.test.ts`, `tests/contextPacketInspection.test.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc9fb1da-f83c-4ce3-9232-8e0fcacf84ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc9fb1da-f83c-4ce3-9232-8e0fcacf84ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

