### PR TITLE
Load calendar context progressively on first Timeline open

### DIFF
--- a/src/main/services/externalSignals.ts
+++ b/src/main/services/externalSignals.ts
@@ -23,6 +23,7 @@ import { collectFocusAppSignals } from './enrichmentDiscovery'
 import { localDateString, shiftLocalDateString } from '../lib/localDate'
 import { isCaptureConsentCurrent } from '@shared/captureConsent'
 import { adoptExternalSignalEntities } from './entities/entityAdoption'
+import { invalidateProjectionScope } from '../core/projections/invalidation'
 
 // ─── Store ────────────────────────────────────────────────────────────────────
 
@@ -125,11 +126,23 @@ export function hasExternalSignalScan(
  *  A finished (past) day's signals never go stale — the day can't change. */
 const LIVE_DAY_STALE_MS = 30 * 60 * 1000
 
+/** In-process completion of today's calendar read (empty or persisted). */
+const liveCalendarCompletedAt = new Map<string, number>()
+const calendarInFlight = new Map<string, Promise<CalendarCollectOutcome>>()
+
+export type CalendarCollectOutcome = 'persisted' | 'empty' | 'skipped' | 'failed' | 'blocked'
+
 function isFresh(db: Database.Database, date: string, source: ExternalSignalSource): boolean {
   const stored = getExternalSignal(db, date, source)
   if (stored) {
     if (date < localDateString()) return true
     return Date.now() - stored.capturedAt < LIVE_DAY_STALE_MS
+  }
+  // An empty live-day calendar completion is remembered in-process for the
+  // same stale window as a stored row. The scan ledger is never used for today.
+  if (source === 'calendar' && date === localDateString()) {
+    const completedAt = liveCalendarCompletedAt.get(date)
+    if (completedAt !== undefined && Date.now() - completedAt < LIVE_DAY_STALE_MS) return true
   }
   // No stored row: a finished day the connectors already scanned came back
   // empty ("collected, nothing found") and cannot change — don't re-run its
@@ -148,6 +161,7 @@ export interface CollectExternalSignalsDeps {
   collectFocus: (date: string) => Promise<import('@shared/types').FocusAppSignal[] | null>
   enrichmentSources: Record<string, boolean>
   isConsentCurrent: () => boolean
+  invalidateTimeline?: (reason: string, date: string) => void
 }
 
 function currentConsentIsGranted(): boolean {
@@ -167,7 +181,97 @@ function defaultDeps(): CollectExternalSignalsDeps {
     collectFocus: (date) => collectFocusAppSignals(date, {}, (app) => enrichmentSources[`focus:${app}`] === true),
     enrichmentSources,
     isConsentCurrent: currentConsentIsGranted,
+    invalidateTimeline: (reason, date) => {
+      invalidateProjectionScope('timeline', reason, { date })
+    },
   }
+}
+
+function markLiveCalendarComplete(date: string): void {
+  if (date === localDateString()) liveCalendarCompletedAt.set(date, Date.now())
+}
+
+function notifyCalendarPersisted(deps: CollectExternalSignalsDeps, date: string): void {
+  const invalidate = deps.invalidateTimeline ?? ((reason, dateStr) => {
+    invalidateProjectionScope('timeline', reason, { date: dateStr })
+  })
+  try {
+    invalidate('calendar-collected', date)
+  } catch { /* no renderer yet; the next Timeline open reads the stored row */ }
+}
+
+function markCalendarScanned(db: Database.Database, date: string): void {
+  const ledgerCutoff = shiftLocalDateString(localDateString(), -1)
+  if (date < ledgerCutoff) recordExternalSignalScan(db, date, 'calendar')
+}
+
+async function collectAndPersistCalendar(
+  date: string,
+  options: { force?: boolean; deps: CollectExternalSignalsDeps },
+): Promise<CalendarCollectOutcome> {
+  const existing = calendarInFlight.get(date)
+  if (existing) return existing
+
+  const run = (async (): Promise<CalendarCollectOutcome> => {
+    const { db, collectCalendar, isConsentCurrent } = options.deps
+    if (!isConsentCurrent()) return 'blocked'
+    if (!options.force && isFresh(db, date, 'calendar')) return 'skipped'
+    try {
+      const calendar = await collectCalendar(date)
+      if (!isConsentCurrent()) return 'blocked'
+      if (calendar && calendar.events.length > 0) {
+        putExternalSignal(db, date, 'calendar', calendar)
+        markCalendarScanned(db, date)
+        markLiveCalendarComplete(date)
+        notifyCalendarPersisted(options.deps, date)
+        return 'persisted'
+      }
+      if (options.force) deleteExternalSignal(db, date, 'calendar')
+      markCalendarScanned(db, date)
+      markLiveCalendarComplete(date)
+      return 'empty'
+    } catch {
+      return 'failed'
+    }
+  })()
+
+  calendarInFlight.set(date, run)
+  try {
+    return await run
+  } finally {
+    if (calendarInFlight.get(date) === run) calendarInFlight.delete(date)
+  }
+}
+
+/** Today's local calendar, before git/focus and without blocking Timeline.
+ *  Persistence of events invalidates the mounted Timeline so they appear
+ *  without a reopen. Never throws. */
+export async function collectTodayCalendarContext(
+  options: { date?: string; deps?: CollectExternalSignalsDeps } = {},
+): Promise<CalendarCollectOutcome> {
+  const isConsentCurrent = options.deps?.isConsentCurrent ?? currentConsentIsGranted
+  if (!isConsentCurrent()) return 'blocked'
+  const date = options.date ?? localDateString()
+  try {
+    const outcome = await collectAndPersistCalendar(date, {
+      deps: options.deps ?? defaultDeps(),
+      force: false,
+    })
+    if (outcome === 'persisted' && isConsentCurrent()) {
+      capture(ANALYTICS_EVENT.WRAPPED_EXTERNAL_SOURCES, {
+        external_sources: ['calendar'],
+        source_count: 1,
+      })
+    }
+    return outcome
+  } catch {
+    return 'failed'
+  }
+}
+
+export function __resetCalendarProgressiveLoadForTests(): void {
+  liveCalendarCompletedAt.clear()
+  calendarInFlight.clear()
 }
 
 /** Run every available connector for a date and persist what they found.
@@ -183,7 +287,7 @@ export async function collectExternalSignals(
   collecting = true
   const fired: ExternalSignalSource[] = []
   try {
-    const { db, collectGit, collectCalendar, collectFocus, enrichmentSources } =
+    const { db, collectGit, collectCalendar, collectFocus, enrichmentSources, invalidateTimeline } =
       options.deps ?? defaultDeps()
 
     // Git and calendar are ALWAYS-ON: read whenever the underlying tools exist
@@ -237,17 +341,12 @@ export async function collectExternalSignals(
 
     if (options.force || !isFresh(db, date, 'calendar')) {
       if (!isConsentCurrent()) return fired
-      try {
-        const calendar = await collectCalendar(date)
-        if (!isConsentCurrent()) return fired
-        if (calendar && calendar.events.length > 0) {
-          putExternalSignal(db, date, 'calendar', calendar)
-          fired.push('calendar')
-        } else {
-          tombstoneIfForced('calendar')
-        }
-        markScanned('calendar')
-      } catch { /* optional source — connector threw; leave any prior row intact */ }
+      const calendarOutcome = await collectAndPersistCalendar(date, {
+        force: options.force,
+        deps: { db, collectGit, collectCalendar, collectFocus, enrichmentSources, isConsentCurrent, invalidateTimeline },
+      })
+      if (calendarOutcome === 'blocked') return fired
+      if (calendarOutcome === 'persisted') fired.push('calendar')
     }
 
     if (options.force || !isFresh(db, date, 'focus_app')) {
@@ -343,11 +442,12 @@ export async function runExternalSignalBackfill(date: string): Promise<void> {
 let scheduled: ReturnType<typeof setInterval> | null = null
 let initialScheduled: ReturnType<typeof setTimeout> | null = null
 
-/** Background cadence: first pass a couple of minutes after launch (today and
- *  yesterday), then a refresh every 6 hours. Cheap: connectors early-exit when
- *  the stored signal is fresh. */
+/** Today's calendar starts immediately; git/focus and yesterday wait a couple
+ *  of minutes, then a refresh every 6 hours. Cheap: connectors early-exit
+ *  when the stored signal is fresh. */
 export function startExternalSignalCollection(): void {
   if (scheduled || initialScheduled) return
+  void collectTodayCalendarContext()
   const run = () => {
     const today = localDateString()
     const yesterday = shiftLocalDateString(localDateString(), -1)

--- a/tests/timelineCalendarProgressiveLoad.test.ts
+++ b/tests/timelineCalendarProgressiveLoad.test.ts
@@ -1,0 +1,209 @@
+// First Timeline open paints from stored activity and lets today's calendar
+// arrive afterwards. The projection is a pure read; persistence invalidates
+// the mounted view so events appear without a reopen. A missing or failing
+// calendar cannot break the day or force a second read.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import type Database from 'better-sqlite3'
+import { createProductionTestDatabase } from './support/testDatabase.ts'
+import { localDateString } from '../src/main/lib/localDate.ts'
+import { getTimelineDayPayload } from '../src/main/services/workBlocks.ts'
+import { getExternalSignal } from '../src/main/services/externalSignals.ts'
+import {
+  __resetCalendarProgressiveLoadForTests,
+  collectExternalSignals,
+  collectTodayCalendarContext,
+  type CollectExternalSignalsDeps,
+} from '../src/main/services/externalSignals.ts'
+import type { CalendarSignal } from '../src/shared/types.ts'
+
+const TODAY = localDateString()
+const dayStart = new Date(`${TODAY}T00:00:00`).getTime()
+const at = (hour: number, minute: number) => dayStart + (hour * 60 + minute) * 60_000
+
+const STANDUP: CalendarSignal = {
+  events: [{ title: 'Standup', startClock: '10:00', durationMinutes: 30, attendeeCount: 3 }],
+}
+
+function session(db: Database.Database): void {
+  db.prepare(`
+    INSERT INTO app_sessions
+      (bundle_id, app_name, start_time, end_time, duration_sec, category, is_focused,
+       window_title, raw_app_name, capture_source, capture_version)
+    VALUES (?, ?, ?, ?, ?, ?, 1, 'notes', ?, 'test', 1)
+  `).run('com.apple.Notes', 'Notes', at(9, 0), at(11, 0), 2 * 60 * 60, 'writing', 'Notes')
+}
+
+function deps(
+  db: Database.Database,
+  over: Partial<CollectExternalSignalsDeps> & {
+    calendar?: () => Promise<CalendarSignal | null>
+    invalidations?: Array<{ reason: string; date: string }>
+  } = {},
+): CollectExternalSignalsDeps & { calendarCalls: number; gitCalls: number } {
+  const invalidations = over.invalidations ?? []
+  let calendarCalls = 0
+  let gitCalls = 0
+  return {
+    db,
+    collectGit: async () => {
+      gitCalls += 1
+      return null
+    },
+    collectCalendar: async () => {
+      calendarCalls += 1
+      return over.calendar ? await over.calendar() : STANDUP
+    },
+    collectFocus: async () => null,
+    enrichmentSources: {},
+    isConsentCurrent: () => true,
+    invalidateTimeline: (reason, date) => {
+      invalidations.push({ reason, date })
+    },
+    ...over,
+    get calendarCalls() { return calendarCalls },
+    get gitCalls() { return gitCalls },
+  }
+}
+
+test('first paint: Timeline reads stored activity and does not collect calendar', () => {
+  __resetCalendarProgressiveLoadForTests()
+  const db = createProductionTestDatabase()
+  session(db)
+
+  const payload = getTimelineDayPayload(db, TODAY, null, { materialize: false })
+  assert.ok(payload.blocks.length > 0, 'core Timeline blocks render from activity')
+  assert.equal(payload.scheduledMeetings, undefined, 'no calendar row yet')
+  assert.equal(getExternalSignal(db, TODAY, 'calendar'), null)
+  db.close()
+})
+
+test('GET_TIMELINE_DAY is a sync projection read — connectors are not a precondition', () => {
+  const handlerSource = fs.readFileSync(new URL('../src/main/ipc/db.handlers.ts', import.meta.url), 'utf8')
+  const start = handlerSource.indexOf('ipcMain.handle(IPC.DB.GET_TIMELINE_DAY')
+  const next = handlerSource.indexOf('ipcMain.handle', start + 1)
+  const handler = handlerSource.slice(start, next)
+  assert.match(handler, /getTimelineDayProjection/)
+  assert.doesNotMatch(handler, /collectExternalSignals|collectTodayCalendarContext|collectCalendarEvents/)
+  assert.doesNotMatch(handler, /await /)
+})
+
+test('window-visible collection starts today\'s calendar before the deferred cadence', () => {
+  const source = fs.readFileSync(new URL('../src/main/services/externalSignals.ts', import.meta.url), 'utf8')
+  const start = source.indexOf('export function startExternalSignalCollection')
+  const stop = source.indexOf('export function stopExternalSignalCollection')
+  const body = source.slice(start, stop)
+  assert.match(body, /collectTodayCalendarContext\(\)/)
+  assert.ok(
+    body.indexOf('collectTodayCalendarContext()') < body.indexOf('2 * 60 * 1000'),
+    'today\'s calendar must start before the 2-minute git/focus pass',
+  )
+})
+
+test('calendar persistence invalidates Timeline so events appear without a reopen', async () => {
+  __resetCalendarProgressiveLoadForTests()
+  const db = createProductionTestDatabase()
+  session(db)
+  const invalidations: Array<{ reason: string; date: string }> = []
+  const injected = deps(db, { invalidations })
+
+  const before = getTimelineDayPayload(db, TODAY, null, { materialize: false })
+  assert.equal(before.scheduledMeetings, undefined)
+
+  const outcome = await collectTodayCalendarContext({ date: TODAY, deps: injected })
+  assert.equal(outcome, 'persisted')
+  assert.equal(injected.gitCalls, 0, 'prompt calendar must not wait on git')
+  assert.deepEqual(invalidations, [{ reason: 'calendar-collected', date: TODAY }])
+
+  const after = getTimelineDayPayload(db, TODAY, null, { materialize: false })
+  const standup = (after.scheduledMeetings ?? []).find((meeting) => meeting.title === 'Standup')
+  assert.ok(standup, 'the scheduled event is on the payload after persistence')
+  db.close()
+})
+
+test('an unavailable or empty calendar leaves the Timeline working and does not invalidate', async () => {
+  __resetCalendarProgressiveLoadForTests()
+  const db = createProductionTestDatabase()
+  session(db)
+
+  const emptyInvalidations: Array<{ reason: string; date: string }> = []
+  const empty = deps(db, { calendar: async () => ({ events: [] }), invalidations: emptyInvalidations })
+  const emptyBefore = getTimelineDayPayload(db, TODAY, null, { materialize: false })
+  assert.equal(await collectTodayCalendarContext({ date: TODAY, deps: empty }), 'empty')
+  const emptyAfter = getTimelineDayPayload(db, TODAY, null, { materialize: false })
+  assert.equal(emptyAfter.blocks.length, emptyBefore.blocks.length)
+  assert.equal(emptyAfter.scheduledMeetings, undefined)
+  assert.deepEqual(emptyInvalidations, [])
+  assert.equal(getExternalSignal(db, TODAY, 'calendar'), null)
+
+  __resetCalendarProgressiveLoadForTests()
+  const failingInvalidations: Array<{ reason: string; date: string }> = []
+  const failing = deps(db, {
+    calendar: async () => { throw new Error('icalBuddy missing') },
+    invalidations: failingInvalidations,
+  })
+  const failBefore = getTimelineDayPayload(db, TODAY, null, { materialize: false })
+  assert.equal(await collectTodayCalendarContext({ date: TODAY, deps: failing }), 'failed')
+  const failAfter = getTimelineDayPayload(db, TODAY, null, { materialize: false })
+  assert.equal(failAfter.blocks.length, failBefore.blocks.length)
+  assert.equal(failAfter.totalSeconds, failBefore.totalSeconds)
+  assert.equal(failAfter.scheduledMeetings, undefined)
+  assert.deepEqual(failingInvalidations, [])
+
+  __resetCalendarProgressiveLoadForTests()
+  const emptyAgain = deps(db, { calendar: async () => ({ events: [] }), invalidations: [] })
+  assert.equal(await collectTodayCalendarContext({ date: TODAY, deps: emptyAgain }), 'empty')
+  assert.deepEqual(await collectExternalSignals(TODAY, { deps: emptyAgain }), [])
+  assert.equal(emptyAgain.calendarCalls, 1, 'an empty first-open read is not repeated by the cadence')
+  db.close()
+})
+
+test('the first-open calendar read and Timeline refetch are not repeated', async () => {
+  __resetCalendarProgressiveLoadForTests()
+  const db = createProductionTestDatabase()
+  session(db)
+  const invalidations: Array<{ reason: string; date: string }> = []
+  let calendarCalls = 0
+  const injected = deps(db, {
+    invalidations,
+    calendar: async () => {
+      calendarCalls += 1
+      return STANDUP
+    },
+  })
+
+  assert.equal(await collectTodayCalendarContext({ date: TODAY, deps: injected }), 'persisted')
+  const fired = await collectExternalSignals(TODAY, { deps: injected })
+  assert.equal(await collectTodayCalendarContext({ date: TODAY, deps: injected }), 'skipped')
+
+  assert.equal(calendarCalls, 1, 'icalBuddy/Outlook runs once')
+  assert.equal(invalidations.length, 1, 'Timeline refetches once when the row lands')
+  assert.ok(!fired.includes('calendar'), 'the deferred collect must not persist calendar again')
+  db.close()
+})
+
+test('overlapping first-open and cadence collects share one in-flight calendar read', async () => {
+  __resetCalendarProgressiveLoadForTests()
+  const db = createProductionTestDatabase()
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => { release = resolve })
+  let calendarCalls = 0
+  const invalidations: Array<{ reason: string; date: string }> = []
+  const injected = deps(db, {
+    invalidations,
+    calendar: async () => {
+      calendarCalls += 1
+      await gate
+      return STANDUP
+    },
+  })
+
+  const first = collectTodayCalendarContext({ date: TODAY, deps: injected })
+  const second = collectTodayCalendarContext({ date: TODAY, deps: injected })
+  release()
+  assert.deepEqual(await Promise.all([first, second]), ['persisted', 'persisted'])
+  assert.equal(calendarCalls, 1)
+  assert.equal(invalidations.length, 1)
+  db.close()
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [DEV-294](https://linear.app/irachrist1/issue/DEV-294/load-calendar-context-progressively-on-the-first-timeline-open). Also tracks [spcsorg/daylens#116](https://github.com/spcsorg/daylens/issues/116).

## Why

The first Timeline open painted from stored activity, but today's calendar waited two minutes (bundled with git/focus) and never invalidated the mounted view. Events only showed up after a poll, an unrelated tracking invalidation, or a reopen.

## What changed

- `GET_TIMELINE_DAY` stays a sync projection read. Connector readiness is not a precondition for first paint.
- `startExternalSignalCollection` starts today's local calendar read immediately, before the deferred git/focus cadence.
- Persisting calendar events invalidates the Timeline (`calendar-collected`) so the open view refetches and draws scheduled events without a reopen.
- Empty or failing calendar reads leave the Timeline intact and do not invalidate.
- An in-flight or just-completed today-calendar read is reused, so the 2-minute cadence and analyze/wrap backfill do not shell icalBuddy/Outlook again.

Follows `docs/specs/calendar-and-blocks.md`: scheduled events remain context, never blocks or tracked time.

## Documentation

No documentation files were edited.

## Acceptance

- Fast first paint: Timeline renders without waiting on connectors.
- Automatic event appearance: calendar events show once persistence completes, no reopen.
- Unavailable/empty calendar: Timeline stays working and correct.
- No duplicate calendar read or Timeline refetch on first open.
- Focused tests in `tests/timelineCalendarProgressiveLoad.test.ts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cafff6e-d779-4c7c-ba01-98ad5f97e291?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cafff6e-d779-4c7c-ba01-98ad5f97e291&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

