### PR TITLE
Rebuild unreliable Apps “What you did there” summaries

### DIFF
--- a/cli/cmdApps.ts
+++ b/cli/cmdApps.ts
@@ -28,25 +28,29 @@ export async function appsForDate(ctx: HarnessContext, date: string, opts: { jso
 
 export async function appDetail(ctx: HarnessContext, appId: string, dateOrDays: string, opts: { json: boolean }): Promise<void> {
   const { getAppDetailProjection } = await import('../src/main/core/query/projections')
+  const { resolveAppDetailAccount } = await import('../src/shared/appDetailAccount')
   const daysOrDate: number | string = /^\d+$/.test(dateOrDays) ? Number(dateOrDays) : dateOrDays
   const detail = getAppDetailProjection(ctx.db, appId, daysOrDate, null)
   emit(detail, opts.json, () => {
     console.log(c('bold', `${detail.displayName} · ${typeof daysOrDate === 'number' ? `last ${daysOrDate}d` : daysOrDate}`))
     console.log(c('dim', `total ${fmtDuration(detail.totalSeconds)} · ${detail.sessionCount} sessions`))
-    if (detail.topArtifacts.length > 0) {
-      console.log(c('bold', '\n  What happened inside:'))
+    const account = resolveAppDetailAccount(detail)
+    console.log(c('bold', '\n  What you did there'))
+    if (account) console.log(`  ${account}`)
+    const breakdown = detail.activityBreakdown
+    if (breakdown) {
+      for (const group of breakdown.groups.slice(0, 12)) {
+        console.log(`  ${fmtDuration(group.totalSeconds).padStart(7)}  ${group.label}`)
+        for (const item of group.items.slice(0, 4)) {
+          console.log(c('gray', `           ${fmtDuration(item.totalSeconds).padStart(7)}  ${item.displayTitle}`))
+        }
+      }
+      if (breakdown.unattributedSeconds > 0) {
+        console.log(c('gray', `  ${fmtDuration(breakdown.unattributedSeconds).padStart(7)}  (no page recorded)`))
+      }
+    } else if (detail.topArtifacts.length > 0) {
       for (const artifact of detail.topArtifacts.slice(0, 15)) {
         console.log(`  ${fmtDuration(artifact.totalSeconds).padStart(7)}  ${artifact.displayTitle}${artifact.subtitle ? c('gray', ` — ${artifact.subtitle}`) : ''}`)
-      }
-    }
-    const browser = detail.browserActivity
-    if (browser) {
-      console.log(c('bold', '\n  Browser time:'))
-      for (const domain of (browser.domains ?? []).slice(0, 12)) {
-        console.log(`  ${fmtDuration(domain.totalSeconds).padStart(7)}  ${domain.domain}`)
-      }
-      if (browser.unattributedSeconds > 0) {
-        console.log(c('gray', `  ${fmtDuration(browser.unattributedSeconds).padStart(7)}  (no page recorded)`))
       }
     }
   })

--- a/src/main/jobs/aiService.ts
+++ b/src/main/jobs/aiService.ts
@@ -37,7 +37,14 @@ import { userVisibleBlockLabel } from '@shared/blockLabel'
 import { labelCandidateViolation, labelProvenance, labelVoiceContextForBlock, rawLabelForm } from '@shared/labelVoice'
 import { activityCategoryLabel } from '@shared/activityCategories'
 import { effectiveBlockKind, partitionDomainsWorkFirst } from '@shared/workKind'
-import { appNarrativeScopeKey, THIN_APP_NARRATIVE_SUMMARY } from '@shared/appNarrativeContract'
+import { evidenceTitlesFromBreakdown } from '@shared/appDetailAccount'
+import {
+  appNarrativeScopeKey,
+  isThinAppNarrative,
+  parseSurfaceSummaryResult,
+  selectVisibleAppNarrative,
+  THIN_APP_NARRATIVE_SUMMARY,
+} from '@shared/appNarrativeContract'
 import { INTERPRETATION_DIRECTIVES } from '@shared/activityDescription'
 import { normalizeSummaryVoice, voiceDirective } from '@shared/summaryVoice'
 import { userProfileDirective } from '@shared/userProfile'
@@ -1313,29 +1320,6 @@ function localDateKeyForMs(ms: number): string {
 }
 
 
-function parseSurfaceSummaryResult(
-  raw: string,
-  fallbackTitle: string,
-): { title: string; summary: string } | null {
-  const normalized = escapeJsonBlock(raw)
-  if (!normalized) return null
-
-  try {
-    const parsed = JSON.parse(normalized) as { title?: unknown; summary?: unknown }
-    const summary = typeof parsed.summary === 'string' ? parsed.summary.trim() : ''
-    if (!summary) return null
-    return {
-      title: typeof parsed.title === 'string' && parsed.title.trim() ? parsed.title.trim() : fallbackTitle,
-      summary,
-    }
-  } catch {
-    return {
-      title: fallbackTitle,
-      summary: normalized,
-    }
-  }
-}
-
 function localDateBoundsFromString(dateStr: string): [number, number] {
   const [year, month, day] = dateStr.split('-').map(Number)
   const from = new Date(year, month - 1, day).getTime()
@@ -2339,7 +2323,7 @@ function buildWeekReviewBundle(weekStartStr: string): ReportContextBundle | null
   }
 }
 
-const APP_NARRATIVE_CACHE_VERSION = 3
+const APP_NARRATIVE_CACHE_VERSION = 4
 
 function appNarrativeHasStaleMetrics(summary: AISurfaceSummary | null): boolean {
   if (!summary) return false
@@ -2367,6 +2351,8 @@ function appNarrativeSignature(detail: ReturnType<typeof getAppDetailPayload>): 
     canonicalAppId: detail.canonicalAppId,
     rangeKey: detail.rangeKey,
     topArtifacts: detail.topArtifacts.slice(0, 8).map((artifact) => artifact.displayTitle),
+    topGroups: (detail.activityBreakdown?.groups ?? []).slice(0, 8).map((group) => group.label),
+    topItems: (detail.activityBreakdown?.groups ?? []).flatMap((group) => group.items).slice(0, 8).map((item) => item.displayTitle),
     topDomains: (detail.browserActivity?.domains ?? []).slice(0, 8).map((entry) => entry.domain),
     topPages: (detail.browserActivity?.domains ?? []).flatMap((entry) => entry.pages).slice(0, 8).map((page) => page.displayTitle),
     blockAppearances: detail.blockAppearances.slice(0, 8).map((block) => `${block.blockId}:${block.label}:${block.startTime}:${block.endTime}`),
@@ -2424,6 +2410,12 @@ function buildAppNarrativeBundle(
     (p) => p.domain,
   )
   const orderedPages = [...pageGroups.work, ...pageGroups.leisure]
+  const activityGroups = [...(detail.activityBreakdown?.groups ?? [])]
+    .sort((left, right) => right.totalSeconds - left.totalSeconds)
+  const activityItems = dedupeByTitle(
+    activityGroups.flatMap((group) => group.items).sort((left, right) => right.totalSeconds - left.totalSeconds),
+    (item) => item.displayTitle,
+  )
 
   // B3: collapse the 24-bucket per-hour distribution into the top whole-hour
   // ranges. The model previously confabulated sub-hour windows like
@@ -2449,6 +2441,8 @@ function buildAppNarrativeBundle(
   const packedArtifacts = take(dedupedArtifacts, evidenceCost)
   const packedDomains = take(orderedDomains, evidenceCost)
   const packedPages = take(orderedPages, evidenceCost)
+  const packedActivityGroups = take(activityGroups, evidenceCost)
+  const packedActivityItems = take(activityItems, evidenceCost)
   const packedBlockAppearances = take(detail.blockAppearances, evidenceCost)
 
   const isDate = typeof daysOrDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(daysOrDate)
@@ -2492,6 +2486,16 @@ function buildAppNarrativeBundle(
         title: page.displayTitle,
         domain: page.domain,
         duration: formatDuration(page.totalSeconds),
+      })),
+      activityGroups: packedActivityGroups.map((group) => ({
+        label: group.label,
+        kind: group.kind,
+        duration: formatDuration(group.totalSeconds),
+      })),
+      activityItems: packedActivityItems.map((item) => ({
+        title: item.displayTitle,
+        detail: item.detail,
+        duration: formatDuration(item.totalSeconds),
       })),
       blockAppearances: packedBlockAppearances.map((block) => ({
         label: block.label,
@@ -2803,8 +2807,8 @@ async function generateAppNarrative(
     USER_VISIBLE_ACTIVITY_PROSE_RULE,
     ...INTERPRETATION_DIRECTIVES,
     voiceDirective(voice),
-    'Explain what this tool was helping with and which artifacts, pages, or sites appeared there. Lead with the work (the domains and pages listed first); mention leisure only briefly if at all.',
-    'Use only the deterministic evidence below.',
+    'Explain what this tool was helping with and which artifacts, files, pages, or sites appeared there. Lead with the work (the activity groups and items listed first); mention leisure only briefly if at all.',
+    'Use only the deterministic evidence below. Native apps use activityGroups/activityItems the same way browsers use domains and pages — treat both as first-class evidence.',
     'Do not write vanity metrics or generic app summaries.',
     // Citation floor: the summary must name at least two concrete entities
     // from the structured evidence (block labels, artifacts, pages, domains).
@@ -2853,6 +2857,15 @@ async function generateAppNarrative(
     const parsed = parseSurfaceSummaryResult(text, bundle.title)
     if (!parsed) {
       console.warn(`[ai] app_narrative parse-failed for ${scopeKey}; falling back`)
+      return fallback
+    }
+    const evidenceTitles = [
+      ...evidenceTitlesFromBreakdown(detail.activityBreakdown),
+      ...detail.topArtifacts.map((artifact) => artifact.displayTitle),
+      ...detail.blockAppearances.map((block) => block.label),
+    ]
+    if (!isThinAppNarrative(parsed.summary) && !selectVisibleAppNarrative(parsed.summary, evidenceTitles)) {
+      console.warn(`[ai] app_narrative rejected ungrounded or structured dump for ${scopeKey}`)
       return fallback
     }
     const stored = upsertAISurfaceSummary(getDb(), {

--- a/src/main/services/appDetail.ts
+++ b/src/main/services/appDetail.ts
@@ -1,6 +1,9 @@
 import type Database from 'better-sqlite3'
 import crypto from 'node:crypto'
 import type {
+  AppActivityBreakdown,
+  AppActivityGroup,
+  AppActivityItem,
   AppCategory,
   AppDetailPayload,
   AppSession,
@@ -9,6 +12,7 @@ import type {
   PageRef,
 } from '@shared/types'
 import { MIN_DOMAIN_ROW_SECONDS } from '@shared/types'
+import { extractDisplayProse } from '@shared/appDetailAccount'
 import { appDetailRangeKey } from '@shared/appNarrativeContract'
 import {
   getBrowserActivityBreakdown,
@@ -58,9 +62,12 @@ function labelForSessionCluster(sessions: AppSession[]): string {
   const lead = sessions.reduce((best, current) => (
     current.durationSeconds > best.durationSeconds ? current : best
   ))
-  const titled = usefulWindowTitle(lead)
-  if (titled) return compactWindowTitle(titled)
   const identity = resolveCanonicalApp(lead.bundleId, lead.appName)
+  const titled = usefulWindowTitle(lead)
+  if (titled) {
+    const prose = extractDisplayProse(compactWindowTitle(titled), identity.displayName)
+    if (prose) return prose
+  }
   return sanitizeBlockLabel(identity.displayName)
     ?? sanitizeBlockLabel(lead.appName)
     ?? prettyCategory(lead.category)
@@ -68,10 +75,6 @@ function labelForSessionCluster(sessions: AppSession[]): string {
 
 function normalizedAppActivityLabel(value: string | null | undefined): string {
   return (value ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '')
-}
-
-function labelMatchesSelectedApp(label: string, displayName: string): boolean {
-  return normalizedAppActivityLabel(label) === normalizedAppActivityLabel(displayName)
 }
 
 function buildSessionDerivedAppDetailBlocksByDate(
@@ -144,6 +147,206 @@ export function foldTinyDomains<T extends { totalSeconds: number; visitCount: nu
       visitCount: folded.reduce((sum, domain) => sum + domain.visitCount, 0),
     },
   }
+}
+
+function folderGroupLabel(filePath: string): string {
+  const parts = filePath.replace(/\\/g, '/').split('/').filter(Boolean)
+  if (parts.length < 2) return parts[0] ?? 'Files'
+  return parts[parts.length - 2] ?? 'Files'
+}
+
+function collectionLabelForArtifact(artifactType: ArtifactRef['artifactType']): string {
+  if (artifactType === 'repo' || artifactType === 'project') return 'Projects'
+  if (artifactType === 'window') return 'Pages'
+  return 'Files'
+}
+
+function activityItemFromArtifact(
+  artifact: ArtifactRef,
+  displayTitle: string,
+  canonicalAppId: string,
+): AppActivityItem {
+  const page = artifact as PageRef
+  return {
+    id: artifact.id,
+    displayTitle,
+    detail: extractDisplayProse(artifact.subtitle ?? artifact.host ?? artifact.path ?? null, displayTitle),
+    totalSeconds: artifact.totalSeconds,
+    visitCount: page.visitCount,
+    artifactType: artifact.artifactType,
+    canonicalAppId: artifact.canonicalAppId ?? canonicalAppId,
+    ownerBundleId: artifact.ownerBundleId,
+    ownerAppName: artifact.ownerAppName,
+    url: artifact.url,
+    host: artifact.host,
+    path: artifact.path,
+    domain: page.domain ?? artifact.host ?? null,
+    normalizedUrl: page.normalizedUrl,
+    pageKey: page.pageKey,
+    openTarget: artifact.openTarget,
+  }
+}
+
+function groupActivityItems(
+  items: AppActivityItem[],
+  totalSeconds: number,
+): AppActivityBreakdown {
+  const groupsByKey = new Map<string, AppActivityGroup>()
+  const order: string[] = []
+  let attributedSeconds = 0
+
+  for (const item of items) {
+    if (item.totalSeconds <= 0) continue
+    const domain = item.domain ?? item.host ?? null
+    const group = domain
+      ? { id: `domain:${domain}`, label: domain, kind: 'domain' as const }
+      : item.path
+        ? { id: `folder:${folderGroupLabel(item.path)}`, label: folderGroupLabel(item.path), kind: 'folder' as const }
+        : {
+          id: `collection:${item.artifactType ?? 'document'}`,
+          label: collectionLabelForArtifact(item.artifactType ?? 'document'),
+          kind: 'collection' as const,
+        }
+    const existing = groupsByKey.get(group.id)
+    if (existing) {
+      existing.items.push(item)
+      existing.totalSeconds += item.totalSeconds
+      existing.itemCount += 1
+      existing.visitCount = (existing.visitCount ?? 0) + (item.visitCount ?? 1)
+    } else {
+      groupsByKey.set(group.id, {
+        ...group,
+        totalSeconds: item.totalSeconds,
+        itemCount: 1,
+        visitCount: item.visitCount ?? 1,
+        items: [item],
+      })
+      order.push(group.id)
+    }
+    attributedSeconds += item.totalSeconds
+  }
+
+  const rawGroups = order.map((key) => {
+    const group = groupsByKey.get(key)!
+    group.items.sort((left, right) => right.totalSeconds - left.totalSeconds)
+    return group
+  }).sort((left, right) => right.totalSeconds - left.totalSeconds)
+
+  const { rows, everythingElse } = foldTinyDomains(rawGroups.map((group) => ({
+    ...group,
+    visitCount: group.visitCount ?? group.itemCount,
+  })))
+  const foldedSeconds = everythingElse?.totalSeconds ?? 0
+  const visibleAttributed = attributedSeconds - foldedSeconds
+
+  return {
+    totalSeconds,
+    attributedSeconds: visibleAttributed + foldedSeconds,
+    unattributedSeconds: Math.max(0, totalSeconds - attributedSeconds),
+    groups: rows,
+    ...(everythingElse
+      ? {
+        everythingElse: {
+          totalSeconds: everythingElse.totalSeconds,
+          groupCount: everythingElse.domainCount,
+          itemCount: everythingElse.visitCount,
+        },
+      }
+      : {}),
+  }
+}
+
+function activityBreakdownFromBrowser(
+  activity: NonNullable<AppDetailPayload['browserActivity']>,
+  displayName: string,
+): AppActivityBreakdown {
+  const groups: AppActivityGroup[] = []
+  let droppedSeconds = 0
+  for (const domain of activity.domains) {
+    const items: AppActivityItem[] = []
+    let keptSeconds = 0
+    for (const page of domain.pages) {
+      const title = extractDisplayProse(page.displayTitle, displayName)
+      if (!title) {
+        droppedSeconds += page.totalSeconds
+        continue
+      }
+      items.push(activityItemFromArtifact({ ...page, displayTitle: title }, title, page.canonicalAppId ?? ''))
+      keptSeconds += page.totalSeconds
+    }
+    const domainLabel = extractDisplayProse(domain.domain) ?? domain.domain
+    if (keptSeconds <= 0 && items.length === 0) {
+      droppedSeconds += domain.totalSeconds
+      continue
+    }
+    groups.push({
+      id: `domain:${domain.domain}`,
+      label: domainLabel,
+      kind: 'domain',
+      totalSeconds: keptSeconds,
+      itemCount: items.length,
+      visitCount: domain.visitCount,
+      items,
+    })
+  }
+  return {
+    totalSeconds: activity.totalSeconds,
+    attributedSeconds: Math.max(0, activity.attributedSeconds - droppedSeconds),
+    unattributedSeconds: activity.unattributedSeconds + droppedSeconds,
+    groups,
+    ...(activity.everythingElse
+      ? {
+        everythingElse: {
+          totalSeconds: activity.everythingElse.totalSeconds,
+          groupCount: activity.everythingElse.domainCount,
+          itemCount: activity.everythingElse.visitCount,
+        },
+      }
+      : {}),
+  }
+}
+
+function collectNativeActivityItems(
+  artifacts: ArtifactRef[],
+  sessions: AppSession[],
+  displayName: string,
+  canonicalAppId: string,
+): AppActivityItem[] {
+  const items: AppActivityItem[] = []
+  const seenTitles = new Set<string>()
+  for (const artifact of artifacts) {
+    const title = extractDisplayProse(artifact.displayTitle, displayName)
+    if (!title) continue
+    const key = title.toLowerCase()
+    if (seenTitles.has(key)) continue
+    seenTitles.add(key)
+    items.push(activityItemFromArtifact({ ...artifact, displayTitle: title }, title, canonicalAppId))
+  }
+  const titleSeconds = new Map<string, { title: string; seconds: number }>()
+  for (const session of sessions) {
+    const raw = usefulWindowTitle(session) ?? session.windowTitle
+    const title = raw ? extractDisplayProse(compactWindowTitle(raw), displayName) : null
+    if (!title) continue
+    const key = title.toLowerCase()
+    if (seenTitles.has(key)) continue
+    const current = titleSeconds.get(key)
+    if (current) current.seconds += session.durationSeconds
+    else titleSeconds.set(key, { title, seconds: session.durationSeconds })
+  }
+  for (const { title, seconds } of titleSeconds.values()) {
+    if (seconds <= 0) continue
+    items.push({
+      id: `window:${normalizedAppActivityLabel(title)}`,
+      displayTitle: title,
+      detail: null,
+      totalSeconds: seconds,
+      visitCount: 1,
+      artifactType: 'window',
+      canonicalAppId,
+      openTarget: { kind: 'unsupported', value: null },
+    })
+  }
+  return items
 }
 
 /** Builds the Apps projection. Timeline formation remains in workBlocks; this
@@ -227,7 +430,7 @@ export function getAppDetailPayload(
       else artifactTotals.set(artifact.id, { ...artifact })
     }
   }
-  const topArtifacts = Array.from(artifactTotals.values()).sort((a, b) => b.totalSeconds - a.totalSeconds).slice(0, 8)
+  const ownedArtifacts = Array.from(artifactTotals.values()).sort((a, b) => b.totalSeconds - a.totalSeconds)
 
   const timeOfDayDistribution = Array.from({ length: 24 }, (_, hour) => ({ hour, totalSeconds: 0 }))
   for (const session of sessions) timeOfDayDistribution[new Date(session.startTime).getHours()].totalSeconds += session.durationSeconds
@@ -236,6 +439,13 @@ export function getAppDetailPayload(
   const displayName = sampleSession
     ? resolveCanonicalApp(sampleSession.bundleId, sampleSession.appName).displayName
     : resolveCanonicalApp(canonicalAppId, canonicalAppId).displayName
+  const topArtifacts = ownedArtifacts
+    .map((artifact) => {
+      const displayTitle = extractDisplayProse(artifact.displayTitle, displayName)
+      return displayTitle ? { ...artifact, displayTitle } : null
+    })
+    .filter((artifact): artifact is ArtifactRef => artifact !== null)
+    .slice(0, 8)
   // Appearances come from the same corrected block facts the Timeline shows
   // (invariant 7 / apps.md invariant 13): persisted blocks carry the user's
   // renames and category corrections, and a deleted block never appears. The
@@ -243,14 +453,17 @@ export function getAppDetailPayload(
   // yet (today/live) — the fallback already applied in blocksByDate above.
   const rawAppearances = [...relatedBlocks]
     .sort((a, b) => b.startTime - a.startTime)
-    .map((block) => ({
-      blockId: block.id,
-      startTime: block.startTime,
-      endTime: block.endTime,
-      label: sanitizeBlockLabel(block.label.current) ?? prettyCategory(block.dominantCategory),
-      dominantCategory: block.dominantCategory,
-    }))
-    .filter((block) => !labelMatchesSelectedApp(block.label, displayName))
+    .flatMap((block) => {
+      const label = extractDisplayProse(sanitizeBlockLabel(block.label.current), displayName)
+      if (!label) return []
+      return [{
+        blockId: block.id,
+        startTime: block.startTime,
+        endTime: block.endTime,
+        label,
+        dominantCategory: block.dominantCategory,
+      }]
+    })
   const mergedByLabel = new Map<string, typeof rawAppearances[number]>()
   for (const appearance of rawAppearances) {
     const key = appearance.label.toLowerCase()
@@ -263,7 +476,12 @@ export function getAppDetailPayload(
     }
   }
   const blockAppearances = Array.from(mergedByLabel.values()).sort((a, b) => b.startTime - a.startTime).slice(0, 12)
-  const blockMemoryRollups = memoryRollupsForBlocks(db, blockAppearances)
+  const blockMemoryRollups = (memoryRollupsForBlocks(db, blockAppearances) ?? [])
+    .map((row) => ({
+      ...row,
+      patternLabel: extractDisplayProse(row.patternLabel, displayName) ?? row.patternLabel,
+    }))
+    .filter((row) => Boolean(extractDisplayProse(row.patternLabel, displayName)))
 
   // Aggregate the sessions already fetched above — allSessions is exactly
   // what getCorrectedAppSummariesForRange would re-derive, and re-running the
@@ -292,7 +510,10 @@ export function getAppDetailPayload(
         totalSeconds: domain.totalSeconds,
         visitCount: domain.visitCount,
         pages: domain.pages.map((page) => {
-          const normalizedTitle = normalizeWebsiteTitleForDisplay(page.domain, page.title)
+          const normalizedTitle = extractDisplayProse(
+            normalizeWebsiteTitleForDisplay(page.domain, page.title),
+            displayName,
+          )
           const displayTitle = normalizedTitle ?? websiteDisplayLabel(page.domain)
           const canonicalKey = page.normalizedUrl ?? page.pageKey ?? page.url ?? `domain:${page.domain}`
           return {
@@ -321,6 +542,24 @@ export function getAppDetailPayload(
     }
   }
 
+  let activityBreakdown: AppActivityBreakdown | undefined
+  if (browserActivity) {
+    activityBreakdown = activityBreakdownFromBrowser(browserActivity, displayName)
+  } else if (totalSeconds > 0) {
+    activityBreakdown = groupActivityItems(
+      collectNativeActivityItems(ownedArtifacts, sessions, displayName, canonicalAppId),
+      totalSeconds,
+    )
+  }
+  if (!activityBreakdown && totalSeconds > 0) {
+    activityBreakdown = {
+      totalSeconds,
+      attributedSeconds: 0,
+      unattributedSeconds: totalSeconds,
+      groups: [],
+    }
+  }
+
   return {
     canonicalAppId,
     displayName,
@@ -328,6 +567,7 @@ export function getAppDetailPayload(
     sessionCount,
     topArtifacts,
     browserActivity,
+    activityBreakdown,
     blockAppearances,
     blockMemoryRollups,
     timeOfDayDistribution,

--- a/src/renderer/views/Apps.tsx
+++ b/src/renderer/views/Apps.tsx
@@ -3,7 +3,8 @@ import { ANALYTICS_EVENT, trackedTimeBucket } from '@shared/analytics'
 import { activityCategoryLabel } from '@shared/activityCategories'
 import { ALL_TIME_DAYS } from '@shared/types'
 import type { AISurfaceSummary, AppCategory, AppDetailPayload, AppUsageSummary } from '@shared/types'
-import { appDetailRangeKey, appNarrativeScopeKey, isThinAppNarrative } from '@shared/appNarrativeContract'
+import { evidenceTitlesFromBreakdown } from '@shared/appDetailAccount'
+import { appDetailRangeKey, appNarrativeScopeKey, isThinAppNarrative, selectVisibleAppNarrative } from '@shared/appNarrativeContract'
 import PeriodNavigator from '../components/PeriodNavigator'
 import { useCompactLayout } from '../hooks/useCompactLayout'
 import { useProjectionResource } from '../hooks/useProjectionResource'
@@ -114,7 +115,17 @@ export default function Apps() {
     && narrativeResource.data.scopeKey === expectedNarrativeScopeKey
     ? narrativeResource.data
     : null
-  const narrative = rawNarrative && !isThinAppNarrative(rawNarrative.summary) ? rawNarrative : null
+  const evidenceTitles = [
+    ...evidenceTitlesFromBreakdown(detail?.activityBreakdown),
+    ...(detail?.topArtifacts ?? []).map((artifact) => artifact.displayTitle),
+    ...(detail?.blockAppearances ?? []).map((block) => block.label),
+  ]
+  const visibleNarrativeSummary = rawNarrative
+    ? selectVisibleAppNarrative(rawNarrative.summary, evidenceTitles)
+    : null
+  const narrative = rawNarrative && visibleNarrativeSummary
+    ? { ...rawNarrative, summary: visibleNarrativeSummary }
+    : null
 
   const [activeGenerationScopes, setActiveGenerationScopes] = useState<Set<string>>(() => new Set())
   const [lastGenerationStatus, setLastGenerationStatus] = useState<Record<string, GenerationStatus>>({})
@@ -142,6 +153,7 @@ export default function Apps() {
       const status: GenerationStatus = !result
         ? { kind: 'no-bundle' }
         : isThinAppNarrative(result.summary)
+          || (evidenceTitles.length > 0 && !selectVisibleAppNarrative(result.summary, evidenceTitles))
           ? { kind: 'thin' }
           : { kind: 'ok' }
       setLastGenerationStatus((previous) => ({ ...previous, [scopeKey]: status }))

--- a/src/renderer/views/apps/ActivityBreakdown.tsx
+++ b/src/renderer/views/apps/ActivityBreakdown.tsx
@@ -1,0 +1,256 @@
+import { useMemo, useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import type { AppActivityBreakdown, AppActivityGroup, AppActivityItem } from '@shared/types'
+import { MIN_DOMAIN_ROW_SECONDS } from '@shared/types'
+import { partitionDomainsWorkFirst } from '@shared/workKind'
+import EntityIcon from '../../components/EntityIcon'
+import EvidenceIdentity from '../../components/EvidenceIdentity'
+import InlineRevealText from '../../components/InlineRevealText'
+import { formatDuration } from '../../lib/format'
+import { openArtifact } from '../../lib/openTarget'
+import type { WebsiteActivityTarget } from './BrowserActivityBreakdown'
+
+const PAGE_WINDOW = 40
+
+function DeleteIconButton({ label, busy, onClick }: { label: string; busy: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={busy}
+      onClick={onClick}
+      style={{
+        width: 30,
+        height: 30,
+        borderRadius: 8,
+        border: '1px solid rgba(248, 113, 113, 0.28)',
+        background: busy ? 'rgba(248, 113, 113, 0.12)' : 'transparent',
+        color: '#ef4444',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: busy ? 'default' : 'pointer',
+        opacity: busy ? 0.55 : 0.82,
+        flexShrink: 0,
+      }}
+    >
+      <Trash2 size={14} strokeWidth={1.9} aria-hidden="true" />
+    </button>
+  )
+}
+
+function itemDeleteTarget(item: AppActivityItem): WebsiteActivityTarget | null {
+  const domain = item.domain ?? item.host
+  if (!domain) return null
+  return {
+    domain,
+    url: item.url,
+    normalizedUrl: item.normalizedUrl,
+    pageKey: item.pageKey,
+    title: item.displayTitle,
+  }
+}
+
+function groupDeleteTarget(group: AppActivityGroup): WebsiteActivityTarget | null {
+  if (group.kind !== 'domain') return null
+  return { domain: group.label, title: group.label }
+}
+
+export default function ActivityBreakdown({
+  activity,
+  deletingActivityKey,
+  onDelete,
+}: {
+  activity: AppActivityBreakdown
+  deletingActivityKey: string | null
+  onDelete: (target: WebsiteActivityTarget) => void
+}) {
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set())
+  const [pageLimits, setPageLimits] = useState<Record<string, number>>({})
+  const groupSplit = useMemo(
+    () => partitionDomainsWorkFirst(activity.groups, (entry) => (
+      entry.kind === 'domain' ? entry.label : null
+    ), (entry) => entry.totalSeconds),
+    [activity.groups],
+  )
+
+  const toggleGroup = (id: string) => {
+    setExpandedGroups((previous) => {
+      const next = new Set(previous)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const renderItemRow = (item: AppActivityItem) => {
+    const deleteTarget = itemDeleteTarget(item)
+    return (
+      <div key={item.id} style={{ display: 'flex', alignItems: 'start', gap: 10, width: '100%' }}>
+        <button
+          type="button"
+          onClick={() => void openArtifact(item)}
+          disabled={item.openTarget.kind === 'unsupported' || !item.openTarget.value}
+          style={{
+            display: 'flex',
+            alignItems: 'start',
+            gap: 10,
+            flex: 1,
+            minWidth: 0,
+            padding: 0,
+            border: 'none',
+            background: 'transparent',
+            textAlign: 'left',
+            cursor: item.openTarget.kind === 'unsupported' || !item.openTarget.value ? 'default' : 'pointer',
+          }}
+        >
+          <EvidenceIdentity
+            icon={(
+              <EntityIcon
+                artifactType={item.artifactType ?? 'document'}
+                canonicalAppId={item.canonicalAppId}
+                ownerBundleId={item.ownerBundleId}
+                ownerAppName={item.ownerAppName}
+                title={item.displayTitle}
+                path={item.path}
+                domain={item.domain ?? item.host}
+                url={item.url}
+                size={28}
+              />
+            )}
+            title={item.displayTitle}
+            titleStyle={{ fontSize: 13.5, fontWeight: 620 }}
+            detail={<>
+              {item.detail && (
+                <InlineRevealText text={item.detail} style={{ fontSize: 11.5, color: 'var(--color-text-tertiary)' }} />
+              )}
+              {item.visitCount != null && (
+                <div style={{ fontSize: 11.5, color: 'var(--color-text-tertiary)', marginTop: 2 }}>
+                  {item.visitCount} visit{item.visitCount === 1 ? '' : 's'}
+                </div>
+              )}
+            </>}
+          />
+        </button>
+        <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>
+          {formatDuration(item.totalSeconds)}
+        </div>
+        {deleteTarget && (
+          <DeleteIconButton
+            label={`Delete activity for ${item.displayTitle}`}
+            busy={deletingActivityKey === (
+              item.url || item.normalizedUrl || item.pageKey
+                ? `url:${item.normalizedUrl ?? item.url ?? item.pageKey}`
+                : `domain:${deleteTarget.domain}`
+            )}
+            onClick={() => onDelete(deleteTarget)}
+          />
+        )}
+      </div>
+    )
+  }
+
+  const renderGroup = (entry: AppActivityGroup) => {
+    const expanded = expandedGroups.has(entry.id)
+    const deleteTarget = groupDeleteTarget(entry)
+    return (
+      <div key={entry.id}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <button
+            type="button"
+            onClick={() => toggleGroup(entry.id)}
+            aria-expanded={expanded}
+            style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1, minWidth: 0, padding: 0, border: 'none', background: 'transparent', textAlign: 'left', cursor: 'pointer' }}
+          >
+            <span aria-hidden="true" style={{ display: 'inline-flex', width: 10, justifyContent: 'center', color: 'var(--color-text-tertiary)', fontSize: 9, transform: expanded ? 'rotate(90deg)' : 'none', transition: 'transform 120ms ease' }}>
+              ▶
+            </span>
+            <EntityIcon artifactType={entry.kind === 'domain' ? 'page' : 'document'} domain={entry.kind === 'domain' ? entry.label : undefined} size={26} />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <InlineRevealText text={entry.label} style={{ fontSize: 13, fontWeight: 620, color: 'var(--color-text-primary)' }} />
+              <div style={{ fontSize: 11.5, color: 'var(--color-text-tertiary)', marginTop: 2 }}>
+                {entry.visitCount != null
+                  ? `${entry.visitCount} visit${entry.visitCount === 1 ? '' : 's'} · ${entry.itemCount} page${entry.itemCount === 1 ? '' : 's'}`
+                  : `${entry.itemCount} item${entry.itemCount === 1 ? '' : 's'}`}
+              </div>
+            </div>
+          </button>
+          <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>
+            {formatDuration(entry.totalSeconds)}
+          </div>
+          {deleteTarget && (
+            <DeleteIconButton
+              label={`Delete activity for ${entry.label}`}
+              busy={deletingActivityKey === `domain:${deleteTarget.domain}`}
+              onClick={() => onDelete(deleteTarget)}
+            />
+          )}
+        </div>
+        {expanded && entry.items.length > 0 && (
+          <div style={{ display: 'grid', gap: 12, margin: '10px 0 4px', paddingLeft: 20, borderLeft: '2px solid var(--color-border-ghost)', marginLeft: 4 }}>
+            {entry.items.slice(0, pageLimits[entry.id] ?? PAGE_WINDOW).map(renderItemRow)}
+            {entry.items.length > (pageLimits[entry.id] ?? PAGE_WINDOW) && (
+              <button
+                type="button"
+                onClick={() => setPageLimits((limits) => ({
+                  ...limits,
+                  [entry.id]: (limits[entry.id] ?? PAGE_WINDOW) + PAGE_WINDOW,
+                }))}
+                style={{ justifySelf: 'start', padding: '4px 10px', borderRadius: 8, border: '1px solid var(--color-border-ghost)', background: 'transparent', color: 'var(--color-text-secondary)', fontSize: 12, cursor: 'pointer' }}
+              >
+                Show {Math.min(PAGE_WINDOW, entry.items.length - (pageLimits[entry.id] ?? PAGE_WINDOW))} more of {entry.items.length} pages
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const everythingElse = activity.everythingElse
+
+  if (groupSplit.work.length === 0 && groupSplit.leisure.length === 0
+    && !everythingElse && activity.unattributedSeconds <= 0) return null
+
+  return (
+    <div style={{ display: 'grid', gap: 10 }}>
+      <div style={{ display: 'grid', gap: 10 }}>{groupSplit.work.map(renderGroup)}</div>
+      {groupSplit.leisure.length > 0 && (
+        <>
+          {groupSplit.work.length > 0 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, margin: '4px 0', color: 'var(--color-text-tertiary)' }}>
+              <div style={{ flex: 1, height: 1, background: 'var(--color-border-ghost)' }} />
+              <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase' }}>Off to the side</span>
+              <div style={{ flex: 1, height: 1, background: 'var(--color-border-ghost)' }} />
+            </div>
+          )}
+          <div style={{ display: 'grid', gap: 10 }}>{groupSplit.leisure.map(renderGroup)}</div>
+        </>
+      )}
+      {everythingElse && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: (groupSplit.work.length > 0 || groupSplit.leisure.length > 0) ? 2 : 0 }}>
+          <span aria-hidden="true" style={{ width: 10 }} />
+          <span aria-hidden="true" style={{ width: 26, height: 26, borderRadius: 7, background: 'var(--color-surface-high)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, color: 'var(--color-text-tertiary)', flexShrink: 0 }}>+</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 620, color: 'var(--color-text-secondary)' }}>Everything else</div>
+            <div style={{ fontSize: 11.5, color: 'var(--color-text-tertiary)', marginTop: 2 }}>
+              {everythingElse.groupCount} group{everythingElse.groupCount === 1 ? '' : 's'} under {MIN_DOMAIN_ROW_SECONDS} seconds each
+            </div>
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>
+            {formatDuration(everythingElse.totalSeconds)}
+          </div>
+        </div>
+      )}
+      {activity.unattributedSeconds > 0 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: (groupSplit.work.length > 0 || groupSplit.leisure.length > 0) ? 2 : 0, opacity: 0.75 }}>
+          <span aria-hidden="true" style={{ width: 10 }} />
+          <span aria-hidden="true" style={{ width: 26, height: 26, borderRadius: 7, background: 'var(--color-surface-high)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, color: 'var(--color-text-tertiary)', flexShrink: 0 }}>—</span>
+          <div style={{ flex: 1, minWidth: 0, fontSize: 13, color: 'var(--color-text-tertiary)' }}>No page recorded</div>
+          <div style={{ fontSize: 12, color: 'var(--color-text-tertiary)', whiteSpace: 'nowrap' }}>{formatDuration(activity.unattributedSeconds)}</div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/views/apps/AppDetail.tsx
+++ b/src/renderer/views/apps/AppDetail.tsx
@@ -1,4 +1,6 @@
 import type { AISurfaceSummary, AppDetailPayload, AppUsageSummary } from '@shared/types'
+import { activityBreakdownHasRows, evidenceTitlesFromBreakdown, resolveAppDetailAccount } from '@shared/appDetailAccount'
+import { selectVisibleAppNarrative } from '@shared/appNarrativeContract'
 import { activityCategoryLabel } from '@shared/activityCategories'
 import { activityColorForCategory } from '@shared/activityColors'
 import ActivityListCard from '../../components/ActivityListCard'
@@ -6,8 +8,8 @@ import EntityIcon from '../../components/EntityIcon'
 import InlineRevealText from '../../components/InlineRevealText'
 import { formatDisplayAppName } from '../../lib/apps'
 import { formatDuration, localDateStringFromMs } from '../../lib/format'
-import { openArtifact } from '../../lib/openTarget'
-import BrowserActivityBreakdown, { type WebsiteActivityTarget } from './BrowserActivityBreakdown'
+import ActivityBreakdown from './ActivityBreakdown'
+import type { WebsiteActivityTarget } from './BrowserActivityBreakdown'
 
 export type GenerationStatus =
   | { kind: 'ok' }
@@ -60,10 +62,18 @@ export default function AppDetail({
     )
   }
 
-  const filteredAppearances = detail?.blockAppearances ?? []
-  const fileArtifacts = detail?.topArtifacts.filter((artifact) => artifact.artifactType !== 'page') ?? []
-  const rollups = detail?.blockMemoryRollups ?? []
-  const useRollup = rollups.some((row) => row.patternId && row.sessionCount >= 2)
+  const evidenceTitles = [
+    ...evidenceTitlesFromBreakdown(detail?.activityBreakdown),
+    ...(detail?.topArtifacts ?? []).map((artifact) => artifact.displayTitle),
+    ...(detail?.blockAppearances ?? []).map((block) => block.label),
+  ]
+  const generatedAccount = selectVisibleAppNarrative(narrative?.summary, evidenceTitles)
+  const account = detail
+    ? resolveAppDetailAccount(detail, generatedAccount)
+    : null
+  const breakdown = detail?.activityBreakdown
+  const showWhatYouDid = Boolean(account) || activityBreakdownHasRows(breakdown) || (detail != null && detail.totalSeconds > 0)
+  const relatedBlocks = (detail?.blockAppearances ?? []).filter((block) => block.label.trim().length > 0)
 
   return (
     <div style={{ display: 'grid', gap: 18 }}>
@@ -106,11 +116,10 @@ export default function AppDetail({
         </div>
         <p style={{ fontSize: 13.5, lineHeight: 1.7, color: 'var(--color-text-secondary)', margin: '14px 0 0' }}>
           {appMetricSentence(summary.totalSeconds, summary.sessionCount)}
-          {narrative?.summary ? ` ${narrative.summary}` : ''}
         </p>
         {!narrative && !isGenerating && !generationStatus && (
           <p style={{ fontSize: 11.5, lineHeight: 1.6, color: 'var(--color-text-tertiary)', margin: '8px 0 0' }}>
-            The sites and pages below are computed from your activity. Press Generate for a written recap.
+            The sites, files, and pages below are computed from your activity. Press Generate for a written recap when the evidence can support one.
           </p>
         )}
         {narrativeError && !isGenerating && (
@@ -123,7 +132,7 @@ export default function AppDetail({
           <div aria-live="polite" style={{ fontSize: 11.5, color: 'var(--color-text-tertiary)', marginTop: 10 }}>Generating a stronger app narrative…</div>
         )}
         {!isGenerating && generationStatus?.kind === 'thin' && (
-          <div style={{ fontSize: 11.5, color: 'var(--color-text-tertiary)', marginTop: 10 }}>Daylens has only thin signal for this app right now — try again after more activity.</div>
+          <div style={{ fontSize: 11.5, color: 'var(--color-text-tertiary)', marginTop: 10 }}>Daylens has only thin signal for this app right now — the breakdown below is the accurate account.</div>
         )}
         {!isGenerating && generationStatus?.kind === 'no-bundle' && (
           <div style={{ fontSize: 11.5, color: 'var(--color-text-tertiary)', marginTop: 10 }}>No recent activity for this app in the selected range.</div>
@@ -150,77 +159,37 @@ export default function AppDetail({
         </div>
       )}
 
-      {detail && (
-        <>
-          {useRollup ? (
-            <ActivityListCard
-              title="What you did there"
-              rows={rollups.slice(0, 10).map((row) => ({
-                id: row.patternId ?? row.sampleBlockIds[0],
-                label: <>
-                  {row.patternLabel}
-                  {row.sessionCount > 1 && <span style={{ color: 'var(--color-text-tertiary)', fontWeight: 500 }}> × {row.sessionCount} sessions</span>}
-                </>,
-                detail: `${formatDuration(row.totalSeconds)}${row.sessionCount === 1 ? ` · ${formatBlockRange(row.earliestStart, row.latestEnd)}` : ''}`,
-                onClick: () => { window.location.hash = `#/timeline?view=day&date=${localDateStringFromMs(row.earliestStart)}` },
-              }))}
-            />
-          ) : (
-            <ActivityListCard
-              title="What you did there"
-              rows={filteredAppearances.slice(0, 10).map((block) => ({
-                id: block.blockId,
-                label: block.label,
-                detail: formatBlockRange(block.startTime, block.endTime),
-                onClick: () => { window.location.hash = `#/timeline?view=day&date=${localDateStringFromMs(block.startTime)}` },
-              }))}
-            />
+      {detail && showWhatYouDid && (
+        <section style={{ borderRadius: 18, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', padding: '18px 20px' }}>
+          <div style={{ fontSize: 10.5, fontWeight: 800, letterSpacing: '0.10em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 12 }}>
+            What you did there
+          </div>
+          {account && (
+            <p style={{ fontSize: 13.5, lineHeight: 1.7, color: 'var(--color-text-secondary)', margin: '0 0 14px' }}>
+              {account}
+            </p>
           )}
-
-          {fileArtifacts.length > 0 && (
-            <section style={{ borderRadius: 18, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', padding: '18px 20px' }}>
-              <div style={{ fontSize: 10.5, fontWeight: 800, letterSpacing: '0.10em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)', marginBottom: 12 }}>Files & documents</div>
-              <div style={{ display: 'grid', gap: 12 }}>
-                {fileArtifacts.slice(0, 8).map((artifact) => (
-                  <button
-                    key={artifact.id}
-                    type="button"
-                    onClick={() => void openArtifact(artifact)}
-                    disabled={artifact.openTarget.kind === 'unsupported' || !artifact.openTarget.value}
-                    style={{ display: 'flex', alignItems: 'start', gap: 10, width: '100%', padding: 0, border: 'none', background: 'transparent', textAlign: 'left', cursor: artifact.openTarget.kind === 'unsupported' || !artifact.openTarget.value ? 'default' : 'pointer' }}
-                  >
-                    <EntityIcon
-                      artifactType={artifact.artifactType}
-                      canonicalAppId={artifact.canonicalAppId}
-                      ownerBundleId={artifact.ownerBundleId}
-                      ownerAppName={artifact.ownerAppName}
-                      ownerAppInstanceId={artifact.ownerAppInstanceId}
-                      title={artifact.displayTitle}
-                      path={artifact.path}
-                      domain={artifact.host}
-                      url={artifact.url}
-                      size={28}
-                    />
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <InlineRevealText text={artifact.displayTitle} style={{ fontSize: 13.5, fontWeight: 620, color: 'var(--color-text-primary)' }} />
-                      <InlineRevealText text={artifact.subtitle || artifact.host || artifact.path || artifact.artifactType} style={{ fontSize: 11.5, color: 'var(--color-text-tertiary)' }} />
-                    </div>
-                    <div style={{ fontSize: 12, color: 'var(--color-text-secondary)', whiteSpace: 'nowrap' }}>{formatDuration(artifact.totalSeconds)}</div>
-                  </button>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {detail.browserActivity && (
-            <BrowserActivityBreakdown
+          {breakdown && (
+            <ActivityBreakdown
               key={`${detail.canonicalAppId}:${detail.rangeKey}`}
-              activity={detail.browserActivity}
+              activity={breakdown}
               deletingActivityKey={deletingActivityKey}
               onDelete={onDeleteWebsiteActivity}
             />
           )}
-        </>
+        </section>
+      )}
+
+      {detail && relatedBlocks.length > 0 && (
+        <ActivityListCard
+          title="Related timeline"
+          rows={relatedBlocks.slice(0, 10).map((block) => ({
+            id: block.blockId,
+            label: block.label,
+            detail: formatBlockRange(block.startTime, block.endTime),
+            onClick: () => { window.location.hash = `#/timeline?view=day&date=${localDateStringFromMs(block.startTime)}` },
+          }))}
+        />
       )}
     </div>
   )

--- a/src/shared/appDetailAccount.ts
+++ b/src/shared/appDetailAccount.ts
@@ -1,0 +1,166 @@
+import { labelIsCategoryFloor } from './blockLabel'
+import type { AppActivityBreakdown, AppDetailPayload } from './types'
+
+const STRUCTURED_TITLE_KEYS = ['title', 'pageTitle', 'displayTitle', 'name', 'label', 'summary', 'text'] as const
+
+export function looksLikeStructuredDump(value: string | null | undefined): boolean {
+  const trimmed = value?.trim()
+  if (!trimmed) return false
+  if (trimmed === '[object Object]') return true
+  if (/^[{[]/.test(trimmed) && /[}\]]$/.test(trimmed)) return true
+  if (/"\w+"\s*:/.test(trimmed) && /[{[]/.test(trimmed)) return true
+  return false
+}
+
+function proseFromUnknown(value: unknown, depth: number): string | null {
+  if (depth > 3) return null
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    if (looksLikeStructuredDump(trimmed)) {
+      try {
+        return proseFromUnknown(JSON.parse(trimmed) as unknown, depth + 1)
+      } catch {
+        return null
+      }
+    }
+    return trimmed
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = proseFromUnknown(item, depth + 1)
+      if (found) return found
+    }
+    return null
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    for (const key of STRUCTURED_TITLE_KEYS) {
+      if (key in record) {
+        const found = proseFromUnknown(record[key], depth + 1)
+        if (found) return found
+      }
+    }
+  }
+  return null
+}
+
+function extractFromStructured(raw: string): string | null {
+  try {
+    return proseFromUnknown(JSON.parse(raw) as unknown, 0)
+  } catch {
+    const field = raw.match(/"(?:title|pageTitle|displayTitle|name|label|summary)"\s*:\s*"((?:[^"\\]|\\.)*)"/)
+    if (!field) return null
+    try {
+      const value = (JSON.parse(`"${field[1]}"`) as string).trim()
+      return value && !looksLikeStructuredDump(value) ? value : null
+    } catch {
+      return null
+    }
+  }
+}
+
+function normalizedLabel(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '')
+}
+
+export function extractDisplayProse(value: string | null | undefined, appName?: string): string | null {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const candidate = looksLikeStructuredDump(trimmed) ? extractFromStructured(trimmed) : trimmed
+  if (!candidate) return null
+  const cleaned = candidate.replace(/\s+/g, ' ').trim()
+  if (!cleaned || looksLikeStructuredDump(cleaned) || /^[{[]/.test(cleaned)) return null
+  if (!/[A-Za-z]/.test(cleaned)) return null
+  if (appName && normalizedLabel(cleaned) === normalizedLabel(appName)) return null
+  if (labelIsCategoryFloor(cleaned)) return null
+  return cleaned
+}
+
+export function evidenceTitlesFromBreakdown(breakdown: AppActivityBreakdown | undefined): string[] {
+  if (!breakdown) return []
+  const titles: string[] = []
+  const seen = new Set<string>()
+  const add = (value: string | null | undefined) => {
+    const prose = extractDisplayProse(value)
+    if (!prose) return
+    const key = prose.toLowerCase()
+    if (seen.has(key)) return
+    seen.add(key)
+    titles.push(prose)
+  }
+  for (const group of breakdown.groups) {
+    add(group.label)
+    for (const item of group.items) add(item.displayTitle)
+  }
+  return titles
+}
+
+export function subjectsFromAppDetail(
+  detail: Pick<AppDetailPayload, 'activityBreakdown' | 'blockAppearances' | 'displayName'>,
+): string[] {
+  const subjects: string[] = []
+  const seen = new Set<string>()
+  const add = (value: string | null | undefined) => {
+    const prose = extractDisplayProse(value, detail.displayName)
+    if (!prose) return
+    const key = prose.toLowerCase()
+    if (seen.has(key)) return
+    seen.add(key)
+    subjects.push(prose)
+  }
+
+  const groups = [...(detail.activityBreakdown?.groups ?? [])]
+    .sort((left, right) => right.totalSeconds - left.totalSeconds)
+  const items = groups
+    .flatMap((group) => group.items)
+    .sort((left, right) => right.totalSeconds - left.totalSeconds)
+  for (const item of items) add(item.displayTitle)
+  if (subjects.length === 0) {
+    for (const group of groups) add(group.label)
+  }
+  if (subjects.length === 0) {
+    for (const block of detail.blockAppearances) add(block.label)
+  }
+  return subjects
+}
+
+export function buildAppDetailAccount(subjects: readonly string[]): string | null {
+  const lead = subjects[0]?.trim()
+  if (!lead) return null
+  return `Most of this time was on ${lead}.`
+}
+
+export function activityBreakdownHasRows(breakdown: AppActivityBreakdown | undefined): boolean {
+  if (!breakdown) return false
+  return breakdown.groups.length > 0
+    || Boolean(breakdown.everythingElse)
+    || breakdown.unattributedSeconds > 0
+}
+
+export function resolveAppDetailAccount(
+  detail: Pick<AppDetailPayload, 'activityBreakdown' | 'blockAppearances' | 'displayName' | 'totalSeconds'>,
+  generatedSummary?: string | null,
+): string | null {
+  const generated = extractDisplayProse(generatedSummary, detail.displayName)
+  if (generated) return generated
+  return buildAppDetailAccount(subjectsFromAppDetail(detail))
+}
+
+export function visibleAppDetailCopy(
+  detail: Pick<AppDetailPayload, 'activityBreakdown' | 'blockAppearances' | 'displayName' | 'totalSeconds'>,
+  generatedSummary?: string | null,
+): { account: string | null; labels: string[]; showSection: boolean } {
+  const account = resolveAppDetailAccount(detail, generatedSummary)
+  const labels = [
+    ...(account ? [account] : []),
+    ...evidenceTitlesFromBreakdown(detail.activityBreakdown),
+    ...detail.blockAppearances.map((block) => block.label),
+  ]
+  return {
+    account,
+    labels,
+    showSection: detail.totalSeconds > 0 || Boolean(account) || activityBreakdownHasRows(detail.activityBreakdown),
+  }
+}

--- a/src/shared/appNarrativeContract.ts
+++ b/src/shared/appNarrativeContract.ts
@@ -1,3 +1,5 @@
+import { extractDisplayProse, looksLikeStructuredDump } from './appDetailAccount'
+
 export const THIN_APP_NARRATIVE_SUMMARY = 'Daylens has only thin app-specific signal for this app.'
 
 export function appDetailRangeKey(daysOrDate: number | string, anchorDate: string): string {
@@ -12,4 +14,89 @@ export function appNarrativeScopeKey(canonicalAppId: string, rangeKey: string): 
 
 export function isThinAppNarrative(summary: string | null | undefined): boolean {
   return summary?.trim() === THIN_APP_NARRATIVE_SUMMARY
+}
+
+function unwrapCodeFence(raw: string): string {
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  return fenced?.[1]?.trim() ?? raw.trim()
+}
+
+function salvageSummaryField(raw: string): string | null {
+  const field = raw.match(/"summary"\s*:\s*"((?:[^"\\]|\\.)*)"/)
+  if (!field) return null
+  try {
+    const summary = (JSON.parse(`"${field[1]}"`) as string).trim()
+    return summary && !looksLikeStructuredDump(summary) && !/^[{[]/.test(summary) ? summary : null
+  } catch {
+    return null
+  }
+}
+
+export function parseSurfaceSummaryResult(
+  raw: string,
+  fallbackTitle: string,
+): { title: string; summary: string } | null {
+  const normalized = unwrapCodeFence(raw)
+  if (!normalized) return null
+
+  try {
+    const parsed = JSON.parse(normalized) as { title?: unknown; summary?: unknown }
+    const summary = typeof parsed.summary === 'string' ? parsed.summary.trim() : ''
+    if (!summary || looksLikeStructuredDump(summary) || /^[{[]/.test(summary)) return null
+    return {
+      title: typeof parsed.title === 'string' && parsed.title.trim() && !looksLikeStructuredDump(parsed.title)
+        ? parsed.title.trim()
+        : fallbackTitle,
+      summary,
+    }
+  } catch {
+    if (looksLikeStructuredDump(normalized) || /"summary"\s*:/.test(normalized)) {
+      const salvaged = salvageSummaryField(normalized)
+      if (!salvaged) return null
+      return { title: fallbackTitle, summary: salvaged }
+    }
+    if (looksLikeStructuredDump(normalized)) return null
+    return { title: fallbackTitle, summary: normalized }
+  }
+}
+
+function citationTokens(title: string): string[] {
+  const lower = title.toLowerCase().trim()
+  const tokens = new Set<string>([lower])
+  const withoutExt = lower.replace(/\.[a-z0-9]{1,8}$/i, '')
+  if (withoutExt !== lower && withoutExt.length >= 3) tokens.add(withoutExt)
+  if (lower.includes('.')) {
+    const stem = lower.replace(/^www\./, '').split('.')[0]
+    if (stem && stem.length >= 3) tokens.add(stem)
+  }
+  return [...tokens]
+}
+
+export function narrativeCitesEvidence(summary: string, evidenceTitles: readonly string[]): boolean {
+  const haystack = summary.toLowerCase()
+  const titles = evidenceTitles.map((title) => title.trim()).filter((title) => title.length >= 3)
+  if (titles.length === 0) return false
+  let hits = 0
+  const seen = new Set<string>()
+  for (const title of titles) {
+    for (const token of citationTokens(title)) {
+      if (seen.has(token) || !haystack.includes(token)) continue
+      seen.add(token)
+      hits += 1
+      break
+    }
+  }
+  return hits >= (titles.length >= 2 ? 2 : 1)
+}
+
+export function selectVisibleAppNarrative(
+  summary: string | null | undefined,
+  evidenceTitles: readonly string[],
+): string | null {
+  if (!summary || isThinAppNarrative(summary)) return null
+  const prose = extractDisplayProse(summary)
+  if (!prose) return null
+  if (evidenceTitles.length === 0) return null
+  if (!narrativeCitesEvidence(prose, evidenceTitles)) return null
+  return prose
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1549,6 +1549,54 @@ export interface WorkflowPattern {
 // the reconciled total without cluttering the list. Default: 10 seconds.
 export const MIN_DOMAIN_ROW_SECONDS = 10
 
+export interface AppActivityItem {
+  id: string
+  displayTitle: string
+  detail: string | null
+  totalSeconds: number
+  visitCount?: number
+  artifactType?: ArtifactRef['artifactType']
+  canonicalAppId?: string | null
+  ownerBundleId?: string | null
+  ownerAppName?: string | null
+  url?: string | null
+  host?: string | null
+  path?: string | null
+  domain?: string | null
+  normalizedUrl?: string | null
+  pageKey?: string | null
+  openTarget: OpenTarget
+}
+
+export interface AppActivityGroup {
+  id: string
+  label: string
+  kind: 'domain' | 'folder' | 'collection'
+  totalSeconds: number
+  itemCount: number
+  visitCount?: number
+  items: AppActivityItem[]
+}
+
+/**
+ * Expandable where-time-went tree for every app. Browsers use domain → page;
+ * native apps use folder/host → file or page. Reconciles:
+ * Σ item.totalSeconds = group.totalSeconds, Σ group.totalSeconds
+ * + everythingElse.totalSeconds = attributedSeconds, and
+ * attributedSeconds + unattributedSeconds = totalSeconds.
+ */
+export interface AppActivityBreakdown {
+  totalSeconds: number
+  attributedSeconds: number
+  unattributedSeconds: number
+  groups: AppActivityGroup[]
+  everythingElse?: {
+    totalSeconds: number
+    groupCount: number
+    itemCount: number
+  }
+}
+
 export interface AppDetailPayload {
   canonicalAppId: string
   displayName: string
@@ -1591,6 +1639,13 @@ export interface AppDetailPayload {
       visitCount: number
     }
   }
+  /**
+   * Comet/Dia-style expandable breakdown for every app, including native
+   * apps that have files, folders, or window titles instead of domains.
+   * Always present when the app has tracked time so the detail view never
+   * goes blank after the header.
+   */
+  activityBreakdown?: AppActivityBreakdown
   blockAppearances: Array<{
     blockId: string
     startTime: number

--- a/tests/appDetailAccount.test.ts
+++ b/tests/appDetailAccount.test.ts
@@ -1,0 +1,197 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import Database from 'better-sqlite3'
+import {
+  buildAppDetailAccount,
+  extractDisplayProse,
+  looksLikeStructuredDump,
+  resolveAppDetailAccount,
+  visibleAppDetailCopy,
+} from '../src/shared/appDetailAccount.ts'
+import {
+  isThinAppNarrative,
+  parseSurfaceSummaryResult,
+  selectVisibleAppNarrative,
+  THIN_APP_NARRATIVE_SUMMARY,
+} from '../src/shared/appNarrativeContract.ts'
+import { getAppDetailPayload } from '../src/main/services/appDetail.ts'
+import { createProductionTestDatabase } from './support/testDatabase.ts'
+
+function todayKey(): string {
+  const date = new Date()
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+function localMs(date: string, hour: number, minute = 0): number {
+  const [year, month, day] = date.split('-').map(Number)
+  return new Date(year, month - 1, day, hour, minute, 0, 0).getTime()
+}
+
+function insertSession(
+  db: Database.Database,
+  values: {
+    bundleId: string
+    appName: string
+    start: number
+    seconds: number
+    category: string
+    windowTitle: string
+    canonicalAppId: string
+  },
+): void {
+  db.prepare(`
+    INSERT INTO app_sessions (
+      bundle_id, app_name, start_time, end_time, duration_sec, category,
+      is_focused, window_title, raw_app_name, canonical_app_id, capture_source, capture_version
+    ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'test', 2)
+  `).run(
+    values.bundleId,
+    values.appName,
+    values.start,
+    values.start + values.seconds * 1000,
+    values.seconds,
+    values.category,
+    values.windowTitle,
+    values.appName,
+    values.canonicalAppId,
+  )
+}
+
+test('structured dumps are not display-worthy and extract an inner title when present', () => {
+  const notionJson = '{"id":"abc","title":"Q3 planning","type":"page"}'
+  assert.equal(looksLikeStructuredDump(notionJson), true)
+  assert.equal(extractDisplayProse(notionJson, 'Notion'), 'Q3 planning')
+  assert.equal(extractDisplayProse('{"foo":1,"bar":2}', 'Notion'), null)
+  assert.equal(extractDisplayProse('[object Object]', 'Safari'), null)
+  assert.equal(extractDisplayProse('Safari', 'Safari'), null)
+  assert.equal(extractDisplayProse('DEV-89 pull request', 'Safari'), 'DEV-89 pull request')
+})
+
+test('account names only evidence-backed subjects and stays silent without them', () => {
+  assert.equal(buildAppDetailAccount([]), null)
+  assert.equal(buildAppDetailAccount(['GitHub']), 'Most of this time was on GitHub.')
+})
+
+test('Generate parse never returns raw JSON as the on-screen summary', () => {
+  const jsonBlob = '{"title":"Notion","summary":"{\\"type\\":\\"page\\"}"}'
+  assert.equal(parseSurfaceSummaryResult(jsonBlob, 'Notion'), null)
+
+  const wrapped = '```json\n{"title":"Cursor","summary":"You edited appDetail.ts and workBlocks.ts."}\n```'
+  const parsed = parseSurfaceSummaryResult(wrapped, 'Cursor')
+  assert.ok(parsed)
+  assert.equal(parsed.summary, 'You edited appDetail.ts and workBlocks.ts.')
+  assert.equal(looksLikeStructuredDump(parsed.summary), false)
+
+  const bareJson = '{"unfinished": true'
+  assert.equal(parseSurfaceSummaryResult(bareJson, 'Safari'), null)
+
+  const prose = 'You reviewed the ACME report in Notion.'
+  assert.deepEqual(parseSurfaceSummaryResult(prose, 'Notion'), {
+    title: 'Notion',
+    summary: prose,
+  })
+})
+
+test('Generate path keeps grounded prose and drops invented or thin text', () => {
+  const evidence = ['appDetail.ts', 'github.com']
+  assert.equal(
+    selectVisibleAppNarrative('You edited appDetail.ts while checking github.com.', evidence),
+    'You edited appDetail.ts while checking github.com.',
+  )
+  assert.equal(
+    selectVisibleAppNarrative('You mostly worked between 10 and 11 inventing a meeting with ACME.', evidence),
+    null,
+  )
+  assert.equal(selectVisibleAppNarrative(THIN_APP_NARRATIVE_SUMMARY, evidence), null)
+  assert.equal(isThinAppNarrative(THIN_APP_NARRATIVE_SUMMARY), true)
+  assert.equal(selectVisibleAppNarrative('{"title":"x","summary":"y"}', evidence), null)
+})
+
+test('Safari with tracked time and no pages still has a breakdown, not an empty section', () => {
+  const db = createProductionTestDatabase()
+  const date = todayKey()
+  const start = localMs(date, 9)
+  insertSession(db, {
+    bundleId: 'com.apple.Safari',
+    appName: 'Safari',
+    start,
+    seconds: 19 * 60,
+    category: 'browsing',
+    windowTitle: 'Safari',
+    canonicalAppId: 'safari',
+  })
+
+  const detail = getAppDetailPayload(db, 'safari', 1, null)
+  const visible = visibleAppDetailCopy(detail)
+  assert.equal(detail.totalSeconds, 19 * 60)
+  assert.ok(detail.activityBreakdown, 'tracked Safari time must carry an activity breakdown')
+  assert.equal(detail.activityBreakdown?.unattributedSeconds, 19 * 60)
+  assert.equal(visible.showSection, true)
+  assert.equal(visible.account, null)
+  assert.ok(visible.labels.every((label) => !looksLikeStructuredDump(label)))
+  db.close()
+})
+
+test('Notion JSON window titles never reach the visible account or breakdown labels', () => {
+  const db = createProductionTestDatabase()
+  const date = todayKey()
+  const start = localMs(date, 10)
+  insertSession(db, {
+    bundleId: 'notion.id',
+    appName: 'Notion',
+    start,
+    seconds: 40 * 60,
+    category: 'productivity',
+    windowTitle: '{"id":"blk","title":"Hiring plan","spaceId":"1"}',
+    canonicalAppId: 'notion',
+  })
+  insertSession(db, {
+    bundleId: 'notion.id',
+    appName: 'Notion',
+    start: start + 40 * 60_000,
+    seconds: 10 * 60,
+    category: 'productivity',
+    windowTitle: '{"foo":true,"bar":[]}',
+    canonicalAppId: 'notion',
+  })
+
+  const detail = getAppDetailPayload(db, 'notion', 1, null)
+  const visible = visibleAppDetailCopy(detail, '{"title":"Notion","summary":{"raw":true}}')
+  assert.ok(detail.activityBreakdown)
+  assert.equal(visible.account, 'Most of this time was on Hiring plan.')
+  assert.ok(detail.activityBreakdown?.groups.some((group) => (
+    group.items.some((item) => item.displayTitle === 'Hiring plan')
+  )))
+  for (const label of visible.labels) {
+    assert.equal(looksLikeStructuredDump(label), false, `JSON leaked onto screen: ${label}`)
+  }
+  assert.equal(resolveAppDetailAccount(detail, '{"oops":true}'), 'Most of this time was on Hiring plan.')
+  db.close()
+})
+
+test('native apps get the same expandable breakdown shape as browsers', () => {
+  const db = createProductionTestDatabase()
+  const date = todayKey()
+  const start = localMs(date, 11)
+  insertSession(db, {
+    bundleId: 'com.todesktop.230313mzl4w4u92',
+    appName: 'Cursor',
+    start,
+    seconds: 25 * 60,
+    category: 'development',
+    windowTitle: 'src/main/services/appDetail.ts — daylens',
+    canonicalAppId: 'cursor',
+  })
+
+  const detail = getAppDetailPayload(db, 'cursor', 1, null)
+  assert.ok(detail.activityBreakdown)
+  assert.ok(detail.activityBreakdown.groups.length > 0)
+  assert.ok(detail.activityBreakdown.groups[0].items.length > 0)
+  assert.equal(detail.activityBreakdown.groups[0].kind === 'domain'
+    || detail.activityBreakdown.groups[0].kind === 'folder'
+    || detail.activityBreakdown.groups[0].kind === 'collection', true)
+  const visible = visibleAppDetailCopy(detail)
+  assert.equal(visible.showSection, true)
+  assert.ok(visible.account?.includes('appDetail.ts'))
+  db.close()
+})

--- a/tests/rendererSharedContracts.test.ts
+++ b/tests/rendererSharedContracts.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { activityCategoryLabel, EDITABLE_BLOCK_CATEGORY_OPTIONS } from '../src/shared/activityCategories.ts'
-import { appDetailRangeKey, appNarrativeScopeKey, isThinAppNarrative, THIN_APP_NARRATIVE_SUMMARY } from '../src/shared/appNarrativeContract.ts'
+import { appDetailRangeKey, appNarrativeScopeKey, isThinAppNarrative, parseSurfaceSummaryResult, THIN_APP_NARRATIVE_SUMMARY } from '../src/shared/appNarrativeContract.ts'
 
 test('shared activity categories keep UI identity separate from prompt prose', () => {
   assert.equal(activityCategoryLabel('aiTools'), 'AI Tools')
@@ -16,5 +16,7 @@ test('app narrative keys and thin status use one shared contract', () => {
   assert.equal(appNarrativeScopeKey('com.example.app', rangeKey), 'app:com.example.app:1d:2026-07-10')
   assert.equal(isThinAppNarrative(THIN_APP_NARRATIVE_SUMMARY), true)
   assert.equal(isThinAppNarrative('A real narrative about two artifacts.'), false)
+  assert.equal(parseSurfaceSummaryResult('{"title":"Dia","summary":"{bad"}', 'Dia'), null)
+  assert.equal(parseSurfaceSummaryResult('{"title":"Dia","summary":"You read Linear and GitHub."}', 'Dia')?.summary, 'You read Linear and GitHub.')
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [DEV-237](https://linear.app/irachrist1/issue/DEV-237/what-you-did-there-app-summaries-are-unreliable).

## Problem

App detail summaries were unreliable: Notion could render raw JSON, Safari could show an empty “What you did there” after tracked time, titles were wrong, and Generate invented specifics the evidence could not support.

## What changed

The section is rebuilt, not removed.

- Every app now gets the Comet/Dia expandable breakdown (domain/folder → pages/files), including native apps.
- A plain-language account is shown only when evidence can support one. Otherwise the breakdown stands alone.
- Structured dumps are extracted to a title when possible (`{"title":"Hiring plan"}` → `Hiring plan`) and never shown as JSON.
- Tracked time with no pages still shows an unattributed “No page recorded” row instead of a blank section.
- Generate uses the same activity-tree evidence for every app and keeps only prose that cites that evidence.

## Tests

- `tests/appDetailAccount.test.ts` — JSON never reaches visible copy; Safari 19m with no pages still shows a breakdown and no invented sentence; Generate parse/grounding rejects dumps and uncited specifics; native apps get the same breakdown shape.
- Existing Apps payload, domain, 30-day, view-model, and contract tests still pass.

## UI verification

This environment cannot drive the packaged Electron Apps view against a real profile. On a machine with real history:

1. Open Apps and select your five most-used apps at Today, 7d, and 30d.
2. Confirm “What you did there” never shows raw JSON.
3. Confirm an app with tracked time and no page/file evidence still shows the section (unattributed row), not a blank card.
4. Confirm the account sentence matches remembered work, or is omitted when only the breakdown is honest.
5. Press Generate / Refresh on a browser app and a native app; quality should be comparable, and invented times/meetings should not appear.

## Docs

No documentation files were edited.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8634784-d639-408f-b6d5-492ce67460ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8634784-d639-408f-b6d5-492ce67460ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

