### PR TITLE
Stop morning/evening main-process stack overflow (DEV-487)

### DIFF
--- a/src/main/services/workBlocks.ts
+++ b/src/main/services/workBlocks.ts
@@ -1213,25 +1213,6 @@ function isHighlyCoherentCandidate(candidate: CandidateBlock): boolean {
   return true
 }
 
-function splitAndAnalyze(
-  sessions: AppSession[],
-  splitIndex: number,
-  boundedBeforeGap: boolean,
-  boundedAfterGap: boolean,
-): CandidateBlock[] {
-  if (splitIndex <= 0 || splitIndex >= sessions.length) {
-    return [{
-      sessions,
-      formation: 'heuristic',
-      boundedBeforeGap,
-      boundedAfterGap,
-    }]
-  }
-
-  return analyzeSessions(sessions.slice(0, splitIndex), boundedBeforeGap, false)
-    .concat(analyzeSessions(sessions.slice(splitIndex), false, boundedAfterGap))
-}
-
 function hasCodeEvidence(candidate: CandidateBlock): boolean {
   return candidate.sessions.some((session) => {
     if (session.category === 'development') return true
@@ -3199,97 +3180,184 @@ function buildBlockFromCandidate(
   }
 }
 
-function analyzeSessions(
+type AnalyzeWork =
+  | { kind: 'job'; sessions: AppSession[]; boundedBeforeGap: boolean; boundedAfterGap: boolean }
+  | { kind: 'block'; block: CandidateBlock }
+
+function pushSplitJobs(
+  stack: AnalyzeWork[],
+  sessions: AppSession[],
+  splitIndex: number,
+  boundedBeforeGap: boolean,
+  boundedAfterGap: boolean,
+): void {
+  if (splitIndex <= 0 || splitIndex >= sessions.length) {
+    stack.push({
+      kind: 'block',
+      block: { sessions, formation: 'heuristic', boundedBeforeGap, boundedAfterGap },
+    })
+    return
+  }
+  stack.push({
+    kind: 'job',
+    sessions: sessions.slice(splitIndex),
+    boundedBeforeGap: false,
+    boundedAfterGap,
+  })
+  stack.push({
+    kind: 'job',
+    sessions: sessions.slice(0, splitIndex),
+    boundedBeforeGap,
+    boundedAfterGap: false,
+  })
+}
+
+// Same splits as the old recursive walk, but the call stack is a heap array.
+// A high-volume meeting or topic-shift chain is O(n) deep; recursion overflowed
+// the main process (DEV-487) during morning/evening Timeline reads.
+export function analyzeSessions(
   sessions: AppSession[],
   boundedBeforeGap: boolean,
   boundedAfterGap: boolean,
 ): CandidateBlock[] {
-  if (sessions.length === 0) return []
+  const output: CandidateBlock[] = []
+  const stack: AnalyzeWork[] = [
+    { kind: 'job', sessions, boundedBeforeGap, boundedAfterGap },
+  ]
 
-  const firstMeetingIndex = sessions.findIndex(isStandaloneMeeting)
-  if (firstMeetingIndex >= 0) {
-    const blocks: CandidateBlock[] = []
-    const before = sessions.slice(0, firstMeetingIndex)
-    if (before.length > 0) {
-      blocks.push(...analyzeSessions(before, boundedBeforeGap, false))
+  while (stack.length > 0) {
+    const item = stack.pop()!
+    if (item.kind === 'block') {
+      output.push(item.block)
+      continue
     }
 
-    const meeting = sessions[firstMeetingIndex]
-    blocks.push({
-      sessions: [meeting],
-      formation: 'meeting',
-      boundedBeforeGap: firstMeetingIndex === 0 ? boundedBeforeGap : false,
-      boundedAfterGap: firstMeetingIndex === sessions.length - 1 ? boundedAfterGap : false,
-      forcedLabel: meetingLabel(meeting),
-    })
+    const jobSessions = item.sessions
+    if (jobSessions.length === 0) continue
 
-    const after = sessions.slice(firstMeetingIndex + 1)
-    if (after.length > 0) {
-      blocks.push(...analyzeSessions(after, false, boundedAfterGap))
-    }
-    return blocks
-  }
-
-  const contextSplitIndex = sustainedContextShiftSplitIndex(sessions)
-  if (contextSplitIndex !== null) {
-    return splitAndAnalyze(sessions, contextSplitIndex, boundedBeforeGap, boundedAfterGap)
-  }
-
-  const streak = longSingleAppStreak(sessions)
-  if (streak) {
-    const [startIndex, endIndex] = streak.range
-    const blocks: CandidateBlock[] = []
-    if (startIndex > 0) {
-      blocks.push(...analyzeSessions(sessions.slice(0, startIndex), boundedBeforeGap, false))
-    }
-    // No forced label: a streak is a formation, not a name. Naming the block
-    // after the app that hosted it is the shape label-voice.md rejects, and it
-    // short-circuits the evidence-based naming in `labelForCandidate` — a
-    // 90-minute browsing streak read "Google Chrome" while its own window and
-    // page titles named the subject.
-    blocks.push({
-      sessions: sessions.slice(startIndex, endIndex),
-      formation: 'longSingleApp',
-      boundedBeforeGap: startIndex === 0 ? boundedBeforeGap : false,
-      boundedAfterGap: endIndex === sessions.length ? boundedAfterGap : false,
-    })
-    if (endIndex < sessions.length) {
-      blocks.push(...analyzeSessions(sessions.slice(endIndex), false, boundedAfterGap))
-    }
-    return blocks
-  }
-
-  const effectiveSessions = effectiveSessionsFor(sessions)
-  const distribution = categoryDistributionFor(effectiveSessions)
-  const dominant = dominantCategoryFromDistribution(distribution)
-  const coherence = coherenceScore(distribution)
-  const averageDwell = averageDwellTime(sessions)
-  const runs = categoryRunsFor(effectiveSessions)
-
-  if (coherence < 0.4) {
-    const splitIndex = sustainedDifferentCategorySplitIndex(runs, dominant)
-    if (splitIndex !== null) {
-      return splitAndAnalyze(sessions, splitIndex, boundedBeforeGap, boundedAfterGap)
-    }
-  }
-
-  if (coherence >= 0.4 && coherence <= 0.75) {
-    if (isDeveloperTestingFlow(new Set(Object.keys(distribution) as AppCategory[]), averageDwell)) {
-      return [{ sessions, formation: 'heuristic', boundedBeforeGap, boundedAfterGap }]
+    const firstMeetingIndex = jobSessions.findIndex(isStandaloneMeeting)
+    if (firstMeetingIndex >= 0) {
+      const after = jobSessions.slice(firstMeetingIndex + 1)
+      if (after.length > 0) {
+        stack.push({
+          kind: 'job',
+          sessions: after,
+          boundedBeforeGap: false,
+          boundedAfterGap: item.boundedAfterGap,
+        })
+      }
+      const meeting = jobSessions[firstMeetingIndex]
+      stack.push({
+        kind: 'block',
+        block: {
+          sessions: [meeting],
+          formation: 'meeting',
+          boundedBeforeGap: firstMeetingIndex === 0 ? item.boundedBeforeGap : false,
+          boundedAfterGap: firstMeetingIndex === jobSessions.length - 1 ? item.boundedAfterGap : false,
+          forcedLabel: meetingLabel(meeting),
+        },
+      })
+      const before = jobSessions.slice(0, firstMeetingIndex)
+      if (before.length > 0) {
+        stack.push({
+          kind: 'job',
+          sessions: before,
+          boundedBeforeGap: item.boundedBeforeGap,
+          boundedAfterGap: false,
+        })
+      }
+      continue
     }
 
-    if (averageDwell > SLOW_SWITCH_THRESHOLD_SEC) {
-      const splitIndex = slowSwitchBoundaryIndex(runs)
+    const contextSplitIndex = sustainedContextShiftSplitIndex(jobSessions)
+    if (contextSplitIndex !== null) {
+      pushSplitJobs(stack, jobSessions, contextSplitIndex, item.boundedBeforeGap, item.boundedAfterGap)
+      continue
+    }
+
+    const streak = longSingleAppStreak(jobSessions)
+    if (streak) {
+      const [startIndex, endIndex] = streak.range
+      if (endIndex < jobSessions.length) {
+        stack.push({
+          kind: 'job',
+          sessions: jobSessions.slice(endIndex),
+          boundedBeforeGap: false,
+          boundedAfterGap: item.boundedAfterGap,
+        })
+      }
+      // No forced label: a streak is a formation, not a name. Naming the block
+      // after the app that hosted it is the shape label-voice.md rejects, and it
+      // short-circuits the evidence-based naming in `labelForCandidate` — a
+      // 90-minute browsing streak read "Google Chrome" while its own window and
+      // page titles named the subject.
+      stack.push({
+        kind: 'block',
+        block: {
+          sessions: jobSessions.slice(startIndex, endIndex),
+          formation: 'longSingleApp',
+          boundedBeforeGap: startIndex === 0 ? item.boundedBeforeGap : false,
+          boundedAfterGap: endIndex === jobSessions.length ? item.boundedAfterGap : false,
+        },
+      })
+      if (startIndex > 0) {
+        stack.push({
+          kind: 'job',
+          sessions: jobSessions.slice(0, startIndex),
+          boundedBeforeGap: item.boundedBeforeGap,
+          boundedAfterGap: false,
+        })
+      }
+      continue
+    }
+
+    const effectiveSessions = effectiveSessionsFor(jobSessions)
+    const distribution = categoryDistributionFor(effectiveSessions)
+    const dominant = dominantCategoryFromDistribution(distribution)
+    const coherence = coherenceScore(distribution)
+    const averageDwell = averageDwellTime(jobSessions)
+    const runs = categoryRunsFor(effectiveSessions)
+
+    if (coherence < 0.4) {
+      const splitIndex = sustainedDifferentCategorySplitIndex(runs, dominant)
       if (splitIndex !== null) {
-        return splitAndAnalyze(sessions, splitIndex, boundedBeforeGap, boundedAfterGap)
+        pushSplitJobs(stack, jobSessions, splitIndex, item.boundedBeforeGap, item.boundedAfterGap)
+        continue
       }
     }
+
+    if (coherence >= 0.4 && coherence <= 0.75) {
+      if (isDeveloperTestingFlow(new Set(Object.keys(distribution) as AppCategory[]), averageDwell)) {
+        output.push({
+          sessions: jobSessions,
+          formation: 'heuristic',
+          boundedBeforeGap: item.boundedBeforeGap,
+          boundedAfterGap: item.boundedAfterGap,
+        })
+        continue
+      }
+
+      if (averageDwell > SLOW_SWITCH_THRESHOLD_SEC) {
+        const splitIndex = slowSwitchBoundaryIndex(runs)
+        if (splitIndex !== null) {
+          pushSplitJobs(stack, jobSessions, splitIndex, item.boundedBeforeGap, item.boundedAfterGap)
+          continue
+        }
+      }
+    }
+
+    const formation: FormationReason =
+      coherence > 0.75 ? 'coherent' : coherence < 0.4 ? 'mixed' : 'heuristic'
+
+    output.push({
+      sessions: jobSessions,
+      formation,
+      boundedBeforeGap: item.boundedBeforeGap,
+      boundedAfterGap: item.boundedAfterGap,
+    })
   }
 
-  const formation: FormationReason =
-    coherence > 0.75 ? 'coherent' : coherence < 0.4 ? 'mixed' : 'heuristic'
-
-  return [{ sessions, formation, boundedBeforeGap, boundedAfterGap }]
+  return output
 }
 
 // Categories where the page/topic IS the activity, so a topic change is a real

--- a/tests/analyzeSessionsStack.test.ts
+++ b/tests/analyzeSessionsStack.test.ts
@@ -1,0 +1,60 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type { AppSession } from '../src/shared/types.ts'
+import { analyzeSessions } from '../src/main/services/workBlocks.ts'
+
+// Each standalone meeting is peeled off and the remainder is analyzed again.
+// On a high-volume day that is O(n) call-stack depth, which is the DEV-487
+// overflow: RangeError: Maximum call stack size exceeded, with thousands of
+// identical `analyzeSessions` frames. The morning/evening notifier hits this
+// path through getTimelineDayPayload → buildBlocksForSessions.
+const HIGH_VOLUME_MEETINGS = 8_000
+
+function meetingSession(index: number): AppSession {
+  const startTime = Date.UTC(2026, 3, 12, 8, 0, 0) + index * 21 * 60_000
+  return {
+    id: index + 1,
+    bundleId: 'us.zoom.xos',
+    appName: 'zoom.us',
+    startTime,
+    endTime: startTime + 21 * 60_000,
+    durationSeconds: 21 * 60,
+    category: 'meetings',
+    isFocused: true,
+    windowTitle: `Weekly sync ${index + 1}`,
+    rawAppName: 'zoom.us',
+    canonicalAppId: 'us.zoom.xos',
+    captureSource: 'foreground_poll',
+    endedReason: null,
+    captureVersion: 2,
+  }
+}
+
+test('analyzeSessions peels consecutive standalone meetings without changing order', () => {
+  const sessions = [0, 1, 2].map(meetingSession)
+  const blocks = analyzeSessions(sessions, true, true)
+  assert.equal(blocks.length, 3)
+  assert.deepEqual(
+    blocks.map((block) => ({
+      formation: block.formation,
+      ids: block.sessions.map((session) => session.id),
+      forcedLabel: block.forcedLabel,
+      boundedBeforeGap: block.boundedBeforeGap,
+      boundedAfterGap: block.boundedAfterGap,
+    })),
+    [
+      { formation: 'meeting', ids: [1], forcedLabel: 'Zoom Call', boundedBeforeGap: true, boundedAfterGap: false },
+      { formation: 'meeting', ids: [2], forcedLabel: 'Zoom Call', boundedBeforeGap: false, boundedAfterGap: false },
+      { formation: 'meeting', ids: [3], forcedLabel: 'Zoom Call', boundedBeforeGap: false, boundedAfterGap: true },
+    ],
+  )
+})
+
+test('analyzeSessions finishes a high-volume meeting chain without overflowing the stack', () => {
+  const sessions = Array.from({ length: HIGH_VOLUME_MEETINGS }, (_, index) => meetingSession(index))
+  const blocks = analyzeSessions(sessions, false, false)
+  assert.equal(blocks.length, HIGH_VOLUME_MEETINGS)
+  assert.equal(blocks[0]?.sessions[0]?.id, 1)
+  assert.equal(blocks[HIGH_VOLUME_MEETINGS - 1]?.sessions[0]?.id, HIGH_VOLUME_MEETINGS)
+  assert.ok(blocks.every((block) => block.formation === 'meeting'))
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [DEV-487](https://linear.app/irachrist1/issue/DEV-487/stop-recurring-morning-and-evening-main-process-stack-overflow-crashes) / [spcsorg/daylens#318](https://github.com/spcsorg/daylens/issues/318).

## Overflowing path

The morning and evening notifier reads Timeline through `getTimelineDayPayload` → `buildBlocksForSessions` → `analyzeSessions`. That walk peeled one standalone meeting or sustained topic-shift at a time and recursed on the remainder, so depth was O(n). On high-volume data V8 throws `RangeError: Maximum call stack size exceeded` and the main process dies (capture stops until restart).

This is not the 1.0.45 `flushCurrent` midnight-split (already guarded on `main`). The previous real-profile harness did not overflow because those days were not worst-case split chains; a deterministic 8,000-meeting chain reproduces the crash on the old recursive walk.

## Fix

`analyzeSessions` uses the same split decisions on an explicit heap stack. Block order and formation are unchanged. Notification scheduling and copy are untouched.

## Tests

- `tests/analyzeSessionsStack.test.ts`: 3-meeting order/bounds stay the same; 8,000 consecutive Zoom meetings overflowed before (`Maximum call stack size exceeded`) and complete after.
- Related Timeline/segmentation/midnight-flush files still pass (78 tests).
- `tsc --noEmit` clean; eslint clean on the changed files.

## Docs

No documentation edits.

## Verification

- Focused regression for the implicated service.
- Typecheck and lint on changed files.
- No deployment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99774c97-e3d7-41dc-ab59-8ca90bed7688?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99774c97-e3d7-41dc-ab59-8ca90bed7688&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved processing of high-volume meeting and topic-shift chains, preventing failures caused by excessive session depth.
  - Preserved session ordering, meeting details, and gap-bound behavior during block analysis.

- **Tests**
  - Added coverage for consecutive standalone meetings and large chains of up to 8,000 sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->