### PR TITLE
Show external MCP activity and find Claude Code and Cursor servers

### DIFF
--- a/docs/codebase/architecture.md
+++ b/docs/codebase/architecture.md
@@ -107,7 +107,9 @@ The current sync path sends live presence and selected day-level facts. Raw capt
 
 ## MCP
 
-`packages/mcp-server` is a local stdio server bundled and launched by the desktop app when enabled. It opens the database read-only, reuses the same tool executors as the in-app agent, and fails closed on a malformed exclusion environment. It is another consumer of Daylens facts and should not invent a parallel activity model.
+`packages/mcp-server` is a local stdio server bundled and launched by the desktop app when enabled. External clients also spawn it. It opens the database read-only, reuses the same tool executors as the in-app agent, and fails closed on a malformed exclusion environment. It is another consumer of Daylens facts and should not invent a parallel activity model.
+
+Each external tool call is appended to `mcp-activity.jsonl` next to the database (tool name, timestamp, sanitized arguments, success/outcome — not the result). The AI tab reads that sidecar over `ai:get-mcp-activity` and shows a plain feed. Settings → Enrichment sources discovers MCP servers from Claude Desktop, Claude Code (`~/.claude.json`, including project-scoped `mcpServers`), and Cursor (`~/.cursor/mcp.json`).
 
 ## Billing
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -14,6 +14,7 @@ import type { TrackingControlsState } from '../../../src/shared/trackingControls
 import { mcpToolManifest } from './tools'
 import { callDaylensReadTool } from './dispatch'
 import { resolveDefaultDbPath } from './dbPath'
+import { mcpActivityLogPath, recordMcpActivity } from '../../../src/shared/mcpActivityLog'
 import { installConsoleStdioGuards } from '../../../src/shared/consoleStdio'
 
 // stderr only: stdout is the JSON-RPC transport, and a transport that has
@@ -30,6 +31,15 @@ if (!fs.existsSync(dbPath)) {
 const db = new Database(dbPath, { readonly: true })
 try { db.pragma('journal_mode = WAL') } catch { /* read-only connection can't change journal mode */ }
 db.pragma('busy_timeout = 5000')
+const activityLogPath = mcpActivityLogPath(dbPath)
+
+function recordCall(name: string, args: unknown, ok: boolean, error?: string): void {
+  try {
+    recordMcpActivity(activityLogPath, { tool: name, arguments: args, ok, error })
+  } catch (err) {
+    console.error('[daylens-mcp] Failed to record activity:', err)
+  }
+}
 
 // The subprocess can't reach the Electron settings store, so the current
 // exclusion set is handed in by env (see mcpServer.ts). Without this the MCP
@@ -88,22 +98,26 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params
+  const toolArgs = (args ?? {}) as Record<string, unknown>
   try {
     const result = await callDaylensReadTool(
       name,
-      (args ?? {}) as Record<string, unknown>,
+      toolArgs,
       db,
       trackingControls,
     )
+    recordCall(name, toolArgs, true)
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
     }
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    recordCall(name, toolArgs, false, message)
     return {
       content: [
         {
           type: 'text' as const,
-          text: `Tool error: ${err instanceof Error ? err.message : String(err)}`,
+          text: `Tool error: ${message}`,
         },
       ],
       isError: true,

--- a/src/main/ipc/ai.handlers.ts
+++ b/src/main/ipc/ai.handlers.ts
@@ -1,4 +1,5 @@
 import { app, ipcMain } from 'electron'
+import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 import type { AgentTurnCheckpointView, AIAgentQuestionEvent } from '@shared/types'
 import { cancelAIRequest, pauseAIRequest } from '../lib/aiCancellation'
@@ -52,7 +53,9 @@ import {
   renameThread,
   setThreadSettings,
 } from '../services/artifacts'
-import { IPC, type AIActionCommitResult, type AIActionUndo, type AIActionWidget, type AIChatSendRequest, type AIStarterSuggestionResult, type AIThreadDetail, type AIThreadPageRequest, type AIThreadSettings, type AIThreadSummary, type WorkContextBlock, type WrappedAskRequest, type WrappedPeriod } from '@shared/types'
+import { IPC, type AIActionCommitResult, type AIActionUndo, type AIActionWidget, type AIChatSendRequest, type AIStarterSuggestionResult, type AIThreadDetail, type AIThreadPageRequest, type AIThreadSettings, type AIThreadSummary, type McpActivityLog, type WorkContextBlock, type WrappedAskRequest, type WrappedPeriod } from '@shared/types'
+import { mcpActivityLogPath, readMcpActivity } from '@shared/mcpActivityLog'
+import { isRealDayHarness } from '../lib/realDayHarness'
 
 // Opening a conversation loads only this many of its newest messages; the
 // renderer pages older ones in with "Load earlier messages".
@@ -394,5 +397,11 @@ export function registerAIHandlers(): void {
   // ─── Artifacts ────────────────────────────────────────────────────────────
   ipcMain.handle(IPC.AI.OPEN_ARTIFACT, async (_e, payload: { artifactId: number }) => {
     return openArtifact(payload.artifactId)
+  })
+
+  ipcMain.handle(IPC.AI.GET_MCP_ACTIVITY, (): McpActivityLog => {
+    if (isRealDayHarness()) return { entries: [] }
+    const dbPath = path.join(app.getPath('userData'), 'daylens.sqlite')
+    return { entries: readMcpActivity(mcpActivityLogPath(dbPath)) }
   })
 }

--- a/src/main/ipc/settings.handlers.ts
+++ b/src/main/ipc/settings.handlers.ts
@@ -12,7 +12,7 @@ import { recordTrackingPauseTransition } from '../services/tracking'
 import { syncLinuxLaunchOnLogin } from '../services/linuxDesktop'
 import { validateProviderConnection } from '../services/providerValidation'
 import { getMcpServerConfig, isMcpServerRunning, startMcpServer, stopMcpServer } from '../services/mcpServer'
-import { detectFocusApps, discoverMcpServers } from '../services/enrichmentDiscovery'
+import { detectFocusApps, discoverAllMcpServers, listMcpConfigFiles } from '../services/enrichmentDiscovery'
 import { applyProviderChangeToSettings } from '../lib/providerRouting'
 import { IPC } from '@shared/types'
 import type { AIProvider, AIProviderMode, AppSettings, EnrichmentSourcesState } from '@shared/types'
@@ -26,26 +26,34 @@ export function registerSettingsHandlers(): void {
     return getSettingsAsync()
   })
 
-  // Discovered optional enrichment sources: MCP servers
-  // from the Claude Desktop config plus focus tools on this machine. Discovery
-  // only — nothing is launched or called from here.
+  // Discovered optional enrichment sources: MCP servers from Claude Desktop,
+  // Claude Code, and Cursor configs plus focus tools on this machine.
+  // Discovery only — nothing is launched or called from here.
   ipcMain.handle(IPC.SETTINGS.GET_ENRICHMENT_SOURCES, async (): Promise<EnrichmentSourcesState> => {
     const settings = await getSettingsAsync()
     const enabled = settings.enrichmentSources ?? {}
     if (isRealDayHarness()) {
-      return { mcpServers: [], focusApps: [] }
+      return {
+        mcpServers: [],
+        focusApps: [],
+        mcpConfigFiles: listMcpConfigFiles().map(({ label, displayPath }) => ({ label, displayPath })),
+      }
     }
+    const discovered = discoverAllMcpServers()
     return {
-      mcpServers: discoverMcpServers().map((server) => ({
+      mcpServers: discovered.servers.map((server) => ({
         name: server.name,
         transport: server.transport,
         enabled: enabled[`mcp:${server.name}`] ?? false,
+        source: server.source,
+        sourceLabel: server.sourceLabel,
       })),
       focusApps: detectFocusApps().map((focus) => ({
         app: focus.app,
         installed: focus.installed,
         enabled: enabled[`focus:${focus.app}`] ?? false,
       })),
+      mcpConfigFiles: discovered.checkedFiles,
     }
   })
 

--- a/src/main/services/enrichmentDiscovery.ts
+++ b/src/main/services/enrichmentDiscovery.ts
@@ -1,27 +1,52 @@
 // Enrichment discovery — optional local sources beyond
-// Daylens' own tracking: MCP servers configured for Claude Desktop, and known
-// focus-timer apps installed on this machine.
+// Daylens' own tracking: MCP servers configured in Claude Desktop, Claude Code,
+// and Cursor, plus known focus-timer apps installed on this machine.
 //
 // Discovery only. This module never launches an MCP server, never calls a
-// tool, and never spawns a subprocess. It reads a JSON config file and probes
+// tool, and never spawns a subprocess. It reads JSON config files and probes
 // the filesystem for known app bundles/containers, nothing else. Every path
 // is best-effort and silent: a missing file, a malformed config, or an
 // unreadable store returns an empty/null result, never a thrown error.
 //
 // Server command arguments, paths, and env values are deliberately never
-// surfaced here (they can carry tokens/secrets) — only the server name and
-// transport kind leave this module.
+// surfaced here (they can carry tokens/secrets) — only the server name,
+// transport kind, and which config named it leave this module.
 
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import type { FocusAppSignal } from '@shared/types'
+import type { FocusAppSignal, McpDiscoverySource } from '@shared/types'
+import {
+  claudeCodeConfigDisplayPath,
+  claudeDesktopConfigDisplayPath,
+  cursorMcpConfigDisplayPath,
+} from '@shared/platformPaths'
 
 export interface McpServerDiscovery {
   /** Server key from the config ("notion", "linear", "jira"). */
   name: string
   /** 'stdio' when a command is configured, 'http' when a url is. */
   transport: 'stdio' | 'http' | 'unknown'
+  source?: McpDiscoverySource
+  sourceLabel?: string
+}
+
+export interface McpConfigFile {
+  source: McpDiscoverySource
+  label: string
+  path: string
+  displayPath: string
+}
+
+export interface McpDiscoveryResult {
+  servers: Array<McpServerDiscovery & { source: McpDiscoverySource; sourceLabel: string }>
+  checkedFiles: Array<{ label: string; displayPath: string }>
+}
+
+export interface McpDiscoveryRoots {
+  homeDir?: string
+  platform?: NodeJS.Platform
+  appData?: string
 }
 
 export interface FocusAppDiscovery {
@@ -59,43 +84,131 @@ export function claudeDesktopConfigPath(
   return path.join(homeDir, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json')
 }
 
-/** Installed MCP servers from the Claude Desktop config. Discovery ONLY —
- *  never launches or calls them. Empty array when no config exists. */
-export function discoverMcpServers(configPath: string = claudeDesktopConfigPath()): McpServerDiscovery[] {
+export function claudeCodeConfigPath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.claude.json')
+}
+
+export function cursorMcpConfigPath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.cursor', 'mcp.json')
+}
+
+const SOURCE_LABEL: Record<McpDiscoverySource, string> = {
+  'claude-desktop': 'Claude Desktop',
+  'claude-code': 'Claude Code',
+  cursor: 'Cursor',
+}
+
+function transportOf(value: unknown): McpServerDiscovery['transport'] {
+  if (!value || typeof value !== 'object') return 'unknown'
+  const entry = value as Record<string, unknown>
+  if (typeof entry.command === 'string' && entry.command.length > 0) return 'stdio'
+  if (typeof entry.url === 'string' && entry.url.length > 0) return 'http'
+  return 'unknown'
+}
+
+function serversFromObject(servers: unknown): McpServerDiscovery[] {
+  if (!servers || typeof servers !== 'object') return []
+  return Object.entries(servers as Record<string, unknown>).map(([name, value]) => ({
+    name,
+    transport: transportOf(value),
+  }))
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> | null {
   let raw: string
   try {
-    raw = fs.readFileSync(configPath, 'utf8')
+    raw = fs.readFileSync(filePath, 'utf8')
   } catch {
-    return []
+    return null
   }
-
   let parsed: unknown
   try {
     parsed = JSON.parse(raw)
   } catch {
-    return []
+    return null
   }
+  if (!parsed || typeof parsed !== 'object') return null
+  return parsed as Record<string, unknown>
+}
 
-  if (!parsed || typeof parsed !== 'object') return []
-  const servers = (parsed as Record<string, unknown>).mcpServers
-  if (!servers || typeof servers !== 'object') return []
+/** Installed MCP servers from one config file. Discovery ONLY —
+ *  never launches or calls them. Empty array when no config exists. */
+export function discoverMcpServers(configPath: string = claudeDesktopConfigPath()): McpServerDiscovery[] {
+  const parsed = readJsonObject(configPath)
+  if (!parsed) return []
+  return serversFromObject(parsed.mcpServers)
+}
 
-  const result: McpServerDiscovery[] = []
-  for (const [name, value] of Object.entries(servers as Record<string, unknown>)) {
-    if (!value || typeof value !== 'object') {
-      result.push({ name, transport: 'unknown' })
-      continue
-    }
-    const entry = value as Record<string, unknown>
-    if (typeof entry.command === 'string' && entry.command.length > 0) {
-      result.push({ name, transport: 'stdio' })
-    } else if (typeof entry.url === 'string' && entry.url.length > 0) {
-      result.push({ name, transport: 'http' })
-    } else {
-      result.push({ name, transport: 'unknown' })
+function serversFromClaudeCodeConfig(parsed: Record<string, unknown>): McpServerDiscovery[] {
+  const found = serversFromObject(parsed.mcpServers)
+  const seen = new Set(found.map((server) => server.name))
+  const projects = parsed.projects
+  if (!projects || typeof projects !== 'object') return found
+  for (const project of Object.values(projects as Record<string, unknown>)) {
+    if (!project || typeof project !== 'object') continue
+    for (const server of serversFromObject((project as Record<string, unknown>).mcpServers)) {
+      if (seen.has(server.name)) continue
+      seen.add(server.name)
+      found.push(server)
     }
   }
-  return result
+  return found
+}
+
+export function listMcpConfigFiles(roots: McpDiscoveryRoots = {}): McpConfigFile[] {
+  const homeDir = roots.homeDir ?? os.homedir()
+  const platform = roots.platform ?? process.platform
+  const appData = roots.appData ?? process.env.APPDATA
+  return [
+    {
+      source: 'claude-desktop',
+      label: SOURCE_LABEL['claude-desktop'],
+      path: claudeDesktopConfigPath(homeDir, platform, appData),
+      displayPath: claudeDesktopConfigDisplayPath(platform),
+    },
+    {
+      source: 'claude-code',
+      label: SOURCE_LABEL['claude-code'],
+      path: claudeCodeConfigPath(homeDir),
+      displayPath: claudeCodeConfigDisplayPath(platform),
+    },
+    {
+      source: 'cursor',
+      label: SOURCE_LABEL.cursor,
+      path: cursorMcpConfigPath(homeDir),
+      displayPath: cursorMcpConfigDisplayPath(platform),
+    },
+  ]
+}
+
+/** MCP servers from Claude Desktop, Claude Code (user + project-scoped),
+ *  and Cursor. Deduplicated by server name; first config in listMcpConfigFiles
+ *  order wins. */
+export function discoverAllMcpServers(roots: McpDiscoveryRoots = {}): McpDiscoveryResult {
+  const files = listMcpConfigFiles(roots)
+  const seen = new Set<string>()
+  const servers: McpDiscoveryResult['servers'] = []
+  for (const file of files) {
+    const parsed = readJsonObject(file.path)
+    const found = parsed
+      ? file.source === 'claude-code'
+        ? serversFromClaudeCodeConfig(parsed)
+        : serversFromObject(parsed.mcpServers)
+      : []
+    for (const server of found) {
+      if (seen.has(server.name)) continue
+      seen.add(server.name)
+      servers.push({
+        ...server,
+        source: file.source,
+        sourceLabel: file.label,
+      })
+    }
+  }
+  return {
+    servers,
+    checkedFiles: files.map(({ label, displayPath }) => ({ label, displayPath })),
+  }
 }
 
 function defaultFocusAppRoots(homeDir: string): Required<Omit<FocusAppRoots, 'homeDir'>> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -42,6 +42,7 @@ import type {
   HistoryExportVerification,
   WrapSlidesExportResult,
   MemoryMirrorSyncResult,
+  McpActivityLog,
   BillingUsageReport,
   SpendGuardrailsReport,
   IntercomIdentity,
@@ -443,6 +444,8 @@ const api = {
       ipcRenderer.invoke(IPC.AI.SET_THREAD_SETTINGS, { threadId, settings }),
     openArtifact: (artifactId: number): Promise<{ ok: boolean; error?: string }> =>
       ipcRenderer.invoke(IPC.AI.OPEN_ARTIFACT, { artifactId }),
+    getMcpActivity: (): Promise<McpActivityLog> =>
+      ipcRenderer.invoke(IPC.AI.GET_MCP_ACTIVITY),
   },
   search: {
     // The unified boundary: the planner scopes, retrieves, reconciles, and

--- a/src/renderer/views/Settings.tsx
+++ b/src/renderer/views/Settings.tsx
@@ -1185,7 +1185,7 @@ const SECTION_GROUPS: SectionGroup[] = [
       { id: 'entities', label: 'Entities', keywords: 'people meetings repositories projects clients files pages apps merge rename alias durable' },
       { id: 'fileAccess', label: 'Agent file access', keywords: 'files folders grant revoke disclosure read permission model indexed observed granola meeting notes terminal commands capability' },
       { id: 'mcp', label: 'MCP server', keywords: 'claude desktop cursor query external clients' },
-      { id: 'enrichment', label: 'Enrichment sources', keywords: 'wrapped git calendar notion linear jira focus mcp connectors signals' },
+      { id: 'enrichment', label: 'Enrichment sources', keywords: 'wrapped git calendar notion linear jira focus mcp connectors signals claude desktop claude code cursor' },
     ],
   },
   {
@@ -2549,6 +2549,7 @@ export default function Settings({ initialSettings = null }: { initialSettings?:
     const next = { ...(settings.enrichmentSources ?? {}), [key]: value }
     if (!await persist({ enrichmentSources: next })) return
     setEnrichmentSources((prev) => prev && ({
+      ...prev,
       mcpServers: prev.mcpServers.map((s) => (`mcp:${s.name}` === key ? { ...s, enabled: value } : s)),
       focusApps: prev.focusApps.map((f) => (`focus:${f.app}` === key ? { ...f, enabled: value } : f)),
     }))
@@ -4133,7 +4134,14 @@ export default function Settings({ initialSettings = null }: { initialSettings?:
                 <div style={{ fontSize: 12.5, color: 'var(--color-text-tertiary)' }}>Looking for installed servers…</div>
               ) : enrichmentSources.mcpServers.length === 0 ? (
                 <div style={{ fontSize: 12.5, color: 'var(--color-text-tertiary)', lineHeight: 1.6 }}>
-                  None found in your Claude Desktop config. If you use Notion, Linear, or Jira through MCP, they'll show up here as future wrap sources.
+                  None found. Daylens checked these files:
+                  <ul style={{ margin: '6px 0 0', paddingLeft: 18 }}>
+                    {enrichmentSources.mcpConfigFiles.map((file) => (
+                      <li key={`${file.label}:${file.displayPath}`}>
+                        {file.label} (<code style={{ fontSize: 11 }}>{file.displayPath}</code>)
+                      </li>
+                    ))}
+                  </ul>
                 </div>
               ) : (
                 enrichmentSources.mcpServers.map((server, i) => (
@@ -4141,7 +4149,7 @@ export default function Settings({ initialSettings = null }: { initialSettings?:
                     key={server.name}
                     first={i === 0}
                     title={server.name}
-                    description={`Discovered in your Claude Desktop config (${server.transport}). Turning it on marks it as a wrap source; Daylens doesn't read it yet.`}
+                    description={`Discovered in ${server.sourceLabel} (${server.transport}). Turning it on marks it as a wrap source; Daylens doesn't read it yet.`}
                     control={
                       <Toggle
                         checked={server.enabled}

--- a/src/renderer/views/insights/AIWorkspace.tsx
+++ b/src/renderer/views/insights/AIWorkspace.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Copy, Pencil, RefreshCw, SlidersHorizontal, ThumbsDown, ThumbsUp, Wand2 } from 'lucide-react'
+import { Activity, Copy, Pencil, RefreshCw, SlidersHorizontal, ThumbsDown, ThumbsUp, Wand2 } from 'lucide-react'
 import { ANALYTICS_EVENT } from '@shared/analytics'
 import type { AIModelCostCatalog, AIProviderMode, AIStarterSuggestion, AIThreadSettings } from '@shared/types'
 import { buildModelSources } from '@shared/aiModelSources'
@@ -21,11 +21,13 @@ import { MessageList } from './MessageList'
 import { AgentQuestionCard } from './AgentQuestionCard'
 import { ModelSelector } from './ModelSelector'
 import { ThreadSettingsPanel } from './ThreadSettingsPanel'
+import { McpActivityPanel } from './McpActivityPanel'
 import { IconChevronDown, IconNewChat, IconSidebar, IconSparkle } from './icons'
 import { useAIChat } from './useAIChat'
 import { ANSWER_TRANSFORMS, type ThreadMessage } from './types'
 
 const SIDEBAR_COLLAPSED_KEY = 'daylens.ai.sidebarCollapsed'
+const MCP_ACTIVITY_OPEN_KEY = 'daylens.ai.mcpActivityOpen'
 
 // Map a chat provider to the settings key holding its chosen model, so picking a
 // model for a brand-new (thread-less) chat updates the right global default.
@@ -103,6 +105,17 @@ export default function AIWorkspace() {
     // FB4: hidden by default — only an explicit "open" choice persists as '0'.
     try { return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) !== '0' } catch { return true }
   })
+  const [mcpActivityOpen, setMcpActivityOpen] = useState(() => {
+    try { return localStorage.getItem(MCP_ACTIVITY_OPEN_KEY) === '1' } catch { return false }
+  })
+
+  const toggleMcpActivity = useCallback(() => {
+    setMcpActivityOpen((open) => {
+      const next = !open
+      try { localStorage.setItem(MCP_ACTIVITY_OPEN_KEY, next ? '1' : '0') } catch { /* ignore */ }
+      return next
+    })
+  }, [])
 
   const toggleSidebar = useCallback(() => {
     setSidebarCollapsed((collapsed) => {
@@ -582,6 +595,16 @@ export default function AIWorkspace() {
         )}
         <button
           type="button"
+          onClick={toggleMcpActivity}
+          title={mcpActivityOpen ? 'Hide MCP activity' : 'Show MCP activity'}
+          aria-label={mcpActivityOpen ? 'Hide MCP activity' : 'Show MCP activity'}
+          aria-pressed={mcpActivityOpen}
+          style={{ width: 34, height: 34, padding: 0, borderRadius: 9, border: '1px solid var(--color-border-ghost)', background: mcpActivityOpen ? 'var(--color-surface-high)' : 'var(--color-surface)', color: 'var(--color-text-secondary)', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}
+        >
+          <Activity size={16} strokeWidth={1.8} aria-hidden="true" />
+        </button>
+        <button
+          type="button"
           onClick={onNewChat}
           title="New chat (⌘N)"
           aria-label="New chat"
@@ -740,6 +763,17 @@ export default function AIWorkspace() {
           onSaved={(next) => setThreadSettings(next)}
         />
       )}
+      <div
+        style={{
+          flexShrink: 0,
+          width: mcpActivityOpen ? 280 : 0,
+          overflow: 'hidden',
+          transition: 'width 200ms cubic-bezier(0.22, 0.61, 0.36, 1)',
+        }}
+        aria-hidden={!mcpActivityOpen}
+      >
+        {mcpActivityOpen && <McpActivityPanel />}
+      </div>
     </div>
   )
 }

--- a/src/renderer/views/insights/McpActivityPanel.tsx
+++ b/src/renderer/views/insights/McpActivityPanel.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Activity, RefreshCw } from 'lucide-react'
+import type { McpActivityEntry } from '@shared/types'
+import { ipc } from '../../lib/ipc'
+
+const POLL_MS = 2_000
+
+function formatWhen(iso: string): string {
+  const date = new Date(iso)
+  if (!Number.isFinite(date.getTime())) return iso || 'Unknown time'
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
+function formatArgs(value: unknown): string {
+  try {
+    return JSON.stringify(value ?? {}, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+export function McpActivityPanel() {
+  const [entries, setEntries] = useState<McpActivityEntry[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const load = useCallback(async (silent = false) => {
+    if (!silent) setRefreshing(true)
+    try {
+      const result = await ipc.ai.getMcpActivity()
+      setEntries([...result.entries].reverse())
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      if (!silent) setRefreshing(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+    const timer = window.setInterval(() => { void load(true) }, POLL_MS)
+    return () => window.clearInterval(timer)
+  }, [load])
+
+  return (
+    <aside
+      style={{ flexShrink: 0, width: 280, display: 'flex', flexDirection: 'column', height: '100%', borderLeft: '1px solid var(--color-border-ghost)', background: 'var(--color-surface-low)' }}
+      aria-label="External MCP activity"
+    >
+      <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8, padding: '12px 12px 10px', borderBottom: '1px solid var(--color-border-ghost)' }}>
+        <Activity size={14} strokeWidth={1.8} aria-hidden="true" style={{ color: 'var(--color-text-tertiary)' }} />
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontSize: 12, fontWeight: 680, color: 'var(--color-text-primary)' }}>MCP activity</div>
+          <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 1 }}>External tool calls</div>
+        </div>
+        <button
+          type="button"
+          onClick={() => { void load() }}
+          aria-label="Refresh MCP activity"
+          title="Refresh"
+          style={{ width: 26, height: 26, border: 'none', borderRadius: 6, background: 'transparent', color: 'var(--color-text-tertiary)', cursor: 'pointer', display: 'grid', placeItems: 'center' }}
+        >
+          <RefreshCw size={13} strokeWidth={1.9} style={{ opacity: refreshing ? 0.5 : 1 }} />
+        </button>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '8px 10px 14px' }}>
+        {error ? (
+          <div role="alert" style={{ padding: '10px 8px', fontSize: 12, color: 'var(--color-text-secondary)', lineHeight: 1.5 }}>
+            Could not load MCP activity. {error}
+            <button
+              type="button"
+              onClick={() => { void load() }}
+              style={{ display: 'block', marginTop: 8, padding: '4px 8px', borderRadius: 6, border: '1px solid var(--color-border-ghost)', background: 'var(--color-surface)', color: 'var(--color-text-primary)', fontSize: 11.5, fontWeight: 600, cursor: 'pointer' }}
+            >
+              Retry
+            </button>
+          </div>
+        ) : entries == null ? (
+          <div style={{ padding: '10px 8px', fontSize: 12, color: 'var(--color-text-tertiary)' }}>Loading…</div>
+        ) : entries.length === 0 ? (
+          <div style={{ padding: '10px 8px', fontSize: 12, color: 'var(--color-text-tertiary)', lineHeight: 1.55 }}>
+            No external MCP calls yet. When Claude Code, Cursor, or Claude Desktop uses the Daylens server, those tool calls show up here.
+          </div>
+        ) : (
+          entries.map((entry, index) => (
+            <article
+              key={`${entry.timestamp}:${entry.tool}:${index}`}
+              style={{ padding: '8px 8px 10px', marginBottom: 4, borderRadius: 8, background: 'var(--color-surface)' }}
+            >
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                <div style={{ fontSize: 12.5, fontWeight: 650, color: 'var(--color-text-primary)', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {entry.tool}
+                </div>
+                <div style={{ marginLeft: 'auto', flexShrink: 0, fontSize: 10.5, fontWeight: 650, color: entry.ok ? 'var(--color-text-tertiary)' : '#ef4444' }}>
+                  {entry.ok ? 'ok' : 'error'}
+                </div>
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--color-text-tertiary)', marginTop: 2 }}>
+                {formatWhen(entry.timestamp)}
+              </div>
+              {!entry.ok && entry.error && (
+                <div style={{ fontSize: 11.5, color: '#ef4444', marginTop: 6, lineHeight: 1.45 }}>
+                  {entry.error}
+                </div>
+              )}
+              <pre style={{ margin: '7px 0 0', padding: 0, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 10.5, lineHeight: 1.45, color: 'var(--color-text-secondary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {formatArgs(entry.arguments)}
+              </pre>
+            </article>
+          ))
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/src/shared/mcpActivityLog.ts
+++ b/src/shared/mcpActivityLog.ts
@@ -1,0 +1,98 @@
+// Sidecar log for external MCP tool calls. The Daylens MCP server is
+// stdio-spawned by clients and has no live IPC into the app, so each call is
+// appended as one JSON line next to the database the server opened.
+//
+// Entries stay small: tool name, timestamp, sanitized arguments, and
+// success/outcome. Full tool results are never written.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import type { McpActivityEntry } from './types'
+import { sanitizeForRender } from './aiSanitize'
+
+export const MCP_ACTIVITY_FILENAME = 'mcp-activity.jsonl'
+export type { McpActivityEntry }
+
+const SECRET_KEY = /(?:^|[_-])(?:token|secret|password|passwd|authorization|credential|api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key|client[_-]?secret)$/i
+
+export function mcpActivityLogPath(dbPath: string): string {
+  return path.join(path.dirname(dbPath), MCP_ACTIVITY_FILENAME)
+}
+
+function isSecretKey(key: string): boolean {
+  const snake = key.replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+  return SECRET_KEY.test(key) || SECRET_KEY.test(snake)
+}
+
+export function stripSecrets(value: unknown): unknown {
+  if (value == null) return value
+  if (typeof value === 'string') return sanitizeForRender(value).text
+  if (typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map(stripSecrets)
+  const out: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = isSecretKey(key) ? '[redacted]' : stripSecrets(child)
+  }
+  return out
+}
+
+export function recordMcpActivity(
+  logPath: string,
+  entry: {
+    tool: string
+    arguments?: unknown
+    ok: boolean
+    error?: string
+    timestamp?: string
+  },
+): void {
+  const recorded: McpActivityEntry = {
+    tool: entry.tool,
+    timestamp: entry.timestamp ?? new Date().toISOString(),
+    arguments: stripSecrets(entry.arguments ?? {}),
+    ok: entry.ok,
+  }
+  if (!entry.ok) recorded.error = entry.error ?? 'Tool error'
+  fs.mkdirSync(path.dirname(logPath), { recursive: true })
+  fs.appendFileSync(logPath, `${JSON.stringify(recorded)}\n`)
+}
+
+export function parseMcpActivityLine(line: string): McpActivityEntry | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const row = parsed as Record<string, unknown>
+  if (typeof row.tool !== 'string' || row.tool.length === 0) return null
+  const entry: McpActivityEntry = {
+    tool: row.tool,
+    timestamp: typeof row.timestamp === 'string' ? row.timestamp : '',
+    arguments: 'arguments' in row ? row.arguments : {},
+    ok: row.ok !== false,
+  }
+  if (typeof row.error === 'string') entry.error = row.error
+  return entry
+}
+
+export function readMcpActivity(logPath: string): McpActivityEntry[] {
+  let raw: string
+  try {
+    raw = fs.readFileSync(logPath, 'utf8')
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') return []
+    throw error
+  }
+
+  const entries: McpActivityEntry[] = []
+  for (const line of raw.split('\n')) {
+    const entry = parseMcpActivityLine(line)
+    if (entry) entries.push(entry)
+  }
+  return entries
+}

--- a/src/shared/platformPaths.ts
+++ b/src/shared/platformPaths.ts
@@ -3,3 +3,13 @@ export function claudeDesktopConfigDisplayPath(platform: NodeJS.Platform): strin
   if (platform === 'linux') return '~/.config/Claude/claude_desktop_config.json'
   return '~/Library/Application Support/Claude/claude_desktop_config.json'
 }
+
+export function claudeCodeConfigDisplayPath(platform: NodeJS.Platform): string {
+  if (platform === 'win32') return '%USERPROFILE%\\.claude.json'
+  return '~/.claude.json'
+}
+
+export function cursorMcpConfigDisplayPath(platform: NodeJS.Platform): string {
+  if (platform === 'win32') return '%USERPROFILE%\\.cursor\\mcp.json'
+  return '~/.cursor/mcp.json'
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2051,13 +2051,36 @@ export interface DayEnrichment {
   } | null
 }
 
+export type McpDiscoverySource = 'claude-desktop' | 'claude-code' | 'cursor'
+
 /** Discovered optional enrichment sources shown in Settings: MCP servers from
- *  the Claude Desktop config and focus tools on this machine. Discovery
- *  only — nothing is called until the user enables it AND the enrichment is
- *  actually wired up. */
+ *  Claude Desktop, Claude Code, and Cursor configs, plus focus tools on this
+ *  machine. Discovery only — nothing is called until the user enables it AND
+ *  the enrichment is actually wired up. */
 export interface EnrichmentSourcesState {
-  mcpServers: Array<{ name: string; transport: 'stdio' | 'http' | 'unknown'; enabled: boolean }>
+  mcpServers: Array<{
+    name: string
+    transport: 'stdio' | 'http' | 'unknown'
+    enabled: boolean
+    source: McpDiscoverySource
+    sourceLabel: string
+  }>
   focusApps: Array<{ app: string; installed: boolean; enabled: boolean }>
+  /** Config files this scan looked at, so an empty state can name them. */
+  mcpConfigFiles: Array<{ label: string; displayPath: string }>
+}
+
+/** One external MCP tool call recorded next to the database. */
+export interface McpActivityEntry {
+  tool: string
+  timestamp: string
+  arguments: unknown
+  ok: boolean
+  error?: string
+}
+
+export interface McpActivityLog {
+  entries: McpActivityEntry[]
 }
 
 // ─── Wrap pre-flight ────────────────────────────────────────────────────────
@@ -3074,6 +3097,7 @@ export const IPC = {
     GET_THREAD_SETTINGS: 'ai:get-thread-settings',
     SET_THREAD_SETTINGS: 'ai:set-thread-settings',
     OPEN_ARTIFACT: 'ai:open-artifact',
+    GET_MCP_ACTIVITY: 'ai:get-mcp-activity',
   },
   SETTINGS: {
     GET: 'settings:get',

--- a/tests/enrichmentDiscovery.test.ts
+++ b/tests/enrichmentDiscovery.test.ts
@@ -4,12 +4,19 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import {
+  claudeCodeConfigPath,
   claudeDesktopConfigPath,
+  cursorMcpConfigPath,
+  discoverAllMcpServers,
   discoverMcpServers,
   detectFocusApps,
   collectFocusAppSignals,
 } from '../src/main/services/enrichmentDiscovery.ts'
-import { claudeDesktopConfigDisplayPath } from '../src/shared/platformPaths.ts'
+import {
+  claudeCodeConfigDisplayPath,
+  claudeDesktopConfigDisplayPath,
+  cursorMcpConfigDisplayPath,
+} from '../src/shared/platformPaths.ts'
 
 function tempDir(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
@@ -36,6 +43,12 @@ test('Claude Desktop config paths are correct on macOS, Windows, and Linux', () 
   assert.equal(claudeDesktopConfigDisplayPath('darwin'), '~/Library/Application Support/Claude/claude_desktop_config.json')
   assert.equal(claudeDesktopConfigDisplayPath('win32'), '%APPDATA%\\Claude\\claude_desktop_config.json')
   assert.equal(claudeDesktopConfigDisplayPath('linux'), '~/.config/Claude/claude_desktop_config.json')
+  assert.equal(claudeCodeConfigPath('/Users/alex'), path.join('/Users/alex', '.claude.json'))
+  assert.equal(cursorMcpConfigPath('/Users/alex'), path.join('/Users/alex', '.cursor', 'mcp.json'))
+  assert.equal(claudeCodeConfigDisplayPath('darwin'), '~/.claude.json')
+  assert.equal(claudeCodeConfigDisplayPath('win32'), '%USERPROFILE%\\.claude.json')
+  assert.equal(cursorMcpConfigDisplayPath('linux'), '~/.cursor/mcp.json')
+  assert.equal(cursorMcpConfigDisplayPath('win32'), '%USERPROFILE%\\.cursor\\mcp.json')
 })
 
 test('discoverMcpServers reads stdio, http, and malformed entries from a fixture config', () => {
@@ -86,6 +99,76 @@ test('discoverMcpServers returns [] when the config has no mcpServers object', (
   const configPath = path.join(dir, 'claude_desktop_config.json')
   writeJson(configPath, { somethingElse: true })
   assert.deepEqual(discoverMcpServers(configPath), [])
+})
+
+test('discoverAllMcpServers reads Claude Desktop, Claude Code (including project-scoped), and Cursor, and lists the files it checked', () => {
+  const homeDir = tempDir('daylens-mcp-multi-home-')
+  const desktopPath = claudeDesktopConfigPath(homeDir, 'darwin')
+  writeJson(desktopPath, {
+    mcpServers: {
+      notion: { command: 'npx', args: ['-y', '@notion/mcp-server', '--token', 'secret-token'] },
+    },
+  })
+  writeJson(claudeCodeConfigPath(homeDir), {
+    mcpServers: {
+      daylens: { command: '/Apps/Daylens.app/Contents/MacOS/Daylens', args: ['--mcp'] },
+    },
+    projects: {
+      '/Users/alex/code/app': {
+        mcpServers: {
+          linear: { url: 'https://mcp.linear.app/sse' },
+          daylens: { command: 'should-not-win' },
+        },
+      },
+    },
+  })
+  writeJson(cursorMcpConfigPath(homeDir), {
+    mcpServers: {
+      github: { command: 'npx', args: ['-y', '@github/mcp'] },
+      notion: { command: 'should-not-replace-desktop' },
+    },
+  })
+
+  const result = discoverAllMcpServers({ homeDir, platform: 'darwin' })
+  const names = result.servers.map((server) => server.name).sort()
+  assert.deepEqual(names, ['daylens', 'github', 'linear', 'notion'])
+
+  const notion = result.servers.find((server) => server.name === 'notion')
+  assert.equal(notion?.source, 'claude-desktop')
+  assert.equal(notion?.sourceLabel, 'Claude Desktop')
+  assert.equal(notion?.transport, 'stdio')
+
+  const daylens = result.servers.find((server) => server.name === 'daylens')
+  assert.equal(daylens?.source, 'claude-code')
+  assert.equal(daylens?.transport, 'stdio')
+
+  const linear = result.servers.find((server) => server.name === 'linear')
+  assert.equal(linear?.source, 'claude-code')
+  assert.equal(linear?.transport, 'http')
+
+  const github = result.servers.find((server) => server.name === 'github')
+  assert.equal(github?.source, 'cursor')
+
+  assert.deepEqual(result.checkedFiles, [
+    { label: 'Claude Desktop', displayPath: '~/Library/Application Support/Claude/claude_desktop_config.json' },
+    { label: 'Claude Code', displayPath: '~/.claude.json' },
+    { label: 'Cursor', displayPath: '~/.cursor/mcp.json' },
+  ])
+
+  const serialized = JSON.stringify(result)
+  assert.ok(!serialized.includes('secret-token'))
+  assert.ok(!serialized.includes('should-not-win'))
+})
+
+test('discoverAllMcpServers empty state still names every file it checked', () => {
+  const homeDir = tempDir('daylens-mcp-none-home-')
+  const result = discoverAllMcpServers({ homeDir, platform: 'linux' })
+  assert.deepEqual(result.servers, [])
+  assert.deepEqual(result.checkedFiles, [
+    { label: 'Claude Desktop', displayPath: '~/.config/Claude/claude_desktop_config.json' },
+    { label: 'Claude Code', displayPath: '~/.claude.json' },
+    { label: 'Cursor', displayPath: '~/.cursor/mcp.json' },
+  ])
 })
 
 test('detectFocusApps finds Raycast (app bundle) and Be Focused (App Store container)', () => {

--- a/tests/mcpActivityLog.test.ts
+++ b/tests/mcpActivityLog.test.ts
@@ -1,0 +1,127 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  mcpActivityLogPath,
+  parseMcpActivityLine,
+  readMcpActivity,
+  recordMcpActivity,
+  stripSecrets,
+} from '../src/shared/mcpActivityLog.ts'
+
+function tempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+test('mcpActivityLogPath sits next to the database', () => {
+  assert.equal(
+    mcpActivityLogPath('/Users/alex/Library/Application Support/Daylens Desktop/daylens.sqlite'),
+    '/Users/alex/Library/Application Support/Daylens Desktop/mcp-activity.jsonl',
+  )
+})
+
+test('recordMcpActivity appends one JSON line and readMcpActivity returns it', () => {
+  const dir = tempDir('daylens-mcp-activity-')
+  const logPath = path.join(dir, 'mcp-activity.jsonl')
+  recordMcpActivity(logPath, {
+    tool: 'getDaySummary',
+    arguments: { date: '2026-07-15' },
+    ok: true,
+    timestamp: '2026-07-15T12:00:00.000Z',
+  })
+  recordMcpActivity(logPath, {
+    tool: 'getTimeChunks',
+    arguments: { date: '2026-07-15' },
+    ok: false,
+    error: 'getTimeChunks is not available through the Daylens MCP server.',
+    timestamp: '2026-07-15T12:00:01.000Z',
+  })
+
+  const entries = readMcpActivity(logPath)
+  assert.equal(entries.length, 2)
+  assert.equal(entries[0]?.tool, 'getDaySummary')
+  assert.equal(entries[0]?.ok, true)
+  assert.deepEqual(entries[0]?.arguments, { date: '2026-07-15' })
+  assert.equal(entries[0]?.error, undefined)
+  assert.equal(entries[1]?.tool, 'getTimeChunks')
+  assert.equal(entries[1]?.ok, false)
+  assert.match(entries[1]?.error ?? '', /not available/)
+
+  const raw = fs.readFileSync(logPath, 'utf8')
+  assert.ok(!raw.includes('"result"'))
+  assert.equal(raw.trim().split('\n').length, 2)
+})
+
+test('readMcpActivity returns [] when the sidecar is missing', () => {
+  const dir = tempDir('daylens-mcp-activity-missing-')
+  assert.deepEqual(readMcpActivity(path.join(dir, 'mcp-activity.jsonl')), [])
+})
+
+test('readMcpActivity skips malformed lines and keeps valid ones', () => {
+  const dir = tempDir('daylens-mcp-activity-malformed-')
+  const logPath = path.join(dir, 'mcp-activity.jsonl')
+  fs.writeFileSync(logPath, [
+    '{ this is not json',
+    JSON.stringify({ tool: 'getDaySummary', timestamp: '2026-07-15T12:00:00.000Z', arguments: { date: '2026-07-15' }, ok: true }),
+    '',
+    JSON.stringify({ timestamp: '2026-07-15T12:00:01.000Z', ok: true }),
+  ].join('\n'))
+
+  const entries = readMcpActivity(logPath)
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0]?.tool, 'getDaySummary')
+})
+
+test('parseMcpActivityLine rejects empty or incomplete rows', () => {
+  assert.equal(parseMcpActivityLine(''), null)
+  assert.equal(parseMcpActivityLine('{"ok":true}'), null)
+  assert.ok(parseMcpActivityLine(JSON.stringify({ tool: 'getDaySummary', ok: true })))
+})
+
+test('stripSecrets redacts secret keys and credential-shaped values', () => {
+  const stripped = stripSecrets({
+    date: '2026-07-15',
+    apiKey: 'sk-ant-secret-value-should-not-leak',
+    nested: {
+      authorization: 'Bearer abc',
+      note: 'plain text',
+    },
+    token: 'lin_api_abcdefghij',
+  }) as Record<string, unknown>
+  const nested = stripped.nested as Record<string, unknown>
+  assert.equal(stripped.date, '2026-07-15')
+  assert.equal(stripped.apiKey, '[redacted]')
+  assert.equal(stripped.token, '[redacted]')
+  assert.equal(nested.authorization, '[redacted]')
+  assert.equal(nested.note, 'plain text')
+
+  const recordedDir = tempDir('daylens-mcp-activity-secret-')
+  const logPath = path.join(recordedDir, 'mcp-activity.jsonl')
+  recordMcpActivity(logPath, {
+    tool: 'custom',
+    arguments: { api_key: 'sk-abcdefghijklmnopqrstuvwxyz012345', date: '2026-07-15' },
+    ok: true,
+  })
+  const raw = fs.readFileSync(logPath, 'utf8')
+  assert.ok(!raw.includes('sk-abcdefghijklmnopqrstuvwxyz012345'))
+  assert.ok(raw.includes('[redacted]'))
+  assert.ok(raw.includes('2026-07-15'))
+})
+
+test('concurrent appends keep one complete JSON object per line', () => {
+  const dir = tempDir('daylens-mcp-activity-concurrent-')
+  const logPath = path.join(dir, 'mcp-activity.jsonl')
+  for (let i = 0; i < 20; i++) {
+    recordMcpActivity(logPath, {
+      tool: `tool-${i}`,
+      arguments: { i },
+      ok: true,
+      timestamp: `2026-07-15T12:00:${String(i).padStart(2, '0')}.000Z`,
+    })
+  }
+  const entries = readMcpActivity(logPath)
+  assert.equal(entries.length, 20)
+  assert.deepEqual(new Set(entries.map((entry) => entry.tool)).size, 20)
+})

--- a/tests/mcpStdioClient.test.ts
+++ b/tests/mcpStdioClient.test.ts
@@ -16,6 +16,7 @@ import { Client } from '@modelcontextprotocol/sdk/client'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import type Database from 'better-sqlite3'
 import { createProductionTestDatabase } from './support/testDatabase.ts'
+import { mcpActivityLogPath, readMcpActivity } from '../src/shared/mcpActivityLog.ts'
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const DATE = '2026-07-15'
@@ -106,6 +107,17 @@ test('an external client lists the read surface and calls it over stdio', async 
     const pageResult = JSON.parse(textOf(pages as { content: Array<{ type: string; text?: string }> }))
     assert.equal(pageResult.found, true)
     assert.equal(pageResult.pages[0].domain, 'coursera.org')
+
+    const activity = readMcpActivity(mcpActivityLogPath(dbPath))
+    const tools = activity.map((entry) => entry.tool)
+    assert.ok(tools.includes('getDaySummary'))
+    assert.ok(tools.includes('getAppUsage'))
+    assert.ok(tools.includes('listPageVisits'))
+    assert.ok(activity.every((entry) => entry.ok))
+    assert.deepEqual(
+      activity.find((entry) => entry.tool === 'getDaySummary')?.arguments,
+      { date: DATE },
+    )
   } finally {
     await close()
     fs.rmSync(dir, { recursive: true, force: true })
@@ -125,6 +137,12 @@ test('an external client is told why an unavailable capability is unavailable', 
     const denied = await client.callTool({ name: 'getTimeChunks', arguments: { date: DATE, incrementMinutes: 30 } })
     assert.equal((denied as { isError?: boolean }).isError, true)
     assert.match(textOf(denied as { content: Array<{ type: string; text?: string }> }), /not available/)
+
+    const activity = readMcpActivity(mcpActivityLogPath(dbPath))
+    const failed = activity.find((entry) => entry.tool === 'getTimeChunks')
+    assert.ok(failed)
+    assert.equal(failed?.ok, false)
+    assert.match(failed?.error ?? '', /not available/)
   } finally {
     await close()
     fs.rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [DEV-258](https://linear.app/irachrist1/issue/DEV-258/external-mcp-activity-is-invisible-in-the-app).

External MCP clients spawn the Daylens server over stdio. That process has no live IPC into the running app, so tool calls never appeared in Daylens. Enrichment sources only read Claude Desktop’s config, so a working Claude Code or Cursor setup showed “None found.”

## Changes

- The MCP server appends one JSONL line per tool call to `mcp-activity.jsonl` next to the database: tool name, timestamp, secret-stripped arguments, success/outcome. Full results are not stored.
- The AI tab reads that sidecar over `ai:get-mcp-activity` and shows a scrollable “MCP activity” panel (header toggle). Honest feed: which tool, when, with what, ok/error.
- Enrichment sources now scans Claude Desktop, Claude Code (`~/.claude.json`, including project-scoped `mcpServers`), and Cursor (`~/.cursor/mcp.json`). Servers are deduplicated by name. The empty state lists the files that were checked.

## Doc edits

- `docs/codebase/architecture.md` — MCP section now describes the sidecar log, the AI-tab feed, and the three config files enrichment discovery reads.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — no new errors
- Focused tests: `mcpActivityLog` (7), `enrichmentDiscovery` (12), `mcpStdioClient` (2) — all pass
- Related MCP/settings tests — pass
- `npm run verify:synthetic-day` — pass
- Full `npm test` — 2456 pass; the one `brutalDay` failure is also present on `main` and is unrelated (recap duration 96420 vs 29820)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6db740c-247b-4895-9a05-09a7fc1e3d75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6db740c-247b-4895-9a05-09a7fc1e3d75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

